### PR TITLE
This commit allow to open a dialog box and choose quickly your install folder

### DIFF
--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -18,18 +18,7 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="button_cancel">
-                <property name="label" translatable="yes" context="cancel">Cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <signal name="clicked" handler="on_button_cancel_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
+              <placeholder/>
             </child>
             <child>
               <object class="GtkButton" id="button_save">
@@ -43,6 +32,20 @@
                 <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_cancel">
+                <property name="label" translatable="yes" context="cancel">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <signal name="clicked" handler="on_button_cancel_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
@@ -78,16 +81,6 @@
               </packing>
             </child>
             <child>
-              <object class="GtkEntry" id="entry_installpath">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -95,6 +88,21 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFileChooserButton" id="filechooser_button">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="focus_on_click">False</property>
+                <property name="action">select-folder</property>
+                <property name="show_hidden">True</property>
+                <property name="title" translatable="yes"/>
+                <signal name="file-set" handler="on_filechooser_button_file_set" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
                 <property name="top_attach">1</property>
               </packing>
             </child>

--- a/minigalaxy/window/preferences.py
+++ b/minigalaxy/window/preferences.py
@@ -35,14 +35,14 @@ class Preferences(Gtk.Dialog):
     button_cancel = Gtk.Template.Child()
     button_save = Gtk.Template.Child()
     combobox_language = Gtk.Template.Child()
-    entry_installpath = Gtk.Template.Child()
+    filechooser_button = Gtk.Template.Child()
 
     def __init__(self, parent, config):
         Gtk.Dialog.__init__(self, title=_("Preferences"), parent=parent, modal=True)
         self.__config = config
         self.parent = parent
         self.__set_language_list()
-        self.entry_installpath.set_text(config.get("install_dir"))
+        self.filechooser_button.set_current_folder(config.get("install_dir"))
 
     def __set_language_list(self) -> None:
         languages = Gtk.ListStore(str, str)
@@ -69,9 +69,19 @@ class Preferences(Gtk.Dialog):
             lang, _ = model[lang_choice][:2]
             self.__config.set("lang", lang)
 
+    ###
+    @Gtk.Template.Callback('on_filechooser_button_file_set')
+    def __set_install_path(self, widget) -> None:
+        path = self.filechooser_button.get_filename()
+        print("The path is :", path)
+        self.filechooser_button.set_current_folder(path)
+
     def __save_install_dir_choice(self) -> bool:
-        choice = self.entry_installpath.get_text()
+        choice = self.filechooser_button.get_current_folder()
+        print("The path saved is :", choice)
+
         if not os.path.exists(choice):
+
             try:
                 os.makedirs(choice)
             except:


### PR DESCRIPTION
Hello,

I did this pull request to add a new button in "preference".
Instead of to insert manually the path for your installation folder, the new button opens a new dialog box which allow to choose quickly the folder you want.

![Screenshot](https://user-images.githubusercontent.com/3606036/71645026-f812f380-2cd1-11ea-8b60-19a0a3f4a106.png)

I have the basic with python (and i love it) and very new with PyOBject :D 