### PR TITLE
Keep install file and avoid to download it again even if the file exists

### DIFF
--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -56,6 +56,7 @@
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="row_homogeneous">True</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
@@ -81,7 +82,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes" context="install_path" comments="The place directory in which games are installed. Ends with &quot;: &quot;.">Installation path: </property>
+                <property name="label" translatable="yes" context="install_path" comments="The place directory in which games are installed. Ends with &quot;: &quot;.">Install path: </property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -89,7 +90,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkFileChooserButton" id="button_filechooser">
+              <object class="GtkFileChooserButton" id="button_file_chooser">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="action">select-folder</property>
@@ -98,6 +99,28 @@
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Enable this option if you want to keep the installer after the installation</property>
+                <property name="label" translatable="yes">Keep installers :</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="switch_install">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
           </object>

--- a/minigalaxy/window/preferences.py
+++ b/minigalaxy/window/preferences.py
@@ -33,16 +33,24 @@ class Preferences(Gtk.Dialog):
     __gtype_name__ = "Preferences"
 
     button_cancel = Gtk.Template.Child()
-    button_filechooser = Gtk.Template.Child()
+    button_file_chooser = Gtk.Template.Child()
     button_save = Gtk.Template.Child()
     combobox_language = Gtk.Template.Child()
+    switch_install = Gtk.Template.Child()
 
     def __init__(self, parent, config):
         Gtk.Dialog.__init__(self, title=_("Preferences"), parent=parent, modal=True)
         self.__config = config
         self.parent = parent
         self.__set_language_list()
-        self.button_filechooser.set_filename(config.get("install_dir"))
+        self.button_file_chooser.set_filename(config.get("install_dir"))
+        self.switch_install.set_active(self.__config.get("keep_installers"))
+
+    def __set_keep_installer(self):
+        if self.switch_install.get_active():
+            self.__config.set("keep_installers", True)
+        else:
+            self.__config.set("keep_installers", False)
 
     def __set_language_list(self) -> None:
         languages = Gtk.ListStore(str, str)
@@ -70,7 +78,7 @@ class Preferences(Gtk.Dialog):
             self.__config.set("lang", lang)
 
     def __save_install_dir_choice(self) -> bool:
-        choice = self.button_filechooser.get_filename()
+        choice = self.button_file_chooser.get_filename()
         if not os.path.exists(choice):
             try:
                 os.makedirs(choice)
@@ -99,6 +107,7 @@ class Preferences(Gtk.Dialog):
     @Gtk.Template.Callback("on_button_save_clicked")
     def save_pressed(self, button):
         self.__save_language_choice()
+        self.__set_keep_installer()
         if self.__save_install_dir_choice():
             self.response(Gtk.ResponseType.OK)
             self.parent.refresh_game_install_states(path_changed=True)


### PR DESCRIPTION
Hello,

What exactly does the Pull Request do :
**1- Revert the line of codes which delete the "_Name_of_my_Game.sh" in download folder.**

Why i did that : I pray for people who have a low bandwidth.
Wasteland 2 has a download size of 15Gb. If these people change/lost their PC, either they saved the install game's folder/install game's file or they lost everything. 

In my case, i have all my _Name_of_my_Game.sh in a External Hard Drive.

**2- Avoid to download again the Install file if it already exists.**
After the 1-, we keep the _Name_of_my_Game.sh_ for each game. 
Unfortunately, if the user needs to re-install the game he wants and click on "Download", the file is downloaded and replace the existing file --> Poor low bandwidth users.

Solution : 
MiniGalaxy test if the file exist and if it's the case, install only the game without to download again the .sh

**3- Change the button label on the Main window**
Initially after to change 1- and 2-, the button in the main window show "Download"

Solution :  
MiniGalaxy test if the file exist and if it's the case, the button label "Download" is replaced by "Install"