### PR TITLE
Update openSUSE instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ sudo dnf install minigalaxy
 
 **openSUSE**
 
-Available in the [OBS](https://build.opensuse.org/package/show/games:tools/minigalaxy). You can use the following set of commands to install Minigalaxy on openSUSE:
+Available in official repos for openSUSE Tumbleweed. You can use the following set of commands to install Minigalaxy on openSUSE from the devel project on [OBS](https://build.opensuse.org/package/show/games:tools/minigalaxy):
 ```shell script
 sudo zypper ar -f obs://games:tools gamestools
 sudo zypper ref


### PR DESCRIPTION
minigalaxy landed now in the official repos of openSUSE Tumbleweed.
Future stable releases will thus contain it too.
However let's still mention the devel project (from where it goes into
official repos) and how to add it.