### PR TITLE
Add environment variable for Mesa ACO.

### DIFF
--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -79,6 +79,14 @@ def __get_execute_command(game) -> list:
         prefix = os.path.join(game.install_dir, "prefix")
         os.environ["WINEPREFIX"] = prefix
 
+        # Enable ACO by default for AMD users.
+        # Mesa 19.x and > are needed.
+        # ACO allow to compile more quickly than with LLVM
+        # and avoid stuttering in Vulkan games (only).
+        # This option is not enabled by default
+        # We'll can remove this variable when it'll be done
+        os.environ["RADV_PERFTEST"] = "aco"
+
         # Find game executable file
         for file in files:
             if re.match(r'^goggame-[0-9]*\.info$', file):


### PR DESCRIPTION
Useful for AMD GPU users and Vulkan games played by Wine.
Allow to reduce stuttering in game, shaders are compiled by ACO
and not LLVM.

Currently, this option is disabled by default. We'll can remove
this option once it will enabled.