### PR TITLE
#98 Don't remove spaces from directory names when installing

### DIFF
--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -257,7 +257,7 @@ class GameTile(Gtk.Box):
     def __get_install_dir(self):
         if self.game.install_dir:
             return self.game.install_dir
-        return os.path.join(Config.get("install_dir"), self.game.get_stripped_name())
+        return os.path.join(Config.get("install_dir"), self.game.name)
 
     def reload_state(self):
         self.game.install_dir = self.__get_install_dir()


### PR DESCRIPTION
I have only discovered one instance to change, so I'm opening a PR.

I have tested locally with two already installed games (native and Wine) with their old directories as well as having installed two new games with their new directories. Both scenarios have worked.