### PR TITLE
add bash to subprocess run during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import subprocess
 from minigalaxy.version import VERSION
 
 # Generate the translations
-subprocess.run(['scripts/compile-translations.sh'])
+subprocess.run(['bash', 'scripts/compile-translations.sh'])
 
 setup(
     name="minigalaxy",


### PR DESCRIPTION
Fixes an error I ran into while packaging for NixOS:
```
...
Executing setuptoolsBuildPhase
Traceback (most recent call last):
  File "nix_run_setup", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 7, in <module>
    subprocess.run(['scripts/compile-translations.sh'])
  File "/nix/store/vs4vj1yzqj1bkcqkf3b6sxm6jfy1gb4j-python3-3.7.7/lib/python3.7/subprocess.py", line 488, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/nix/store/vs4vj1yzqj1bkcqkf3b6sxm6jfy1gb4j-python3-3.7.7/lib/python3.7/subprocess.py", line 800, in __init__
    restore_signals, start_new_session)
  File "/nix/store/vs4vj1yzqj1bkcqkf3b6sxm6jfy1gb4j-python3-3.7.7/lib/python3.7/subprocess.py", line 1551, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'scripts/compile-translations.sh': 'scripts/compile-translations.sh'
builder for '/nix/store/2xh0vcmsna06p4ligq1a0qqkvi174a87-minigalaxy-0.9.3.drv' failed with exit code 1
error: build of '/nix/store/2xh0vcmsna06p4ligq1a0qqkvi174a87-minigalaxy-0.9.3.drv' failed
```