### PR TITLE
Add repology badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Other Linux distributions may work as well. Minigalaxy requires the following de
 
 ## Installation
 
+<a href="https://repology.org/project/minigalaxy/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/minigalaxy.svg" alt="Packaging status" align="right">
+</a>
+
 <details><summary>Ubuntu/Debian</summary>
 
 Download the latest deb package from the <a href="https://github.com/sharkwouter/minigalaxy/releases">releases page</a> and install it.


### PR DESCRIPTION
I believe it would be useful for users to see the packaging status on the readme. I am not sure where would be a good spot on readme for it though.
I have choosen to right-align it here to avoid wasting space.

![repology](https://user-images.githubusercontent.com/50471800/80188918-7d2e6980-862f-11ea-8d2d-23bec64de5a6.png).

There are also a few smaller badge variants https://repology.org/project/minigalaxy/badges if you'd like something smaller.

