### PR TITLE
Create a new config when config.json is empty

### DIFF
--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -31,7 +31,11 @@ class __Config:
     def __load_config_file(self) -> dict:
         if os.path.exists(self.__config_file):
             with open(self.__config_file, "r") as file:
-                return json.loads(file.read())
+                try:
+                    return json.loads(file.read())
+                except json.decoder.JSONDecodeError:
+                    print("Reading config.json failed, creating new config file.")
+                    return self.__create_config_file()
         else:
             return self.__create_config_file()
 


### PR DESCRIPTION
Got an issue where the config.json file is empty, which prevents the program from being launched as the json.decode will fail on this file. Added a print statement to log it, but you may replace this with actual logging how you guys see fit.