### PR TITLE
Add disk space checking before download.

### DIFF
--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -37,10 +37,7 @@ class __DownloadManger:
         diskspace_available = self.get_availablediskspace(location)
         # Reserved space can be used to mimic a full disk or prevent filling a disk completely.
         reserved_space = 0
-        if diskspace_available < (download_remaining + reserved_space):
-            return False
-        else:
-            return True
+        return False if diskspace_available < (download_remaining + reserved_space) else True
 
     def download(self, download):
         if isinstance(download, Download):
@@ -124,11 +121,6 @@ class __DownloadManger:
             download.cancel()
             self.__current_download = None
             print("There is insufficient disk space to cache the download.")
-            # self.window.show_error(
-            #     text="There is insufficient disk space to cache the download.",
-            #     secondary_text=(f"Cache location is '{CACHE_DIR}' ({self.get_availablediskspace(download.save_location)})"
-            #                     f" and current download is {file_size}."),
-            # )
         else:
             if downloaded_size < file_size:
                 with open(download.save_location, download_mode) as save_file:

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -8,6 +8,17 @@ from minigalaxy.download import Download
 
 
 class __DownloadManger:
+    #TODO: Move static method to ui.gametile?
+    @staticmethod
+    def get_availablediskspace(location):
+        """Check disk space available to the user. This method uses the absolute path so
+        symlinks to disks with sufficient space are correctly measured. Note this is
+        a linux-specific command."""
+        absolute_location = os.path.realpath(location)
+        disk_status = os.statvfs(os.path.dirname(absolute_location))
+        available_diskspace = disk_status.f_frsize * disk_status.f_bavail
+        return available_diskspace
+
     def __init__(self):
         self.__queue = queue.Queue()
         self.__current_download = None

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -22,6 +22,7 @@ def install_game(game, installer, main_window=None) -> None:
 
         # Make a temporary empty directory for extracting the installer
         temp_dir = os.path.join(CACHE_DIR, "extract/{}".format(game.id))
+        # TODO: Add disk space checking for extracting installer?
         if os.path.exists(temp_dir):
             shutil.rmtree(temp_dir, ignore_errors=True)
         os.makedirs(temp_dir)
@@ -38,6 +39,7 @@ def install_game(game, installer, main_window=None) -> None:
             os.makedirs(library_dir)
 
         # Copy the game files into the correct directory
+        # TODO: Add disk space checking for final install directory?
         shutil.move(os.path.join(temp_dir, "data/noarch"), game.install_dir)
 
         # Remove the temporary directory
@@ -65,6 +67,7 @@ def install_game(game, installer, main_window=None) -> None:
         download_dir = os.path.join(CACHE_DIR, "download")
         if not os.path.exists(keep_dir):
             os.makedirs(keep_dir)
+        # TODO:Add disk space checking for keep_dir location?
         try:
             # It's needed for multiple files
             for file in os.listdir(download_dir):

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -198,6 +198,7 @@ class GameTile(Gtk.Box):
     def __install(self):
         GLib.idle_add(self.update_to_state, self.state.INSTALLING)
         self.game.install_dir = self.__get_install_dir()
+        # TODO: Add disk space checking for installing the game?
         try:
             if os.path.exists(self.keep_path):
                 install_game(self.game, self.keep_path, main_window=self.parent.parent)


### PR DESCRIPTION
Currently minigalaxy will simply download until the disk is full, which may slow down the pc while giving no benefit (as download cannot be completed anyway). This mainly concerns the .cache folder, where the files reside before finishing.
To prevent this, this code will check the disk space before initialising the download. For Linux it should prevent the whole download, as it is one file, while for Windows it will only stop downloading the last file that doesn't fit.

Edit: Currently also analysing whether to add disk space validation to extracting installer, saving installer to install dir, and copying to final install destination.

Also removed the obsolete save_file.close() command, as the code already uses the 'with' context manager to close save_file upon any exit of the block.

Edit:
147: PR for disk space checking
- issue 155