### PR TITLE
paths: support merged /usr directory

### DIFF
--- a/minigalaxy/paths.py
+++ b/minigalaxy/paths.py
@@ -2,6 +2,8 @@ import os
 import sys
 
 LAUNCH_DIR = os.path.abspath(os.path.dirname(sys.argv[0]))
+if LAUNCH_DIR == "/bin" or LAUNCH_DIR == "/sbin":
+    LAUNCH_DIR = "/usr" + LAUNCH_DIR
 
 CONFIG_DIR = os.path.join(os.getenv('XDG_CONFIG_HOME', os.path.expanduser('~/.config')), "minigalaxy")
 CONFIG_FILE_PATH = os.path.join(CONFIG_DIR, "config.json")


### PR DESCRIPTION
In the Linux world, some distribution started to merge:
- /bin into /usr/bin
- /sbin into /usr/sbin
- /lib into /usr/lib
- /lib64 into /usr/lib64

Some distro go with more extreme approach, merge `/bin`, `/sbin`,
`/usr/sbin` into `/usr/bin`.

See: https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/

If minigalaxy was invoked as:

	/bin/galaxy

We'll see this error:

> Traceback (most recent call last):
>   File "/bin/minigalaxy", line 66, in <module>
>     main()
>   File "/bin/minigalaxy", line 57, in main
>     from minigalaxy.ui import Window
>   File "/usr/lib/python3.8/site-packages/minigalaxy/ui/__init__.py", line 2, in <module>
>     from minigalaxy.ui.window import Window
>   File "/usr/lib/python3.8/site-packages/minigalaxy/ui/window.py", line 5, in <module>
>     from minigalaxy.ui.login import Login
>   File "/usr/lib/python3.8/site-packages/minigalaxy/ui/login.py", line 13, in <module>
>     class Login(Gtk.Dialog):
>   File "/usr/lib/python3.8/site-packages/gi/_gtktemplate.py", line 226, in __call__
>     bytes_ = GLib.Bytes.new(file_.load_contents()[1])
> gi.repository.GLib.Error: g-io-error-quark: Error opening file /share/minigalaxy/ui/login.ui: No such file or directory

Fix this problem by explicit checking if LAUNCH_DIR is `/bin` or
`/sbin`.

---
See https://github.com/void-linux/void-packages/issues/21347