### PR TITLE
Checking for workingDir property and executing wine accordingly (Issue #158)

### DIFF
--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -85,6 +85,9 @@ def __get_execute_command(game) -> list:
                 os.chdir(game.install_dir)
                 with open(file, 'r') as info_file:
                     info = json.loads(info_file.read())
+                    # if we have the workingDir property, start the executable at that directory
+                    if "workingDir" in info["playTasks"][0]:
+                        return ["wine", "start","/b","/wait","/d", info["playTasks"][0]["workingDir"], info["playTasks"][0]["path"]]
                     return ["wine", info["playTasks"][0]["path"]]
 
         # in case no goggame info file was found


### PR DESCRIPTION
I've added two lines checking for the `workingDir` property in the `goggame-\d+.info` file and executing wine accordingly.
I'm not sure if this is also needed in non-wine program launches, at least I haven't found a game where that is the case, so for now I have left that out.