### PR TITLE
Track downloads

### DIFF
--- a/data/ui/application.ui
+++ b/data/ui/application.ui
@@ -140,6 +140,26 @@
           </packing>
         </child>
         <child>
+          <object class="GtkMenuButton" id="header_downloads">
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="no_show_all">True</property>
+            <property name="valign">center</property>
+            <property name="use_popover">False</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">folder-download-symbolic</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkSearchEntry" id="header_search">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -150,7 +170,7 @@
           </object>
           <packing>
             <property name="pack_type">end</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/data/ui/application.ui
+++ b/data/ui/application.ui
@@ -146,6 +146,7 @@
             <property name="no_show_all">True</property>
             <property name="valign">center</property>
             <property name="use_popover">False</property>
+            <signal name="toggled" handler="on_header_downloads_toggled" swapped="no"/>
             <child>
               <object class="GtkImage">
                 <property name="visible">True</property>

--- a/data/ui/application.ui
+++ b/data/ui/application.ui
@@ -144,6 +144,7 @@
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="no_show_all">True</property>
+            <property name="tooltip_text" translatable="yes" context="header_downloads_tooltip" comments="Tooltip for button which shows active downloads">Downloads</property>
             <property name="valign">center</property>
             <property name="use_popover">False</property>
             <signal name="toggled" handler="on_header_downloads_toggled" swapped="no"/>

--- a/data/ui/application.ui
+++ b/data/ui/application.ui
@@ -147,7 +147,6 @@
             <property name="tooltip_text" translatable="yes" context="header_downloads_tooltip" comments="Tooltip for button which shows active downloads">Downloads</property>
             <property name="valign">center</property>
             <property name="use_popover">False</property>
-            <signal name="toggled" handler="on_header_downloads_toggled" swapped="no"/>
             <child>
               <object class="GtkImage">
                 <property name="visible">True</property>

--- a/data/ui/download.ui
+++ b/data/ui/download.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="Download" parent="GtkBox">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkLabel" id="title">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="valign">center</property>
+            <property name="margin_right">20</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="cancel">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="stock">gtk-cancel</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="information">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkProgressBar" id="progress">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+  </template>
+</interface>

--- a/minigalaxy/download.py
+++ b/minigalaxy/download.py
@@ -4,6 +4,8 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GLib
 from minigalaxy.paths import UI_DIR
+from minigalaxy.translation import _
+
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "download.ui"))
 class Download(Gtk.Box):
@@ -27,6 +29,7 @@ class Download(Gtk.Box):
 
         if name:
             self.title.set_text(self.name)
+            self.information.set_text(_("in queue.."))
             self.show_all()
 
     def set_progress(self, percentage: int) -> None:
@@ -36,6 +39,8 @@ class Download(Gtk.Box):
                 progress_start = 100/self.out_of_amount*(self.number-1)
                 percentage = progress_start + percentage/self.out_of_amount
             self.__progress_func(percentage)
+        GLib.idle_add(self.progress.set_fraction, percentage/100)
+        GLib.idle_add(self.information.set_text,_("downloading.."))
 
     def finish(self):
         if self.__finish_func:
@@ -43,6 +48,7 @@ class Download(Gtk.Box):
                 self.__finish_func()
             except (FileNotFoundError, BadZipFile):
                 self.cancel()
+        GLib.idle_add(self.hide)
 
     @Gtk.Template.Callback("on_cancel_clicked")
     def cancel(self, button=None):

--- a/minigalaxy/download.py
+++ b/minigalaxy/download.py
@@ -1,8 +1,22 @@
+import os
 from zipfile import BadZipFile
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, GLib
+from minigalaxy.paths import UI_DIR
 
+@Gtk.Template.from_file(os.path.join(UI_DIR, "download.ui"))
+class Download(Gtk.Box):
+    __gtype_name__ = "Download"
 
-class Download:
-    def __init__(self, url, save_location, finish_func=None, progress_func=None, cancel_func=None, number=1, out_of_amount=1):
+    title = Gtk.Template.Child()
+    information = Gtk.Template.Child()
+    progress = Gtk.Template.Child()
+    cancel = Gtk.Template.Child()
+
+    def __init__(self, url, save_location, finish_func=None, progress_func=None, cancel_func=None, number=1, out_of_amount=1, name=""):
+        Gtk.Box.__init__(self)
+        self.name = name
         self.url = url
         self.save_location = save_location
         self.__finish_func = finish_func
@@ -10,6 +24,10 @@ class Download:
         self.__cancel_func = cancel_func
         self.number = number
         self.out_of_amount = out_of_amount
+
+        if name:
+            self.title.set_text(self.name)
+            self.show_all()
 
     def set_progress(self, percentage: int) -> None:
         if self.__progress_func:
@@ -26,6 +44,8 @@ class Download:
             except (FileNotFoundError, BadZipFile):
                 self.cancel()
 
-    def cancel(self):
+    @Gtk.Template.Callback("on_cancel_clicked")
+    def cancel(self, button=None):
         if self.__cancel_func:
             self.__cancel_func()
+            GLib.idle_add(self.hide)

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -40,7 +40,6 @@ class DownloadManager(Gtk.Popover):
 
         GLib.idle_add(self.button.show)
 
-
     def download_now(self, download):
         download_file_thread = threading.Thread(target=self.__download_file, args=(download,))
         download_file_thread.daemon = True
@@ -66,6 +65,8 @@ class DownloadManager(Gtk.Popover):
                 self.__queue = new_queue
                 self.__paused = False
 
+        self.hide_download_button_if_no_downloads()
+
     def cancel_current_download(self):
         self.__cancel = True
 
@@ -77,6 +78,8 @@ class DownloadManager(Gtk.Popover):
         # wait for the download to be fully cancelled
         while self.__current_download:
             time.sleep(0.1)
+
+        self.hide_download_button_if_no_downloads()
 
     def __download_thread(self):
         while True:
@@ -148,3 +151,7 @@ class DownloadManager(Gtk.Popover):
             with open(download.save_location, "rb") as file:
                 file_content = file.read(size_to_check)
                 return file_content == chunk
+
+    def hide_download_button_if_no_downloads(self):
+        if self.__queue.empty():
+            GLib.idle_add(self.button.hide)

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -65,8 +65,6 @@ class DownloadManager(Gtk.Popover):
                 self.__queue = new_queue
                 self.__paused = False
 
-        self.hide_download_button_if_no_downloads()
-
     def cancel_current_download(self):
         self.__cancel = True
 
@@ -79,13 +77,13 @@ class DownloadManager(Gtk.Popover):
         while self.__current_download:
             time.sleep(0.1)
 
-        self.hide_download_button_if_no_downloads()
-
     def __download_thread(self):
         while True:
             if not self.__queue.empty():
                 self.__current_download = self.__queue.get()
                 self.__download_file(self.__current_download)
+            else:
+                self.button.hide()
             time.sleep(0.1)
 
     def __download_file(self, download):
@@ -151,7 +149,3 @@ class DownloadManager(Gtk.Popover):
             with open(download.save_location, "rb") as file:
                 file_content = file.read(size_to_check)
                 return file_content == chunk
-
-    def hide_download_button_if_no_downloads(self):
-        if self.__queue.empty():
-            GLib.idle_add(self.button.hide)

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -21,10 +21,11 @@ class Library(Gtk.Viewport):
 
     flowbox = Gtk.Template.Child()
 
-    def __init__(self, parent, api: Api):
+    def __init__(self, parent, api: Api, download_manager):
         Gtk.Viewport.__init__(self)
         self.parent = parent
         self.api = api
+        self.download_manager = download_manager
         self.show_installed_only = False
         self.search_string = ""
         self.offline = False
@@ -108,7 +109,7 @@ class Library(Gtk.Viewport):
             self.__add_gametile(game)
 
     def __add_gametile(self, game):
-        self.flowbox.add(GameTile(self, game, self.api))
+        self.flowbox.add(GameTile(self, game, self.api, self.download_manager))
         self.sort_library()
         self.flowbox.show_all()
 

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -7,7 +7,6 @@ from minigalaxy.translation import _
 from minigalaxy.paths import UI_DIR
 from minigalaxy.constants import SUPPORTED_DOWNLOAD_LANGUAGES
 from minigalaxy.config import Config
-from minigalaxy.download_manager import DownloadManager
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "preferences.ui"))
@@ -24,9 +23,10 @@ class Preferences(Gtk.Dialog):
     button_cancel = Gtk.Template.Child()
     button_save = Gtk.Template.Child()
 
-    def __init__(self, parent):
+    def __init__(self, parent, download_manager):
         Gtk.Dialog.__init__(self, title=_("Preferences"), parent=parent, modal=True)
         self.parent = parent
+        self.__download_manager = download_manager
         self.__set_language_list()
         self.button_file_chooser.set_filename(Config.get("install_dir"))
         self.switch_keep_installers.set_active(Config.get("keep_installers"))
@@ -115,7 +115,7 @@ class Preferences(Gtk.Dialog):
         # Only change the install_dir is it was actually changed
         if self.button_file_chooser.get_filename() != Config.get("install_dir"):
             if self.__save_install_dir_choice():
-                DownloadManager.cancel_all_downloads()
+                self.__download_manager.cancel_all_downloads()
                 self.parent.reset_library()
             else:
                 dialog = Gtk.MessageDialog(

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -92,11 +92,6 @@ class Window(Gtk.ApplicationWindow):
             self.__authenticate()
         self.library.update_library()
 
-    @Gtk.Template.Callback("on_header_downloads_toggled")
-    def downloads_toggled(self, button):
-        if not button.get_active():
-            self.__download_manager.hide_download_button_if_no_downloads()
-
     def reset_library(self):
         self.library.reset()
 

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -10,6 +10,7 @@ from minigalaxy.api import Api
 from minigalaxy.config import Config
 from minigalaxy.paths import UI_DIR, LOGO_IMAGE_PATH, THUMBNAIL_DIR
 from minigalaxy.ui.library import Library
+from minigalaxy.download_manager import DownloadManager
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "application.ui"))
@@ -20,6 +21,7 @@ class Window(Gtk.ApplicationWindow):
     header_sync = Gtk.Template.Child()
     header_installed = Gtk.Template.Child()
     header_search = Gtk.Template.Child()
+    header_downloads = Gtk.Template.Child()
     menu_about = Gtk.Template.Child()
     menu_preferences = Gtk.Template.Child()
     menu_logout = Gtk.Template.Child()
@@ -31,9 +33,10 @@ class Window(Gtk.ApplicationWindow):
         self.show_installed_only = False
         self.search_string = ""
         self.offline = False
+        self.__download_manager = DownloadManager(self.header_downloads)
 
         # Set library
-        self.library = Library(self, self.api)
+        self.library = Library(self, self.api, self.__download_manager)
         self.window_library.add(self.library)
 
         # Set the icon
@@ -58,7 +61,7 @@ class Window(Gtk.ApplicationWindow):
 
     @Gtk.Template.Callback("on_menu_preferences_clicked")
     def show_preferences(self, button):
-        preferences_window = Preferences(self)
+        preferences_window = Preferences(self, self.__download_manager)
         preferences_window.run()
         preferences_window.destroy()
 

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -92,6 +92,11 @@ class Window(Gtk.ApplicationWindow):
             self.__authenticate()
         self.library.update_library()
 
+    @Gtk.Template.Callback("on_header_downloads_toggled")
+    def downloads_toggled(self, button):
+        if not button.get_active():
+            self.__download_manager.hide_download_button_if_no_downloads()
+
     def reset_library(self):
         self.library.reset()
 


### PR DESCRIPTION
I'm still not sure if this is the cleanest way to do this, but it is a working solution. The main downside is that the popover menu does not close automatically when the last download is finished. The button does hide when you then close it. Downloads are never deleted, just hidden. That could also be improved.

The overview shows the downloads per file. It shows a progress bar and a cancel button. The cancel button does not have an "are you sure?" warning yet. It also shows which downloads are queued and which one is being downloaded.

I think there are some things not happening which should be happening when a download is cancelled. I need to look into this more.