### PR TITLE
Dlc support

### DIFF
--- a/data/ui/gametile.ui
+++ b/data/ui/gametile.ui
@@ -1,7 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface domain="minigalaxy">
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkPopover" id="dlc_popover">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkImage" id="dlc_image">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="stock">gtk-missing-image</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="dlc_name">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">label</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="dlc_button">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="focus_on_click">False</property>
+                <property name="receives_default">True</property>
+                <property name="relief">none</property>
+                <child>
+                  <object class="GtkImage" id="dlc_button_icon">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="stock">gtk-goto-bottom</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
   <object class="GtkPopover" id="menu">
     <property name="can_focus">False</property>
     <child>
@@ -20,7 +89,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
@@ -91,6 +160,30 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkMenuButton" id="menu_button_dlc">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="focus_on_click">False</property>
+            <property name="receives_default">True</property>
+            <property name="direction">right</property>
+            <property name="popover">dlc_popover</property>
+            <child>
+              <object class="GtkModelButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="text" translatable="yes">DLC</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">7</property>
           </packing>
         </child>
       </object>

--- a/data/ui/gametile.ui
+++ b/data/ui/gametile.ui
@@ -5,66 +5,10 @@
   <object class="GtkPopover" id="dlc_popover">
     <property name="can_focus">False</property>
     <child>
-      <object class="GtkBox">
+      <object class="GtkBox" id="dlc_horizontal_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <object class="GtkImage" id="dlc_image">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="stock">gtk-missing-image</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="dlc_name">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">label</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="dlc_button">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="focus_on_click">False</property>
-                <property name="receives_default">True</property>
-                <property name="relief">none</property>
-                <child>
-                  <object class="GtkImage" id="dlc_button_icon">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="stock">gtk-goto-bottom</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
         <child>
           <placeholder/>
         </child>

--- a/data/ui/gametile.ui
+++ b/data/ui/gametile.ui
@@ -94,7 +94,6 @@
         </child>
         <child>
           <object class="GtkMenuButton" id="menu_button_dlc">
-            <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="focus_on_click">False</property>
             <property name="receives_default">True</property>
@@ -105,6 +104,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="hexpand">False</property>
                 <property name="text" translatable="yes">DLC</property>
               </object>
             </child>

--- a/data/ui/gametile.ui
+++ b/data/ui/gametile.ui
@@ -149,20 +149,6 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton" id="menu_button_uninstall">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes" context="uninstall" comments="Removes the game files from the local machine">Uninstall</property>
-            <signal name="clicked" handler="on_menu_button_uninstall_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">5</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkMenuButton" id="menu_button_dlc">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -182,8 +168,21 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">7</property>
+            <property name="position">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="menu_button_uninstall">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="text" translatable="yes" context="uninstall" comments="Removes the game files from the local machine">Uninstall</property>
+            <signal name="clicked" handler="on_menu_button_uninstall_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">6</property>
           </packing>
         </child>
       </object>

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -124,10 +124,14 @@ class Api:
         return response
 
     # This returns a unique download url and a link to the checksum of the download
-    def get_download_info(self, game: Game, operating_system="linux") -> tuple:
-        response = self.get_info(game)
+    def get_download_info(self, game: Game, operating_system="linux", dlc=False, dlc_installers="") -> tuple:
+        if dlc:
+            installers = dlc_installers
+        else:
+            response = self.get_info(game)
+            installers = response["downloads"]["installers"]
         possible_downloads = []
-        for installer in response["downloads"]["installers"]:
+        for installer in installers:
             if installer["os"] == operating_system:
                 possible_downloads.append(installer)
         if not possible_downloads:

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -118,10 +118,9 @@ class Api:
 
     # Get Extrainfo about a game
     def get_info(self, game: Game) -> tuple:
-        request_url = "https://api.gog.com/products/" + str(game.id) + "?expand=downloads,expanded_dlcs,description," \
-                                                                       "screenshots,videos,related_products,changelog "
+        request_url = "https://api.gog.com/products/{}?expand=downloads,expanded_dlcs,description,screenshots,videos," \
+                      "related_products,changelog ".format(str(game.id))
         response = self.__request(request_url)
-
         return response
 
     # This returns a unique download url and a link to the checksum of the download

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -1,5 +1,6 @@
 import os
 import re
+import pickle
 
 
 class Game:
@@ -51,11 +52,37 @@ class Game:
                 is_latest = True
         return is_latest
 
-    def get_dlc_status(self, dlc):
-        # TODO
+    def get_dlc_status(self, dlc_title):
         status_list = ["installed", "updatable", "not-installed", "not-installable"]
         status = status_list[2]
+        dlc_status_file_name = "minigalaxy-dlc.pickle"
+        dlc_status_file_path = os.path.join(self.install_dir, dlc_status_file_name)
+        if self.installed_version:
+            if os.path.isfile(dlc_status_file_path):
+                dlc_staus_file = open(dlc_status_file_path, 'rb')
+                dlc_status_dict = pickle.load(dlc_staus_file)
+                dlc_staus_file.close()
+                if dlc_status_dict[dlc_title]:
+                    status = status_list[0]
         return status
+
+    def set_dlc_status(self, dlc_title, status):
+        dlc_status_file_name = "minigalaxy-dlc.pickle"
+        dlc_status_file_path = os.path.join(self.install_dir, dlc_status_file_name)
+        if self.installed_version:
+            if os.path.isfile(dlc_status_file_path):
+                dlc_staus_file = open(dlc_status_file_path, 'rb')
+                dlc_status_dict = pickle.load(dlc_staus_file)
+                dlc_staus_file.close()
+            else:
+                dlc_status_dict = {}
+            for dlc in self.dlcs:
+                if dlc["title"] not in dlc_status_dict:
+                    dlc_status_dict[dlc["title"]] = False
+            dlc_status_dict[dlc_title] = status
+            dlc_staus_file = open(dlc_status_file_path, 'wb')
+            pickle.dump(dlc_status_dict, dlc_staus_file)
+            dlc_staus_file.close()
 
     def __str__(self):
         return self.name

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -1,6 +1,6 @@
 import os
 import re
-import pickle
+import json
 
 
 class Game:
@@ -18,7 +18,7 @@ class Game:
         self.dlcs = dlcs
 
         self.dlc_status_list = ["not-installed", "installed"]
-        self.dlc_status_file_name = "minigalaxy-dlc.pickle"
+        self.dlc_status_file_name = "minigalaxy-dlc.json"
         self.dlc_status_file_path = ""
         self.read_installed_version()
 
@@ -66,8 +66,8 @@ class Game:
         status = self.dlc_status_list[0]
         if self.installed_version:
             if os.path.isfile(self.dlc_status_file_path):
-                dlc_staus_file = open(self.dlc_status_file_path, 'rb')
-                dlc_status_dict = pickle.load(dlc_staus_file)
+                dlc_staus_file = open(self.dlc_status_file_path, 'r')
+                dlc_status_dict = json.load(dlc_staus_file)
                 dlc_staus_file.close()
                 status = dlc_status_dict[dlc_title]
         return status
@@ -76,8 +76,8 @@ class Game:
         self.read_installed_version()
         if self.installed_version:
             if os.path.isfile(self.dlc_status_file_path):
-                dlc_staus_file = open(self.dlc_status_file_path, 'rb')
-                dlc_status_dict = pickle.load(dlc_staus_file)
+                dlc_staus_file = open(self.dlc_status_file_path, 'r')
+                dlc_status_dict = json.load(dlc_staus_file)
                 dlc_staus_file.close()
             else:
                 dlc_status_dict = {}
@@ -88,8 +88,8 @@ class Game:
                 dlc_status_dict[dlc_title] = self.dlc_status_list[1]
             else:
                 dlc_status_dict[dlc_title] = self.dlc_status_list[0]
-            dlc_status_file = open(self.dlc_status_file_path, 'wb')
-            pickle.dump(dlc_status_dict, dlc_status_file)
+            dlc_status_file = open(self.dlc_status_file_path, 'w')
+            json.dump(dlc_status_dict, dlc_status_file)
             dlc_status_file.close()
 
     def __str__(self):

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -12,14 +12,15 @@ class Game:
         self.install_dir = install_dir
         self.image_url = image_url
         self.platform = platform
-        self.installed_version = self.get_installed_version()
+        self.installed_version = ""
         if dlcs is None:
             dlcs = []
         self.dlcs = dlcs
 
-        self.dlc_status_list = ["installed", "updatable", "not-installed", "not-installable"]
+        self.dlc_status_list = ["not-installed", "installed"]
         self.dlc_status_file_name = "minigalaxy-dlc.pickle"
-        self.dlc_status_file_path = os.path.join(self.install_dir, self.dlc_status_file_name)
+        self.dlc_status_file_path = ""
+        self.read_installed_version()
 
     def get_stripped_name(self):
         return self.__strip_string(self.name)
@@ -31,7 +32,7 @@ class Game:
     def __strip_string(string):
         return re.sub('[^A-Za-z0-9]+', '', string)
 
-    def get_installed_version(self):
+    def read_installed_version(self):
         gameinfo = os.path.join(self.install_dir, "gameinfo")
         gameinfo_list = []
         if os.path.isfile(gameinfo):
@@ -41,9 +42,11 @@ class Game:
             version = gameinfo_list[1].strip()
         else:
             version = ""
-        return version
+        self.installed_version = version
+        self.dlc_status_file_path = os.path.join(self.install_dir, self.dlc_status_file_name)
 
     def validate_if_installed_is_latest(self, installers):
+        self.read_installed_version()
         if not self.installed_version:
             is_latest = False
         else:
@@ -59,7 +62,8 @@ class Game:
         return is_latest
 
     def get_dlc_status(self, dlc_title):
-        status = self.dlc_status_list[2]
+        self.read_installed_version()
+        status = self.dlc_status_list[0]
         if self.installed_version:
             if os.path.isfile(self.dlc_status_file_path):
                 dlc_staus_file = open(self.dlc_status_file_path, 'rb')
@@ -69,6 +73,7 @@ class Game:
         return status
 
     def set_dlc_status(self, dlc_title, status):
+        self.read_installed_version()
         if self.installed_version:
             if os.path.isfile(self.dlc_status_file_path):
                 dlc_staus_file = open(self.dlc_status_file_path, 'rb')
@@ -78,14 +83,14 @@ class Game:
                 dlc_status_dict = {}
             for dlc in self.dlcs:
                 if dlc["title"] not in dlc_status_dict:
-                    dlc_status_dict[dlc["title"]] = self.dlc_status_list[2]
+                    dlc_status_dict[dlc["title"]] = self.dlc_status_list[0]
             if status:
-                dlc_status_dict[dlc_title] = self.dlc_status_list[0]
+                dlc_status_dict[dlc_title] = self.dlc_status_list[1]
             else:
-                dlc_status_dict[dlc_title] = self.dlc_status_list[2]
-            dlc_staus_file = open(self.dlc_status_file_path, 'wb')
-            pickle.dump(dlc_status_dict, dlc_staus_file)
-            dlc_staus_file.close()
+                dlc_status_dict[dlc_title] = self.dlc_status_list[0]
+            dlc_status_file = open(self.dlc_status_file_path, 'wb')
+            pickle.dump(dlc_status_dict, dlc_status_file)
+            dlc_status_file.close()
 
     def __str__(self):
         return self.name

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -4,7 +4,7 @@ import re
 
 class Game:
     def __init__(self, name: str, url: str = "", game_id: int = 0, install_dir: str = "", image_url="",
-                 platform="linux"):
+                 platform="linux", dlcs=[]):
         self.name = name
         self.url = url
         self.id = game_id
@@ -12,6 +12,7 @@ class Game:
         self.image_url = image_url
         self.platform = platform
         self.installed_version = self.get_installed_version()
+        self.dlcs = dlcs
 
     def get_stripped_name(self):
         return self.__strip_string(self.name)
@@ -55,12 +56,6 @@ class Game:
         status_list = ["installed", "updatable", "not-installed", "not-installable"]
         status = status_list[2]
         return status
-
-    def install_dlc(self, installer):
-        # TODO
-        print("Install DLC")
-        print(installer)
-        return True
 
     def __str__(self):
         return self.name

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -50,6 +50,18 @@ class Game:
                 is_latest = True
         return is_latest
 
+    def get_dlc_status(self, dlc):
+        # TODO
+        status_list = ["installed", "updatable", "not-installed", "not-installable"]
+        status = status_list[2]
+        return status
+
+    def install_dlc(self, installer):
+        # TODO
+        print("Install DLC")
+        print(installer)
+        return True
+
     def __str__(self):
         return self.name
 

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -17,7 +17,7 @@ class Game:
             dlcs = []
         self.dlcs = dlcs
 
-        self.dlc_status_list = ["not-installed", "installed"]
+        self.dlc_status_list = ["not-installed", "installed", "updatable"]
         self.dlc_status_file_name = "minigalaxy-dlc.json"
         self.dlc_status_file_path = ""
         self.read_installed_version()
@@ -67,7 +67,8 @@ class Game:
         if self.installed_version:
             if os.path.isfile(self.dlc_status_file_path):
                 dlc_staus_file = open(self.dlc_status_file_path, 'r')
-                dlc_status_dict = json.load(dlc_staus_file)
+                json_list = json.load(dlc_staus_file)
+                dlc_status_dict = json_list[0]
                 dlc_staus_file.close()
                 status = dlc_status_dict[dlc_title]
         return status
@@ -77,19 +78,27 @@ class Game:
         if self.installed_version:
             if os.path.isfile(self.dlc_status_file_path):
                 dlc_staus_file = open(self.dlc_status_file_path, 'r')
-                dlc_status_dict = json.load(dlc_staus_file)
+                json_list = json.load(dlc_staus_file)
+                dlc_status_dict = json_list[0]
+                dlc_installers_version_dict = json_list[1]
                 dlc_staus_file.close()
             else:
                 dlc_status_dict = {}
+                dlc_installers_version_dict = {}
             for dlc in self.dlcs:
                 if dlc["title"] not in dlc_status_dict:
                     dlc_status_dict[dlc["title"]] = self.dlc_status_list[0]
             if status:
                 dlc_status_dict[dlc_title] = self.dlc_status_list[1]
+                dlc_installers = {}
+                for dlc in self.dlcs:
+                    if dlc_title == dlc["title"]:
+                        dlc_installers = dlc["downloads"]["installers"]
+                dlc_installers_version_dict[dlc_title] = dlc_installers
             else:
                 dlc_status_dict[dlc_title] = self.dlc_status_list[0]
             dlc_status_file = open(self.dlc_status_file_path, 'w')
-            json.dump(dlc_status_dict, dlc_status_file)
+            json.dump([dlc_status_dict, dlc_installers_version_dict], dlc_status_file)
             dlc_status_file.close()
 
     def __str__(self):

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -5,7 +5,7 @@ import pickle
 
 class Game:
     def __init__(self, name: str, url: str = "", game_id: int = 0, install_dir: str = "", image_url="",
-                 platform="linux", dlcs=[]):
+                 platform="linux", dlcs=None):
         self.name = name
         self.url = url
         self.id = game_id
@@ -13,7 +13,13 @@ class Game:
         self.image_url = image_url
         self.platform = platform
         self.installed_version = self.get_installed_version()
+        if dlcs is None:
+            dlcs = []
         self.dlcs = dlcs
+
+        self.dlc_status_list = ["installed", "updatable", "not-installed", "not-installable"]
+        self.dlc_status_file_name = "minigalaxy-dlc.pickle"
+        self.dlc_status_file_path = os.path.join(self.install_dir, self.dlc_status_file_name)
 
     def get_stripped_name(self):
         return self.__strip_string(self.name)
@@ -53,34 +59,31 @@ class Game:
         return is_latest
 
     def get_dlc_status(self, dlc_title):
-        status_list = ["installed", "updatable", "not-installed", "not-installable"]
-        status = status_list[2]
-        dlc_status_file_name = "minigalaxy-dlc.pickle"
-        dlc_status_file_path = os.path.join(self.install_dir, dlc_status_file_name)
+        status = self.dlc_status_list[2]
         if self.installed_version:
-            if os.path.isfile(dlc_status_file_path):
-                dlc_staus_file = open(dlc_status_file_path, 'rb')
+            if os.path.isfile(self.dlc_status_file_path):
+                dlc_staus_file = open(self.dlc_status_file_path, 'rb')
                 dlc_status_dict = pickle.load(dlc_staus_file)
                 dlc_staus_file.close()
-                if dlc_status_dict[dlc_title]:
-                    status = status_list[0]
+                status = dlc_status_dict[dlc_title]
         return status
 
     def set_dlc_status(self, dlc_title, status):
-        dlc_status_file_name = "minigalaxy-dlc.pickle"
-        dlc_status_file_path = os.path.join(self.install_dir, dlc_status_file_name)
         if self.installed_version:
-            if os.path.isfile(dlc_status_file_path):
-                dlc_staus_file = open(dlc_status_file_path, 'rb')
+            if os.path.isfile(self.dlc_status_file_path):
+                dlc_staus_file = open(self.dlc_status_file_path, 'rb')
                 dlc_status_dict = pickle.load(dlc_staus_file)
                 dlc_staus_file.close()
             else:
                 dlc_status_dict = {}
             for dlc in self.dlcs:
                 if dlc["title"] not in dlc_status_dict:
-                    dlc_status_dict[dlc["title"]] = False
-            dlc_status_dict[dlc_title] = status
-            dlc_staus_file = open(dlc_status_file_path, 'wb')
+                    dlc_status_dict[dlc["title"]] = self.dlc_status_list[2]
+            if status:
+                dlc_status_dict[dlc_title] = self.dlc_status_list[0]
+            else:
+                dlc_status_dict[dlc_title] = self.dlc_status_list[2]
+            dlc_staus_file = open(self.dlc_status_file_path, 'wb')
             pickle.dump(dlc_status_dict, dlc_staus_file)
             dlc_staus_file.close()
 

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -346,21 +346,17 @@ class GameTile(Gtk.Box):
 
     def __check_for_dlc(self, game_info):
         dlcs = game_info["expanded_dlcs"]
-        dlcs_present = False
         for dlc in dlcs:
             d_installer = dlc["downloads"]["installers"]
             if d_installer:
-                dlcs_present = True
                 d_icon = dlc["images"]["sidebarIcon"]
                 d_name = dlc["title"]
                 d_status = self.game.get_dlc_status(d_name)
                 self.dlc_box(d_icon, d_name, d_status, d_installer)
                 if dlc not in self.game.dlcs:
                     self.game.dlcs.append(dlc)
-        if dlcs_present:
+        if self.game.dlcs:
             self.menu_button_dlc.show()
-        else:
-            self.menu_button_dlc.hide()
 
     def dlc_box(self, icon, title, status, installer):
         if title not in self.dlc_dict:

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -40,10 +40,7 @@ class GameTile(Gtk.Box):
     menu_button_store = Gtk.Template.Child()
     menu_button_update = Gtk.Template.Child()
     menu_button_dlc = Gtk.Template.Child()
-    dlc_image = Gtk.Template.Child()
-    dlc_name = Gtk.Template.Child()
-    dlc_button = Gtk.Template.Child()
-    dlc_button_icon = Gtk.Template.Child()
+    dlc_horizontal_box = Gtk.Template.Child()
 
     state = Enum('state',
                  'DOWNLOADABLE INSTALLABLE UPDATABLE QUEUED DOWNLOADING INSTALLING INSTALLED NOTLAUNCHABLE UNINSTALLING'
@@ -323,23 +320,38 @@ class GameTile(Gtk.Box):
     def __check_for_dlc(self, game_info):
         dlcs = game_info["expanded_dlcs"]
         if dlcs:
-            print("yes")
             self.menu_button_dlc.show()
         else:
-            print("no")
             self.menu_button_dlc.hide()
         for dlc in dlcs:
             print(dlc["id"])
             print(dlc["title"])
-            self.dlc_name.set_text(dlc["title"])
-            url = "http:{}".format(dlc["images"]["sidebarIcon"])
-            response = urllib.request.urlopen(url)
-            input_stream = Gio.MemoryInputStream.new_from_data(response.read(), None)
-            pixbuf = Pixbuf.new_from_stream(input_stream, None)
-            self.dlc_image.set_from_pixbuf(pixbuf)
+            self.dlc_box(dlc["images"]["sidebarIcon"], dlc["title"], "installed")
             break
-#           print(dlc["images"]["sidebarIcon"])
 #           print(dlc["downloads"]["installers"])
+
+    def dlc_box(self, icon, title, status):
+        dlc_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        image = Gtk.Image()
+        url = "http:{}".format(icon)
+        response = urllib.request.urlopen(url)
+        input_stream = Gio.MemoryInputStream.new_from_data(response.read(), None)
+        pixbuf = Pixbuf.new_from_stream(input_stream, None)
+        image.set_from_pixbuf(pixbuf)
+        dlc_box.pack_start(image, True, True, 0)
+        label = Gtk.Label(label=title, xalign=0)
+        dlc_box.pack_start(label, True, True, 0)
+        install_button = Gtk.Button()
+        install_button_image = Gtk.Image()
+        if status.lower() == "installed":
+            icon_name = "gtk-ok"
+        else:
+            icon_name = "gtk-goto-bottom"
+        install_button_image.set_from_icon_name(icon_name, 1)
+        install_button.add(install_button_image)
+        dlc_box.pack_start(install_button, True, True, 0)
+        self.dlc_horizontal_box.pack_start(dlc_box, True, True, 0)
+        dlc_box.show_all()
 
     def set_progress(self, percentage: int):
         if self.current_state == self.state.QUEUED:

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -342,7 +342,7 @@ class GameTile(Gtk.Box):
         if not install_success:
             GLib.idle_add(self.update_to_state, self.state.INSTALLED)
         self.game.set_dlc_status(dlc_title, install_success)
-        self.__check_for_dlc(self.api.get_info(self.game))
+        self.__check_for_update_dlc()
 
     def __check_for_dlc(self, game_info):
         dlcs = game_info["expanded_dlcs"]

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -324,11 +324,12 @@ class GameTile(Gtk.Box):
         else:
             self.menu_button_dlc.hide()
         for dlc in dlcs:
-            d_icon = dlc["images"]["sidebarIcon"]
-            d_name = dlc["title"]
-            d_status = self.game.get_dlc_status(dlc)
             d_installer = dlc["downloads"]["installers"]
-            self.dlc_box(d_icon, d_name, d_status, d_installer)
+            if d_installer:
+                d_icon = dlc["images"]["sidebarIcon"]
+                d_name = dlc["title"]
+                d_status = self.game.get_dlc_status(dlc)
+                self.dlc_box(d_icon, d_name, d_status, d_installer)
 
     def dlc_box(self, icon, title, status, installer):
         if title not in self.dlc_dict:

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -352,13 +352,13 @@ class GameTile(Gtk.Box):
                 d_icon = dlc["images"]["sidebarIcon"]
                 d_name = dlc["title"]
                 d_status = self.game.get_dlc_status(d_name)
-                self.dlc_box(d_icon, d_name, d_status, d_installer)
+                self.update_gtk_box_for_dlc(d_icon, d_name, d_status, d_installer)
                 if dlc not in self.game.dlcs:
                     self.game.dlcs.append(dlc)
         if self.game.dlcs:
             self.menu_button_dlc.show()
 
-    def dlc_box(self, icon, title, status, installer):
+    def update_gtk_box_for_dlc(self, icon, title, status, installer):
         if title not in self.dlc_dict:
             dlc_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
             image = Gtk.Image()
@@ -432,8 +432,8 @@ class GameTile(Gtk.Box):
             self.update_to_state(self.state.INSTALLABLE)
         else:
             self.update_to_state(self.state.DOWNLOADABLE)
-        check_upd_thread = threading.Thread(target=self.__check_for_update_dlc())
-        check_upd_thread.start()
+        check_update_thread = threading.Thread(target=self.__check_for_update_dlc())
+        check_update_thread.start()
 
     def update_to_state(self, state):
         self.current_state = state

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -8,7 +8,6 @@ import threading
 import subprocess
 import re
 import urllib.parse
-import urllib.request
 from gi.repository.GdkPixbuf import Pixbuf
 from enum import Enum
 from zipfile import BadZipFile
@@ -335,32 +334,37 @@ class GameTile(Gtk.Box):
         if title not in self.dlc_dict:
             dlc_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
             image = Gtk.Image()
-            if icon:
-                url = "http:{}".format(icon)
-                response = urllib.request.urlopen(url)
-                input_stream = Gio.MemoryInputStream.new_from_data(response.read(), None)
-                pixbuf = Pixbuf.new_from_stream(input_stream, None)
-                image.set_from_pixbuf(pixbuf)
-            else:
-                image.set_from_icon_name("no-icon", 1)
+            image.set_from_icon_name("gtk-cdrom", 1)
             dlc_box.pack_start(image, False, True, 0)
             label = Gtk.Label(label=title, xalign=0)
             dlc_box.pack_start(label, True, True, 0)
             install_button = Gtk.Button()
             dlc_box.pack_start(install_button, False, True, 0)
-            self.dlc_dict[title] = install_button
-            self.dlc_dict[title].connect("clicked", lambda x: self.game.install_dlc(installer))
+            self.dlc_dict[title] = [install_button, image]
+            self.dlc_dict[title][0].connect("clicked", lambda x: self.game.install_dlc(installer))
             self.dlc_horizontal_box.pack_start(dlc_box, False, True, 0)
             dlc_box.show_all()
+            self.get_async_image_dlc_icon(icon, title)
         if status.lower() == "installed":
             icon_name = "gtk-ok"
-            self.dlc_dict[title].set_sensitive(False)
+            self.dlc_dict[title][0].set_sensitive(False)
         else:
             icon_name = "gtk-goto-bottom"
-            self.dlc_dict[title].set_sensitive(True)
+            self.dlc_dict[title][0].set_sensitive(True)
         install_button_image = Gtk.Image()
         install_button_image.set_from_icon_name(icon_name, 1)
-        self.dlc_dict[title].set_image(install_button_image)
+        self.dlc_dict[title][0].set_image(install_button_image)
+
+    def get_async_image_dlc_icon(self, icon, title):
+        if icon:
+            url = "http:{}".format(icon)
+            response = Gio.File.new_for_uri(url)
+            response.read_async(3, None, self.set_proper_dlc_icon, title)
+
+    def set_proper_dlc_icon(self, source, async_res, user_data):
+        response = source.read_finish(async_res)
+        pixbuf = Pixbuf.new_from_stream(response)
+        self.dlc_dict[user_data][1].set_from_pixbuf(pixbuf)
 
     def set_progress(self, percentage: int):
         if self.current_state == self.state.QUEUED:

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -89,23 +89,18 @@ class Library(Gtk.Viewport):
         games_with_removed_tiles = []
         for child in self.flowbox.get_children():
             tile = child.get_children()[0]
-            if tile.current_state == tile.state.INSTALLED:
-                if not tile.game.image_url:
-                    games_with_removed_tiles.append(copy.deepcopy(tile.game))
-                    self.flowbox.remove(tile)
-                    continue
-            if tile.game in self.games:
+            if tile.current_state == tile.state.INSTALLED and not tile.game.image_url:
+                games_with_removed_tiles.append(copy.deepcopy(tile.game))
+            elif tile.game in self.games:
                 games_with_tiles.append(tile.game)
 
         for game in self.games:
-            if game in games_with_tiles:
-                continue
             if game in games_with_removed_tiles:
                 for tile_game in games_with_removed_tiles:
                     if game == tile_game:
                         game.install_dir = tile_game.install_dir
-                        break
-            self.__add_gametile(game)
+            if game not in games_with_tiles + games_with_removed_tiles:
+                self.__add_gametile(game)
 
     def __add_gametile(self, game):
         self.flowbox.add(GameTile(self, game, self.api, self.offline))

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -59,7 +59,6 @@ class Library(Gtk.Viewport):
             tile.reload_state()
 
     def filter_library(self, widget: Gtk.Widget = None):
-        self.__load_tile_states()
         if isinstance(widget, Gtk.Switch):
             self.show_installed_only = widget.get_active()
         elif isinstance(widget, Gtk.SearchEntry):

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -86,20 +86,13 @@ class Library(Gtk.Viewport):
 
     def __create_gametiles(self) -> None:
         games_with_tiles = []
-        games_with_removed_tiles = []
         for child in self.flowbox.get_children():
             tile = child.get_children()[0]
-            if tile.current_state == tile.state.INSTALLED and not tile.game.image_url:
-                games_with_removed_tiles.append(copy.deepcopy(tile.game))
-            elif tile.game in self.games:
+            if tile.game in self.games:
                 games_with_tiles.append(tile.game)
 
         for game in self.games:
-            if game in games_with_removed_tiles:
-                for tile_game in games_with_removed_tiles:
-                    if game == tile_game:
-                        game.install_dir = tile_game.install_dir
-            if game not in games_with_tiles + games_with_removed_tiles:
+            if game not in games_with_tiles:
                 self.__add_gametile(game)
 
     def __add_gametile(self, game):


### PR DESCRIPTION
OK. This pull request is to address issue #4 
I tested it on Stellaris and Neverwinter Nights and it seems to work fine for me:
![neverwinter_dlc](https://user-images.githubusercontent.com/1833284/97371200-01003180-18b1-11eb-887e-ecc027e7b3f7.png)
There are few notes:
- in offline mode, there is no DLC button. Technically there is no reason why user cannot check installed DLCs in offline mode. If this is real use case, maybe we should create another issue for it.
- DLCs do not support update at the moment. What I saw from Stellaris DLCs installers names, they are connected to game version, so this might be a big deal. Please decide if it should be addressed in separate issue or in this pull request.
- Some DLCs (Stellaris: Infinite Frontiers eBook) points to game installer itself which results in game redownload and reinstall. Please decide if it should be addressed in separate issue or in this pull request.
- Some DLCs (Stellaris: Arachnoid Portrait Pack) cause following error in api.get_real_download_link:
"
Traceback (most recent call last):
  File "/home/makson/Publiczny/minigalaxy/GitHub/minigalaxy/build/lib/minigalaxy/ui/gametile.py", line 399, in <lambda>
    self.dlc_dict[title][0].connect("clicked", lambda x: self.__download_dlc(installer))
  File "/home/makson/Publiczny/minigalaxy/GitHub/minigalaxy/build/lib/minigalaxy/ui/gametile.py", line 324, in __download_dlc
    result = self.__download(download_info, finish_func, cancel_to_state)
  File "/home/makson/Publiczny/minigalaxy/GitHub/minigalaxy/build/lib/minigalaxy/ui/gametile.py", line 233, in __download
    download_url = self.api.get_real_download_link(file_info["downlink"])
  File "/home/makson/Publiczny/minigalaxy/GitHub/minigalaxy/build/lib/minigalaxy/api.py", line 156, in get_real_download_link
    return self.__request(url)['downlink']
  File "/home/makson/Publiczny/minigalaxy/GitHub/minigalaxy/build/lib/minigalaxy/api.py", line 193, in __request
    return response.json()
  File "/usr/lib/python3/dist-packages/requests/models.py", line 897, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
"
It is properly handled (ValueError) and proper message is returned to user, but I don't know what cause this error and how to fix it.
- If you find DLC button odd, could you try to fix it in Glade and propose solution.

Some others note from the work:
- Performance. reload_state for all tiles is our most expensive procedure, which can be noticed by user. I have tracked some cases, where it was executed two times in the row and I have deduplicated it. In a result I think, that aplication performance has improved, but please check if there are some corner cases, where tiles are not updated properly (I haven't seen any). Downloading DLCs icons is done in async now, so it should not hurt performance.
- Cleaning. I have deduplicated some code in gemetiles.ui. I hope it is now more clean and easier to maintain.

Waiting for the feadback.
Tomek