### PR TITLE
Improve DLC support

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -103,6 +103,13 @@ class Api:
             current_page += 1
         return games
 
+    def get_owned_products_ids(self):
+        if not self.active_token:
+            return
+        url2 = "https://embed.gog.com/user/data/games"
+        response2 = self.__request(url2)
+        return response2["owned"]
+
     # Generate the URL for the login page for GOG
     def get_login_url(self) -> str:
         params = {

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -61,7 +61,8 @@ class Game:
                 is_latest = True
         return is_latest
 
-    def get_dlc_status(self, dlc_title):
+    def get_dlc_status(self, dlc_title, available_version):
+        json_list = ["", ""]
         self.read_installed_version()
         status = self.dlc_status_list[0]
         if self.installed_version:
@@ -74,34 +75,36 @@ class Game:
                     status = dlc_status_dict[dlc_title]
                 else:
                     status = self.dlc_status_list[0]
+        if status == self.dlc_status_list[1]:
+            installed_version_dcit = json_list[1]
+            if dlc_title in installed_version_dcit:
+                installed_version = installed_version_dcit[dlc_title]
+            if available_version != installed_version:
+                status = self.dlc_status_list[2]
         return status
 
-    def set_dlc_status(self, dlc_title, status):
+    def set_dlc_status(self, dlc_title, status, version):
         self.read_installed_version()
         if self.installed_version:
             if os.path.isfile(self.dlc_status_file_path):
                 dlc_staus_file = open(self.dlc_status_file_path, 'r')
                 json_list = json.load(dlc_staus_file)
                 dlc_status_dict = json_list[0]
-                dlc_installers_version_dict = json_list[1]
+                dlc_version = json_list[1]
                 dlc_staus_file.close()
             else:
                 dlc_status_dict = {}
-                dlc_installers_version_dict = {}
+                dlc_version = ""
             for dlc in self.dlcs:
                 if dlc["title"] not in dlc_status_dict:
                     dlc_status_dict[dlc["title"]] = self.dlc_status_list[0]
             if status:
                 dlc_status_dict[dlc_title] = self.dlc_status_list[1]
-                dlc_installers = {}
-                for dlc in self.dlcs:
-                    if dlc_title == dlc["title"]:
-                        dlc_installers = dlc["downloads"]["installers"]
-                dlc_installers_version_dict[dlc_title] = dlc_installers
+                dlc_version[dlc_title] = version
             else:
                 dlc_status_dict[dlc_title] = self.dlc_status_list[0]
             dlc_status_file = open(self.dlc_status_file_path, 'w')
-            json.dump([dlc_status_dict, dlc_installers_version_dict], dlc_status_file)
+            json.dump([dlc_status_dict, dlc_version], dlc_status_file)
             dlc_status_file.close()
 
     def __str__(self):

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -79,8 +79,8 @@ class Game:
             installed_version_dcit = json_list[1]
             if dlc_title in installed_version_dcit:
                 installed_version = installed_version_dcit[dlc_title]
-            if available_version != installed_version:
-                status = self.dlc_status_list[2]
+                if available_version != installed_version:
+                    status = self.dlc_status_list[2]
         return status
 
     def set_dlc_status(self, dlc_title, status, version):
@@ -94,7 +94,7 @@ class Game:
                 dlc_staus_file.close()
             else:
                 dlc_status_dict = {}
-                dlc_version = ""
+                dlc_version = {}
             for dlc in self.dlcs:
                 if dlc["title"] not in dlc_status_dict:
                     dlc_status_dict[dlc["title"]] = self.dlc_status_list[0]

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -70,7 +70,10 @@ class Game:
                 json_list = json.load(dlc_staus_file)
                 dlc_status_dict = json_list[0]
                 dlc_staus_file.close()
-                status = dlc_status_dict[dlc_title]
+                if dlc_title in dlc_status_dict:
+                    status = dlc_status_dict[dlc_title]
+                else:
+                    status = self.dlc_status_list[0]
         return status
 
     def set_dlc_status(self, dlc_title, status):

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -45,15 +45,15 @@ class GameTile(Gtk.Box):
                  'DOWNLOADABLE INSTALLABLE UPDATABLE QUEUED DOWNLOADING INSTALLING INSTALLED NOTLAUNCHABLE UNINSTALLING'
                  ' UPDATING UPDATE_INSTALLABLE')
 
-    def __init__(self, parent, game, api, offline):
+    def __init__(self, parent, game):
         Gtk.Frame.__init__(self)
         Gtk.StyleContext.add_provider(self.button.get_style_context(),
                                       CSS_PROVIDER,
                                       Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         self.parent = parent
         self.game = game
-        self.api = api
-        self.offline = offline
+        self.api = parent.api
+        self.offline = parent.offline
         self.progress_bar = None
         self.thumbnail_set = False
         self.download = None

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -347,8 +347,8 @@ class GameTile(Gtk.Box):
     def __check_for_dlc(self, game_info):
         dlcs = game_info["expanded_dlcs"]
         for dlc in dlcs:
-            d_installer = dlc["downloads"]["installers"]
-            if d_installer:
+            if dlc["is_installable"]:
+                d_installer = dlc["downloads"]["installers"]
                 d_icon = dlc["images"]["sidebarIcon"]
                 d_name = dlc["title"]
                 d_status = self.game.get_dlc_status(d_name)

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -347,7 +347,7 @@ class GameTile(Gtk.Box):
     def __check_for_dlc(self, game_info):
         dlcs = game_info["expanded_dlcs"]
         for dlc in dlcs:
-            if dlc["is_installable"]:
+            if dlc["is_installable"] and dlc["id"] in self.parent.owned_products_ids:
                 d_installer = dlc["downloads"]["installers"]
                 d_icon = dlc["images"]["sidebarIcon"]
                 d_name = dlc["title"]

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -98,7 +98,7 @@ class Library(Gtk.Viewport):
                 self.__add_gametile(game)
 
     def __add_gametile(self, game):
-        self.flowbox.add(GameTile(self, game, self.api, self.offline))
+        self.flowbox.add(GameTile(self, game))
         self.sort_library()
         self.flowbox.show_all()
 

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -29,6 +29,7 @@ class Library(Gtk.Viewport):
         self.search_string = ""
         self.offline = False
         self.games = []
+        self.owned_products_ids = []
 
     def reset(self):
         self.games = []
@@ -44,6 +45,7 @@ class Library(Gtk.Viewport):
 
     def __update_library(self):
         GLib.idle_add(self.__load_tile_states)
+        self.owned_products_ids = self.api.get_owned_products_ids()
         # Get already installed games first
         self.games = self.__get_installed_games()
         GLib.idle_add(self.__create_gametiles)

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -17,16 +17,22 @@ class MyTestCase(unittest.TestCase):
 
     def test_local_and_api_comparison(self):
         larry1_api = Game("Leisure Suit Larry 1 - In the Land of the Lounge Lizards", game_id=1207662033)
-        larry1_local_gog = Game("Leisure Suit Larry", install_dir="/home/user/Games/Leisure Suit Larry", game_id=1207662033)
-        larry1_local_minigalaxy = Game("Leisure Suit Larry", install_dir="/home/wouter/Games/Leisure Suit Larry 1 - In the Land of the Lounge Lizards", game_id=1207662033)
+        larry1_local_gog = Game("Leisure Suit Larry", install_dir="/home/user/Games/Leisure Suit Larry",
+                                game_id=1207662033)
+        larry1_local_minigalaxy = Game("Leisure Suit Larry",
+                                       install_dir="/home/wouter/Games/Leisure Suit Larry 1 - In the Land of the Lounge Lizards",
+                                       game_id=1207662033)
 
         self.assertEqual(larry1_local_gog, larry1_local_minigalaxy)
         self.assertEqual(larry1_local_minigalaxy, larry1_api)
         self.assertEqual(larry1_local_gog, larry1_api)
 
         larry2_api = Game("Leisure Suit Larry 2 - Looking For Love (In Several Wrong Places)", game_id=1207662053)
-        larry2_local_minigalaxy = Game("Leisure Suit Larry 2", install_dir="/home/user/Games/Leisure Suit Larry 2 - Looking For Love (In Several Wrong Places)", game_id=1207662053)
-        larry2_local_gog = Game("Leisure Suit Larry 2", install_dir="/home/user/Games/Leisure Suit Larry 2", game_id=1207662053)
+        larry2_local_minigalaxy = Game("Leisure Suit Larry 2",
+                                       install_dir="/home/user/Games/Leisure Suit Larry 2 - Looking For Love (In Several Wrong Places)",
+                                       game_id=1207662053)
+        larry2_local_gog = Game("Leisure Suit Larry 2", install_dir="/home/user/Games/Leisure Suit Larry 2",
+                                game_id=1207662053)
 
         self.assertNotEqual(larry1_api, larry2_api)
         self.assertNotEqual(larry2_local_gog, larry1_api)
@@ -36,8 +42,10 @@ class MyTestCase(unittest.TestCase):
         self.assertNotEqual(larry2_local_minigalaxy, larry1_local_minigalaxy)
 
     def test_local_comparison(self):
-        larry1_local_gog = Game("Leisure Suit Larry", install_dir="/home/user/Games/Leisure Suit Larry", game_id=1207662033)
-        larry1_vga_local_gog = Game("Leisure Suit Larry VGA", install_dir="/home/user/Games/Leisure Suit Larry VGA", game_id=1207662043)
+        larry1_local_gog = Game("Leisure Suit Larry", install_dir="/home/user/Games/Leisure Suit Larry",
+                                game_id=1207662033)
+        larry1_vga_local_gog = Game("Leisure Suit Larry VGA", install_dir="/home/user/Games/Leisure Suit Larry VGA",
+                                    game_id=1207662043)
 
         self.assertNotEqual(larry1_local_gog, larry1_vga_local_gog)
 
@@ -45,7 +53,8 @@ class MyTestCase(unittest.TestCase):
         game = Game("Version Test game")
         game.installed_version = "gog-2"
         game.read_installed_version = MagicMock()
-        installers = [{'os': 'windows', 'version': '1.0'}, {'os': 'mac', 'version': '1.0'}, {'os': 'linux', 'version': 'gog-2'}]
+        installers = [{'os': 'windows', 'version': '1.0'}, {'os': 'mac', 'version': '1.0'},
+                      {'os': 'linux', 'version': 'gog-2'}]
         expected = True
         observed = game.validate_if_installed_is_latest(installers)
         self.assertEqual(expected, observed)
@@ -54,7 +63,8 @@ class MyTestCase(unittest.TestCase):
         game = Game("Version Test game")
         game.installed_version = "91.8193.16"
         game.read_installed_version = MagicMock()
-        installers = [{'os': 'windows', 'version': '81.8193.16'}, {'os': 'mac', 'version': '81.8193.16'}, {'os': 'linux', 'version': '81.8193.16'}]
+        installers = [{'os': 'windows', 'version': '81.8193.16'}, {'os': 'mac', 'version': '81.8193.16'},
+                      {'os': 'linux', 'version': '81.8193.16'}]
         expected = False
         observed = game.validate_if_installed_is_latest(installers)
         self.assertEqual(expected, observed)
@@ -113,7 +123,7 @@ en-US
             game = Game("Game Name test1")
             game.read_installed_version = MagicMock()
             game.installed_version = "1"
-            dlc_status = game.get_dlc_status("Neverwinter Nights: Wyvern Crown of Cormyr")
+            dlc_status = game.get_dlc_status("Neverwinter Nights: Wyvern Crown of Cormyr", "")
         expected = "not-installed"
         observed = dlc_status
         self.assertEqual(expected, observed)
@@ -128,7 +138,7 @@ en-US
             game = Game("Game Name test2")
             game.read_installed_version = MagicMock()
             game.installed_version = "1"
-            dlc_status = game.get_dlc_status("Neverwinter Nights: Infinite Dungeons")
+            dlc_status = game.get_dlc_status("Neverwinter Nights: Infinite Dungeons", "")
         expected = "updatable"
         observed = dlc_status
         self.assertEqual(expected, observed)
@@ -143,7 +153,7 @@ en-US
             game = Game("Game Name test2")
             game.read_installed_version = MagicMock()
             game.installed_version = "1"
-            dlc_status = game.get_dlc_status("Neverwinter Nights: Infinite Dungeons")
+            dlc_status = game.get_dlc_status("Neverwinter Nights: Infinite Dungeons", "")
         expected = "not-installed"
         observed = dlc_status
         self.assertEqual(expected, observed)
@@ -160,7 +170,7 @@ en-US
             game = Game("Game Name test2")
             game.read_installed_version = MagicMock()
             game.installed_version = "1"
-            game.set_dlc_status(dlc_name, dlc_status)
+            game.set_dlc_status(dlc_name, dlc_status, "")
         mock_c = m.mock_calls
         write_string = ""
         for kall in mock_c:
@@ -169,7 +179,7 @@ en-US
                 write_string = "{}{}".format(write_string, args[0])
         expected = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "installed", ' \
                    '"Neverwinter Nights: Infinite Dungeons": "updatable", "Neverwinter Nights: Pirates of ' \
-                   'the Sword Coast": "installed"}, {"Neverwinter Nights: Wyvern Crown of Cormyr": {}}]'
+                   'the Sword Coast": "installed"}, {"Neverwinter Nights: Wyvern Crown of Cormyr": ""}]'
         observed = write_string
         self.assertEqual(expected, observed)
 
@@ -182,7 +192,7 @@ en-US
             game = Game("Game Name test2")
             game.read_installed_version = MagicMock()
             game.installed_version = "1"
-            game.set_dlc_status(dlc_name, dlc_status)
+            game.set_dlc_status(dlc_name, dlc_status, "")
         mock_c = m.mock_calls
         write_string = ""
         for kall in mock_c:
@@ -190,6 +200,82 @@ en-US
             if name == "().write":
                 write_string = "{}{}".format(write_string, args[0])
         expected = '[{"Neverwinter Nights: Test DLC": "not-installed"}, {}]'
+        observed = write_string
+        self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.path.isfile')
+    def test1_get_dlc_status_version(self, mock_isfile):
+        mock_isfile.side_effect = [False, True]
+        json_content = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "not-installed", ' \
+                       '"Neverwinter Nights: Infinite Dungeons": "installed", "Neverwinter Nights: Pirates of ' \
+                       'the Sword Coast": "installed"}, {"Neverwinter Nights: Wyvern Crown of Cormyr": ' \
+                       '"81.8193.16", "Neverwinter Nights: Infinite Dungeons": "81.8193.17", "Neverwinter Nights: ' \
+                       'Pirates of the Sword Coast": "81.8193.18"}] '
+        with patch("builtins.open", mock_open(read_data=json_content)):
+            game = Game("Game Name test2")
+            game.read_installed_version = MagicMock()
+            game.installed_version = "1"
+            dlc_status = game.get_dlc_status("Neverwinter Nights: Infinite Dungeons", "81.8193.16")
+        expected = "updatable"
+        observed = dlc_status
+        self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.path.isfile')
+    def test2_get_dlc_status_version(self, mock_isfile):
+        mock_isfile.side_effect = [False, True]
+        json_content = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "updatable", ' \
+                       '"Neverwinter Nights: Infinite Dungeons": "installed", "Neverwinter Nights: Pirates of ' \
+                       'the Sword Coast": "installed"}, {"Neverwinter Nights: Wyvern Crown of Cormyr": ' \
+                       '"81.8193.16", "Neverwinter Nights: Infinite Dungeons": "81.8193.17", "Neverwinter Nights: ' \
+                       'Pirates of the Sword Coast": "81.8193.18"}] '
+        with patch("builtins.open", mock_open(read_data=json_content)):
+            game = Game("Game Name test2")
+            game.read_installed_version = MagicMock()
+            game.installed_version = "1"
+            dlc_status = game.get_dlc_status("Neverwinter Nights: Wyvern Crown of Cormyr", "")
+        expected = "updatable"
+        observed = dlc_status
+        self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.path.isfile')
+    def test3_get_dlc_status_version(self, mock_isfile):
+        mock_isfile.side_effect = [False, True]
+        json_content = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "updatable", ' \
+                       '"Neverwinter Nights: Infinite Dungeons": "installed", "Neverwinter Nights: Pirates of ' \
+                       'the Sword Coast": "installed"}, {"Neverwinter Nights: Wyvern Crown of Cormyr": ' \
+                       '"81.8193.16", "Neverwinter Nights: Infinite Dungeons": "81.8193.17", "Neverwinter Nights: ' \
+                       'Pirates of the Sword Coast": "81.8193.18"}] '
+        with patch("builtins.open", mock_open(read_data=json_content)):
+            game = Game("Game Name test2")
+            game.read_installed_version = MagicMock()
+            game.installed_version = "1"
+            dlc_status = game.get_dlc_status("Neverwinter Nights: Infinite Dungeons", "81.8193.17")
+        expected = "installed"
+        observed = dlc_status
+        self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.path.isfile')
+    def test1_set_dlc_status_version(self, mock_isfile):
+        mock_isfile.return_value = True
+        json_content = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "not-installed", ' \
+                       '"Neverwinter Nights: Infinite Dungeons": "updatable", "Neverwinter Nights: Pirates of ' \
+                       'the Sword Coast": "installed"}, {}]'
+        dlc_name = "Neverwinter Nights: Wyvern Crown of Cormyr"
+        dlc_status = True
+        with patch("builtins.open", mock_open(read_data=json_content)) as m:
+            game = Game("Game Name test2")
+            game.read_installed_version = MagicMock()
+            game.installed_version = "1"
+            game.set_dlc_status(dlc_name, dlc_status, "81.8193.17")
+        mock_c = m.mock_calls
+        write_string = ""
+        for kall in mock_c:
+            name, args, kwargs = kall
+            if name == "().write":
+                write_string = "{}{}".format(write_string, args[0])
+        expected = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "installed", ' \
+                   '"Neverwinter Nights: Infinite Dungeons": "updatable", "Neverwinter Nights: Pirates of ' \
+                   'the Sword Coast": "installed"}, {"Neverwinter Nights: Wyvern Crown of Cormyr": "81.8193.17"}]'
         observed = write_string
         self.assertEqual(expected, observed)
 


### PR DESCRIPTION
Uff... I manage to do this before 1.0.0 release.

This pull request is to address this issue: https://github.com/sharkwouter/minigalaxy/issues/197
Now:
- DLCs marked as "is_installable" False are not displayed.
- DLCs not present in owned_products_ids (new thing) are not displayed.
- Added proper support for updating DLCs:
![improve_dlcs](https://user-images.githubusercontent.com/1833284/99695894-65687800-2a8e-11eb-81b1-edd92ac1c3d6.png)

This pull request is backward compatible - it can handle previous DLCs json files, but all previously installed DLCs will be initially marked as "updatable".

I have adjust unit tests to new DLCs status handling and added few more unit tests for reading/writing game version.