### PR TITLE
Fix 207

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -172,17 +172,18 @@ class Api:
             Config.set("username", username)
         return username
 
-    def get_version(self, game: Game, dlc_name="") -> str:
+    def get_version(self, game: Game, gameinfo=None, dlc_name="") -> str:
+        if gameinfo is None:
+            gameinfo = self.get_info(game)
         version = "0"
-        response = self.get_info(game)
         if dlc_name:
             installers = {}
-            for dlc in response["expanded_dlcs"]:
+            for dlc in gameinfo["expanded_dlcs"]:
                 if dlc["title"] == dlc_name:
                     installers = dlc["downloads"]["installers"]
                     break
         else:
-            installers = response["downloads"]["installers"]
+            installers = gameinfo["downloads"]["installers"]
         for installer in installers:
             if installer["os"] == game.platform:
                 version = installer["version"]

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -44,7 +44,7 @@ class Game:
         json_dict = self.load_minigalaxy_info_json()
         if dlc_title:
             if "dlcs" in json_dict:
-                if dlc_title in json_dict["dlc"]:
+                if dlc_title in json_dict["dlcs"]:
                     if "version" in json_dict["dlcs"][dlc_title]:
                         installed = True
         else:
@@ -63,7 +63,7 @@ class Game:
         json_dict = self.load_minigalaxy_info_json()
         if dlc_title:
             if "dlcs" in json_dict:
-                if dlc_title in json_dict["dlc"]:
+                if dlc_title in json_dict["dlcs"]:
                     if "version" in json_dict["dlcs"][dlc_title]:
                         installed_version = json_dict["dlcs"][dlc_title]["version"]
         else:

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -54,6 +54,9 @@ class Game:
         if dlc_title and not installed:
             status = self.legacy_get_dlc_status(dlc_title)
             installed = True if status in ["installed", "updatable"] else False
+        if not dlc_title and not installed:
+            if self.install_dir and os.path.exists(self.install_dir):
+                installed = True
         # End: Code for compatibility with minigalaxy 1.0
         return installed
 
@@ -75,6 +78,10 @@ class Game:
         if dlc_title and not update_available:
             status = self.legacy_get_dlc_status(dlc_title, version_from_api)
             update_available = True if status in ["updatable"] else False
+        if not dlc_title and update_available:
+            installed_version = self.legacy_read_installed_version()
+            if version_from_api == installed_version:
+                update_available = False
         # End: Code for compatibility with minigalaxy 1.0
         return update_available
 
@@ -101,6 +108,22 @@ class Game:
                 if available_version != installed_version:
                     status = dlc_status_list[2]
         return status
+
+    # This function is for compatibility with minigalaxy 1.0. It can be removed, when decision to break compatibility
+    # is taken.
+    # This is not a big deal. After removal of this function all games from minigalaxy 1.0 will
+    # be marked as update available.
+    def legacy_read_installed_version(self):
+        gameinfo = os.path.join(self.install_dir, "gameinfo")
+        gameinfo_list = []
+        if os.path.isfile(gameinfo):
+            with open(gameinfo, 'r') as file:
+                gameinfo_list = file.readlines()
+        if len(gameinfo_list) > 1:
+            version = gameinfo_list[1].strip()
+        else:
+            version = ""
+        return version
 
     def set_status(self, key, value, dlc_title=""):
         json_dict = self.load_minigalaxy_info_json()

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -12,15 +12,9 @@ class Game:
         self.install_dir = install_dir
         self.image_url = image_url
         self.platform = platform
-        self.installed_version = ""
-        if dlcs is None:
-            dlcs = []
-        self.dlcs = dlcs
-
-        self.dlc_status_list = ["not-installed", "installed", "updatable"]
-        self.dlc_status_file_name = "minigalaxy-dlc.json"
-        self.dlc_status_file_path = ""
-        self.read_installed_version()
+        self.dlcs = [] if dlcs is None else dlcs
+        self.status_file_name = "minigalaxy-info.json"
+        self.status_file_path = os.path.join(self.install_dir, self.status_file_name)
 
     def get_stripped_name(self):
         return self.__strip_string(self.name)
@@ -28,84 +22,97 @@ class Game:
     def get_install_directory_name(self):
         return re.sub('[^A-Za-z0-9 ]+', '', self.name)
 
+    def load_minigalaxy_info_json(self):
+        json_dict = {}
+        if os.path.isfile(self.status_file_path):
+            staus_file = open(self.status_file_path, 'r')
+            json_dict = json.load(staus_file)
+            staus_file.close()
+        return json_dict
+
+    def save_minigalaxy_info_json(self, json_dict):
+        status_file = open(self.status_file_path, 'w')
+        json.dump(json_dict, status_file)
+        status_file.close()
+
     @staticmethod
     def __strip_string(string):
         return re.sub('[^A-Za-z0-9]+', '', string)
 
-    def read_installed_version(self):
-        gameinfo = os.path.join(self.install_dir, "gameinfo")
-        gameinfo_list = []
-        if os.path.isfile(gameinfo):
-            with open(gameinfo, 'r') as file:
-                gameinfo_list = file.readlines()
-        if len(gameinfo_list) > 1:
-            version = gameinfo_list[1].strip()
+    def is_installed(self, dlc_title="") -> bool:
+        installed = False
+        json_dict = self.load_minigalaxy_info_json()
+        if dlc_title:
+            if "dlcs" in json_dict:
+                if dlc_title in json_dict["dlc"]:
+                    if "version" in json_dict["dlcs"][dlc_title]:
+                        installed = True
         else:
-            version = ""
-        self.installed_version = version
-        self.dlc_status_file_path = os.path.join(self.install_dir, self.dlc_status_file_name)
+            if "version" in json_dict:
+                installed = True
+        # Start: Code for compatibility with minigalaxy 1.0
+        if dlc_title and not installed:
+            status = self.legacy_get_dlc_status(dlc_title)
+            installed = True if status in ["installed", "updatable"] else False
+        # End: Code for compatibility with minigalaxy 1.0
+        return installed
 
-    def validate_if_installed_is_latest(self, installers):
-        self.read_installed_version()
-        if not self.installed_version:
-            is_latest = False
+    def is_update_available(self, version_from_api, dlc_title="") -> bool:
+        update_available = False
+        installed_version = "0"
+        json_dict = self.load_minigalaxy_info_json()
+        if dlc_title:
+            if "dlcs" in json_dict:
+                if dlc_title in json_dict["dlc"]:
+                    if "version" in json_dict["dlcs"][dlc_title]:
+                        installed_version = json_dict["dlcs"][dlc_title]["version"]
         else:
-            current_installer = None
-            for installer in installers:
-                if installer["os"] == self.platform:
-                    current_installer = installer
-                    break
-            if current_installer is not None and current_installer["version"] != self.installed_version:
-                is_latest = False
-            else:
-                is_latest = True
-        return is_latest
+            if "version" in json_dict:
+                installed_version = json_dict["version"]
+        if version_from_api != installed_version:
+            update_available = True
+        # Start: Code for compatibility with minigalaxy 1.0
+        if dlc_title and not update_available:
+            status = self.legacy_get_dlc_status(dlc_title, version_from_api)
+            update_available = True if status in ["updatable"] else False
+        # End: Code for compatibility with minigalaxy 1.0
+        return update_available
 
-    def get_dlc_status(self, dlc_title, available_version):
+    # This function is for compatibility with minigalaxy 1.0. It can be removed, when decision to break compatibility
+    # is taken.
+    # This is not a big deal. After removal of this function all DLCs from minigalaxy 1.0 will be marked as uninstalled.
+    def legacy_get_dlc_status(self, dlc_title, available_version="0"):
+        dlc_status_list = ["not-installed", "installed", "updatable"]
+        dlc_status_file_name = "minigalaxy-dlc.json"
+        dlc_status_file_path = os.path.join(self.install_dir, dlc_status_file_name)
         json_list = ["", ""]
-        self.read_installed_version()
-        status = self.dlc_status_list[0]
-        if self.installed_version:
-            if os.path.isfile(self.dlc_status_file_path):
-                dlc_staus_file = open(self.dlc_status_file_path, 'r')
-                json_list = json.load(dlc_staus_file)
-                dlc_status_dict = json_list[0]
-                dlc_staus_file.close()
-                if dlc_title in dlc_status_dict:
-                    status = dlc_status_dict[dlc_title]
-                else:
-                    status = self.dlc_status_list[0]
-        if status == self.dlc_status_list[1]:
-            installed_version_dcit = json_list[1]
-            if dlc_title in installed_version_dcit:
-                installed_version = installed_version_dcit[dlc_title]
+        status = dlc_status_list[0]
+        if os.path.isfile(dlc_status_file_path):
+            dlc_staus_file = open(dlc_status_file_path, 'r')
+            json_list = json.load(dlc_staus_file)
+            dlc_status_dict = json_list[0]
+            dlc_staus_file.close()
+            if dlc_title in dlc_status_dict:
+                status = dlc_status_dict[dlc_title]
+        if status == dlc_status_list[1]:
+            installed_version_dict = json_list[1]
+            if dlc_title in installed_version_dict:
+                installed_version = installed_version_dict[dlc_title]
                 if available_version != installed_version:
-                    status = self.dlc_status_list[2]
+                    status = dlc_status_list[2]
         return status
 
-    def set_dlc_status(self, dlc_title, status, version):
-        self.read_installed_version()
-        if self.installed_version:
-            if os.path.isfile(self.dlc_status_file_path):
-                dlc_staus_file = open(self.dlc_status_file_path, 'r')
-                json_list = json.load(dlc_staus_file)
-                dlc_status_dict = json_list[0]
-                dlc_version = json_list[1]
-                dlc_staus_file.close()
-            else:
-                dlc_status_dict = {}
-                dlc_version = {}
-            for dlc in self.dlcs:
-                if dlc["title"] not in dlc_status_dict:
-                    dlc_status_dict[dlc["title"]] = self.dlc_status_list[0]
-            if status:
-                dlc_status_dict[dlc_title] = self.dlc_status_list[1]
-                dlc_version[dlc_title] = version
-            else:
-                dlc_status_dict[dlc_title] = self.dlc_status_list[0]
-            dlc_status_file = open(self.dlc_status_file_path, 'w')
-            json.dump([dlc_status_dict, dlc_version], dlc_status_file)
-            dlc_status_file.close()
+    def set_status(self, key, value, dlc_title=""):
+        json_dict = self.load_minigalaxy_info_json()
+        if dlc_title:
+            if "dlcs" not in json_dict:
+                json_dict["dlcs"] = {}
+            if dlc_title not in json_dict["dlcs"]:
+                json_dict["dlcs"][dlc_title] = {}
+            json_dict["dlcs"][dlc_title][key] = value
+        else:
+            json_dict[key] = value
+        self.save_minigalaxy_info_json(json_dict)
 
     def __str__(self):
         return self.name

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -310,7 +310,7 @@ class GameTile(Gtk.Box):
             GLib.idle_add(self.update_to_state, cancel_to_state)
 
     def __check_for_update_dlc(self):
-        if self.game.installed_version and self.game.id and not self.offline:
+        if self.game.is_installed() and self.game.id and not self.offline:
             game_version = self.api.get_version(self.game)
             update_available = self.game.is_update_available(game_version)
             if update_available:
@@ -434,7 +434,7 @@ class GameTile(Gtk.Box):
                               self.state.UPDATING, self.state.DOWNLOADING]
         if self.current_state in dont_act_in_states:
             return
-        if self.game.install_dir and os.path.exists(self.game.install_dir):
+        if self.game.is_installed():
             self.update_to_state(self.state.INSTALLED)
             check_update_thread = threading.Thread(target=self.__check_for_update_dlc())
             check_update_thread.start()

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -289,7 +289,7 @@ class GameTile(Gtk.Box):
         if not err_msg:
             GLib.idle_add(self.update_to_state, success_state)
             install_success = True
-            self.game.set_status("version", self.api.get_version(dlc_title), dlc_title)
+            self.game.set_status("version", self.api.get_version(self.game, dlc_name=dlc_title), dlc_title=dlc_title)
         else:
             self.parent.parent.show_error(_("Failed to install {}").format(self.game.name), err_msg)
             GLib.idle_add(self.update_to_state, failed_state)
@@ -311,11 +311,12 @@ class GameTile(Gtk.Box):
 
     def __check_for_update_dlc(self):
         if self.game.is_installed() and self.game.id and not self.offline:
-            game_version = self.api.get_version(self.game)
+            game_info = self.api.get_info(self.game)
+            game_version = self.api.get_version(self.game, gameinfo=game_info)
             update_available = self.game.is_update_available(game_version)
             if update_available:
                 self.update_to_state(self.state.UPDATABLE)
-            self.__check_for_dlc()
+            self.__check_for_dlc(game_info)
         if self.offline:
             self.menu_button_dlc.hide()
 
@@ -345,8 +346,7 @@ class GameTile(Gtk.Box):
             GLib.idle_add(self.update_to_state, self.state.INSTALLED)
         self.__check_for_update_dlc()
 
-    def __check_for_dlc(self):
-        game_info = self.api.get_info(self.game)
+    def __check_for_dlc(self, game_info):
         dlcs = game_info["expanded_dlcs"]
         for dlc in dlcs:
             if dlc["is_installable"] and dlc["id"] in self.parent.owned_products_ids:

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -270,7 +270,7 @@ class GameTile(Gtk.Box):
         if install_success:
             self.__check_for_dlc(self.api.get_info(self.game))
 
-    def __install(self, update=False):
+    def __install(self, update=False, dlc_title=""):
         keep_executable_path = self.get_keep_executable_path()
         if keep_executable_path:
             installer = keep_executable_path
@@ -289,6 +289,7 @@ class GameTile(Gtk.Box):
         if not err_msg:
             GLib.idle_add(self.update_to_state, success_state)
             install_success = True
+            self.game.set_status("version", self.api.get_version(dlc_title), dlc_title)
         else:
             self.parent.parent.show_error(_("Failed to install {}").format(self.game.name), err_msg)
             GLib.idle_add(self.update_to_state, failed_state)
@@ -310,12 +311,11 @@ class GameTile(Gtk.Box):
 
     def __check_for_update_dlc(self):
         if self.game.installed_version and self.game.id and not self.offline:
-            game_info = self.api.get_info(self.game)
-            installer = game_info["downloads"]["installers"]
-            update_available = not self.game.validate_if_installed_is_latest(installer)
+            game_version = self.api.get_version(self.game)
+            update_available = self.game.is_update_available(game_version)
             if update_available:
                 self.update_to_state(self.state.UPDATABLE)
-            self.__check_for_dlc(game_info)
+            self.__check_for_dlc()
         if self.offline:
             self.menu_button_dlc.hide()
 
@@ -328,40 +328,38 @@ class GameTile(Gtk.Box):
                 self.image.set_tooltip_text(self.game.name)
 
     def __download_dlc(self, dlc_installers) -> None:
-        download_info = self.api.get_download_info(self.game, dlc=True, dlc_installers=dlc_installers)
+        download_info = self.api.get_download_info(self.game, dlc_installers=dlc_installers)
         dlc_title = self.game.name
         for dlc in self.game.dlcs:
             if dlc["downloads"]["installers"] == dlc_installers:
                 dlc_title = dlc["title"]
-        finish_func = lambda: self.__install_dlc(dlc_title, download_info["version"])
+        finish_func = lambda: self.__install_dlc(dlc_title=dlc_title)
         cancel_to_state = self.state.INSTALLED
         result = self.__download(download_info, finish_func, cancel_to_state)
         if not result:
             GLib.idle_add(self.update_to_state, cancel_to_state)
 
-    def __install_dlc(self, dlc_title, dlc_version):
-        install_success = self.__install()
+    def __install_dlc(self, dlc_title):
+        install_success = self.__install(dlc_title=dlc_title)
         if not install_success:
             GLib.idle_add(self.update_to_state, self.state.INSTALLED)
-        self.game.set_dlc_status(dlc_title, install_success, dlc_version)
         self.__check_for_update_dlc()
 
-    def __check_for_dlc(self, game_info):
+    def __check_for_dlc(self):
+        game_info = self.api.get_info(self.game)
         dlcs = game_info["expanded_dlcs"]
         for dlc in dlcs:
             if dlc["is_installable"] and dlc["id"] in self.parent.owned_products_ids:
                 d_installer = dlc["downloads"]["installers"]
                 d_icon = dlc["images"]["sidebarIcon"]
                 d_name = dlc["title"]
-                download_info = self.api.get_download_info(self.game, dlc=True, dlc_installers=d_installer)
-                d_status = self.game.get_dlc_status(d_name, download_info["version"])
-                self.update_gtk_box_for_dlc(d_icon, d_name, d_status, d_installer)
+                self.update_gtk_box_for_dlc(d_icon, d_name, d_installer)
                 if dlc not in self.game.dlcs:
                     self.game.dlcs.append(dlc)
         if self.game.dlcs:
             self.menu_button_dlc.show()
 
-    def update_gtk_box_for_dlc(self, icon, title, status, installer):
+    def update_gtk_box_for_dlc(self, icon, title, installer):
         if title not in self.dlc_dict:
             dlc_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
             image = Gtk.Image()
@@ -376,10 +374,11 @@ class GameTile(Gtk.Box):
             self.dlc_horizontal_box.pack_start(dlc_box, False, True, 0)
             dlc_box.show_all()
             self.get_async_image_dlc_icon(icon, title)
-        if status.lower() == "installed":
+        download_info = self.api.get_download_info(self.game, dlc_installers=installer)
+        if self.game.is_installed(dlc_title=title):
             icon_name = "gtk-ok"
             self.dlc_dict[title][0].set_sensitive(False)
-        elif status.lower() == "updatable":
+        elif self.game.is_update_available(version_from_api=download_info["version"], dlc_title=title):
             icon_name = ICON_UPDATE_PATH
             self.dlc_dict[title][0].set_sensitive(True)
         else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,13 @@ sys.modules['minigalaxy.constants'] = m_constants
 sys.modules['minigalaxy.config'] = m_config
 from minigalaxy.api import Api
 
+API_GET_INFO_TOONSTRUCK = {'downloads': {'installers': [{'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]},
+                                    {'id': 'installer_mac_en', 'name': 'Toonstruck', 'os': 'mac', 'language': 'en', 'language_full': 'English', 'version': 'gog-3', 'total_size': 975175680, 'files': [{'id': 'en2installer0', 'size': 975175680, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en2installer0'}]},
+                                    {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]},
+                                    {'id': 'installer_windows_fr', 'name': 'Toonstruck', 'os': 'windows', 'language': 'fr', 'language_full': 'français', 'version': '1.0', 'total_size': 985661440, 'files': [{'id': 'fr1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer0'}, {'id': 'fr1installer1', 'size': 984612864, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer1'}]},
+                                    {'id': 'installer_mac_fr', 'name': 'Toonstruck', 'os': 'mac', 'language': 'fr', 'language_full': 'français', 'version': 'gog-3', 'total_size': 1023410176, 'files': [{'id': 'fr2installer0', 'size': 1023410176, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr2installer0'}]},
+                                    {'id': 'installer_linux_fr', 'name': 'Toonstruck', 'os': 'linux', 'language': 'fr', 'language_full': 'français', 'version': 'gog-2', 'total_size': 1011875840, 'files': [{'id': 'fr3installer0', 'size': 1011875840, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr3installer0'}]}]}}
+
 
 class TestApi(TestCase):
     def test_get_login_url(self):
@@ -40,12 +47,7 @@ class TestApi(TestCase):
     def test1_get_download_info(self):
         api = Api()
         api.get_info = MagicMock()
-        api.get_info.return_value = {'downloads': {'installers': [{'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]},
-                                    {'id': 'installer_mac_en', 'name': 'Toonstruck', 'os': 'mac', 'language': 'en', 'language_full': 'English', 'version': 'gog-3', 'total_size': 975175680, 'files': [{'id': 'en2installer0', 'size': 975175680, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en2installer0'}]},
-                                    {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]},
-                                    {'id': 'installer_windows_fr', 'name': 'Toonstruck', 'os': 'windows', 'language': 'fr', 'language_full': 'français', 'version': '1.0', 'total_size': 985661440, 'files': [{'id': 'fr1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer0'}, {'id': 'fr1installer1', 'size': 984612864, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer1'}]},
-                                    {'id': 'installer_mac_fr', 'name': 'Toonstruck', 'os': 'mac', 'language': 'fr', 'language_full': 'français', 'version': 'gog-3', 'total_size': 1023410176, 'files': [{'id': 'fr2installer0', 'size': 1023410176, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr2installer0'}]},
-                                    {'id': 'installer_linux_fr', 'name': 'Toonstruck', 'os': 'linux', 'language': 'fr', 'language_full': 'français', 'version': 'gog-2', 'total_size': 1011875840, 'files': [{'id': 'fr3installer0', 'size': 1011875840, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr3installer0'}]}]}}
+        api.get_info.return_value = API_GET_INFO_TOONSTRUCK
         m_config.Config.get.return_value = "pl"
         exp = {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]}
         obs = api.get_download_info("Test Game")
@@ -54,12 +56,7 @@ class TestApi(TestCase):
     def test2_get_download_info(self):
         api = Api()
         api.get_info = MagicMock()
-        api.get_info.return_value = {'downloads': {'installers': [{'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]},
-                                    {'id': 'installer_mac_en', 'name': 'Toonstruck', 'os': 'mac', 'language': 'en', 'language_full': 'English', 'version': 'gog-3', 'total_size': 975175680, 'files': [{'id': 'en2installer0', 'size': 975175680, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en2installer0'}]},
-                                    {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]},
-                                    {'id': 'installer_windows_fr', 'name': 'Toonstruck', 'os': 'windows', 'language': 'fr', 'language_full': 'français', 'version': '1.0', 'total_size': 985661440, 'files': [{'id': 'fr1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer0'}, {'id': 'fr1installer1', 'size': 984612864, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer1'}]},
-                                    {'id': 'installer_mac_fr', 'name': 'Toonstruck', 'os': 'mac', 'language': 'fr', 'language_full': 'français', 'version': 'gog-3', 'total_size': 1023410176, 'files': [{'id': 'fr2installer0', 'size': 1023410176, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr2installer0'}]},
-                                    {'id': 'installer_linux_fr', 'name': 'Toonstruck', 'os': 'linux', 'language': 'fr', 'language_full': 'français', 'version': 'gog-2', 'total_size': 1011875840, 'files': [{'id': 'fr3installer0', 'size': 1011875840, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr3installer0'}]}]}}
+        api.get_info.return_value = API_GET_INFO_TOONSTRUCK
         m_config.Config.get.return_value = "fr"
         exp = {'id': 'installer_linux_fr', 'name': 'Toonstruck', 'os': 'linux', 'language': 'fr', 'language_full': 'français', 'version': 'gog-2', 'total_size': 1011875840, 'files': [{'id': 'fr3installer0', 'size': 1011875840, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr3installer0'}]}
         obs = api.get_download_info("Test Game")
@@ -79,15 +76,10 @@ class TestApi(TestCase):
 
     def test4_get_download_info(self):
         api = Api()
-        dlc_test_installer = [{'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]},
-                                    {'id': 'installer_mac_en', 'name': 'Toonstruck', 'os': 'mac', 'language': 'en', 'language_full': 'English', 'version': 'gog-3', 'total_size': 975175680, 'files': [{'id': 'en2installer0', 'size': 975175680, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en2installer0'}]},
-                                    {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]},
-                                    {'id': 'installer_windows_fr', 'name': 'Toonstruck', 'os': 'windows', 'language': 'fr', 'language_full': 'français', 'version': '1.0', 'total_size': 985661440, 'files': [{'id': 'fr1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer0'}, {'id': 'fr1installer1', 'size': 984612864, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer1'}]},
-                                    {'id': 'installer_mac_fr', 'name': 'Toonstruck', 'os': 'mac', 'language': 'fr', 'language_full': 'français', 'version': 'gog-3', 'total_size': 1023410176, 'files': [{'id': 'fr2installer0', 'size': 1023410176, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr2installer0'}]},
-                                    {'id': 'installer_linux_fr', 'name': 'Toonstruck', 'os': 'linux', 'language': 'fr', 'language_full': 'français', 'version': 'gog-2', 'total_size': 1011875840, 'files': [{'id': 'fr3installer0', 'size': 1011875840, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr3installer0'}]}]
+        dlc_test_installer = API_GET_INFO_TOONSTRUCK["downloads"]["installers"]
         m_config.Config.get.return_value = "en"
         exp = {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]}
-        obs = api.get_download_info("Test Game", dlc=True, dlc_installers=dlc_test_installer)
+        obs = api.get_download_info("Test Game", dlc_installers=dlc_test_installer)
         self.assertEqual(exp, obs)
 
     def test1_get_library(self):
@@ -100,6 +92,25 @@ class TestApi(TestCase):
         m_constants.SESSION.get.return_value = response_mock
         exp = "Neverwinter Nights: Enhanced Edition"
         obs = api.get_library()[0].name
+        self.assertEqual(exp, obs)
+
+    def test1_get_version(self):
+        api = Api()
+        game = MagicMock()
+        game.platform = "linux"
+        exp = "gog-2"
+        obs = api.get_version(game, gameinfo=API_GET_INFO_TOONSTRUCK)
+        self.assertEqual(exp, obs)
+
+    def test2_get_version(self):
+        api = Api()
+        game = MagicMock()
+        game.platform = "linux"
+        dlc_name = "Test DLC"
+        game_info = API_GET_INFO_TOONSTRUCK
+        game_info["expanded_dlcs"] = [{"title": dlc_name, "downloads": {"installers": [{"os": "linux", "version": "1.2.3.4"}]}}]
+        exp = "1.2.3.4"
+        obs = api.get_version(game, gameinfo=API_GET_INFO_TOONSTRUCK, dlc_name=dlc_name)
         self.assertEqual(exp, obs)
 
 


### PR DESCRIPTION
This pull request is to address issue #207

The idea is as follows:
After game installation we will create minigalaxy-info.json file in game directory. This file will store game version (from Api) and DLC versions. It can also be used in future to store more data about Game.
If file is present minigalaxy will use it to check if update is available. If file is not present, minigalaxy will fall back to checking gameinfo file.
As it goes to DLCs. We keep compatibility with previous system. If DLC version cannot be determined from minigalaxy-info.json, we will also check minigalaxy-dlc.json. If DLC is present in both files, only minigalaxy-info.json is taken into account.
![dlc_backord](https://user-images.githubusercontent.com/1833284/102698692-97146080-423f-11eb-9c07-5be386438ba9.png)


This method is applied on all new games, dlcs installation, but backward compatibility is preserved.

I also hope, that code is now more clean and understandable.

Unit tests are adapted to this change and their range is expanded.