### PR TITLE
GtkModelButton replaced by GtkButton for aesthetic.

### DIFF
--- a/data/ui/gametile.ui
+++ b/data/ui/gametile.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.38.2 -->
 <interface domain="minigalaxy">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkPopover" id="dlc_popover">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkBox" id="dlc_horizontal_box">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <placeholder/>
@@ -15,20 +15,21 @@
       </object>
     </child>
   </object>
-  <object class="GtkPopover" id="menu">
-    <property name="can_focus">False</property>
+  <object class="GtkPopover" id="options_popover">
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkModelButton" id="menu_button_store">
+          <object class="GtkButton" id="menu_button_open">
+            <property name="label" translatable="yes" context="open_files" comments="Opens the directory the game is installed in">Open Files</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes" context="store" comments="Open store page">Store Page</property>
-            <signal name="clicked" handler="on_menu_button_store_clicked" swapped="no"/>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_menu_button_open_clicked" swapped="no"/>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -37,12 +38,13 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton" id="menu_button_support">
+          <object class="GtkButton" id="menu_button_settings">
+            <property name="label" translatable="yes" context="Wine Settings" comments="Open winecfg settings for Windows games">Settings</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes" context="support" comments="Opens the official support webpage">Support</property>
-            <signal name="clicked" handler="on_menu_button_support_clicked" swapped="no"/>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_menu_button_settings_clicked" swapped="no"/>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -51,12 +53,13 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton" id="menu_button_open">
+          <object class="GtkButton" id="menu_button_update">
+            <property name="label" translatable="yes" context="update" comments="Updates game">Update</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes" context="open_files" comments="Opens the directory the game is installed in">Open Files</property>
-            <signal name="clicked" handler="on_menu_button_open_clicked" swapped="no"/>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_menu_button_update_clicked" swapped="no"/>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -65,12 +68,13 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton" id="menu_button_settings">
+          <object class="GtkButton" id="menu_button_uninstall">
+            <property name="label" translatable="yes" context="uninstall" comments="Removes the game files from the local machine">Uninstall</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes" context="Wine Settings" comments="Open winecfg settings for Windows games">Settings</property>
-            <signal name="clicked" handler="on_menu_button_settings_clicked" swapped="no"/>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_menu_button_uninstall_clicked" swapped="no"/>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -79,12 +83,22 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton" id="menu_button_update">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes" context="update" comments="Updates game">Update</property>
-            <signal name="clicked" handler="on_menu_button_update_clicked" swapped="no"/>
+          <object class="GtkMenuButton" id="menu_button_dlc">
+            <property name="can-focus">True</property>
+            <property name="focus-on-click">False</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <property name="direction">right</property>
+            <property name="popover">dlc_popover</property>
+            <child>
+              <object class="GtkButton">
+                <property name="label" translatable="yes">DLC</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="relief">none</property>
+              </object>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -93,49 +107,80 @@
           </packing>
         </child>
         <child>
-          <object class="GtkMenuButton" id="menu_button_dlc">
-            <property name="can_focus">True</property>
-            <property name="focus_on_click">False</property>
-            <property name="receives_default">True</property>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkPopover" id="menu">
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkButton" id="menu_button_store">
+            <property name="label" translatable="yes" context="store" comments="Open store page">Store Page</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_menu_button_store_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="menu_button_support">
+            <property name="label" translatable="yes" context="support" comments="Opens the official support webpage">Support</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="on_menu_button_support_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkMenuButton" id="menu_button_options">
+            <property name="can-focus">True</property>
+            <property name="focus-on-click">False</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
             <property name="direction">right</property>
-            <property name="popover">dlc_popover</property>
+            <property name="popover">options_popover</property>
             <child>
-              <object class="GtkModelButton">
+              <object class="GtkButton">
+                <property name="label" translatable="yes">Options</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
                 <property name="hexpand">False</property>
-                <property name="text" translatable="yes">DLC</property>
+                <property name="relief">none</property>
               </object>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="menu_button_uninstall">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes" context="uninstall" comments="Removes the game files from the local machine">Uninstall</property>
-            <signal name="clicked" handler="on_menu_button_uninstall_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">6</property>
+            <property name="position">7</property>
           </packing>
         </child>
       </object>
     </child>
   </object>
   <template class="GameTile" parent="GtkBox">
-    <property name="width_request">196</property>
+    <property name="width-request">196</property>
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="halign">start</property>
     <property name="valign">start</property>
     <property name="hexpand">False</property>
@@ -144,40 +189,40 @@
     <child>
       <object class="GtkOverlay">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="GtkImage" id="image">
-            <property name="width_request">196</property>
-            <property name="height_request">110</property>
+            <property name="width-request">196</property>
+            <property name="height-request">110</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="icon_name">dialog-warning-symbolic</property>
+            <property name="can-focus">False</property>
+            <property name="icon-name">dialog-warning-symbolic</property>
             <property name="icon_size">0</property>
           </object>
           <packing>
-            <property name="pass_through">True</property>
+            <property name="pass-through">True</property>
             <property name="index">-1</property>
           </packing>
         </child>
         <child type="overlay">
           <object class="GtkMenuButton" id="menu_button">
-            <property name="can_focus">True</property>
-            <property name="has_focus">True</property>
-            <property name="focus_on_click">False</property>
-            <property name="receives_default">True</property>
-            <property name="no_show_all">True</property>
+            <property name="can-focus">True</property>
+            <property name="has-focus">True</property>
+            <property name="focus-on-click">False</property>
+            <property name="receives-default">True</property>
+            <property name="no-show-all">True</property>
             <property name="halign">end</property>
             <property name="valign">start</property>
             <property name="relief">none</property>
-            <property name="use_popover">False</property>
+            <property name="use-popover">False</property>
             <property name="popover">menu</property>
             <child>
               <object class="GtkImage" id="menu_icon">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="icon_name">applications-system-symbolic</property>
+                <property name="icon-name">applications-system-symbolic</property>
                 <property name="icon_size">3</property>
               </object>
             </child>
@@ -188,11 +233,11 @@
         </child>
         <child type="overlay">
           <object class="GtkButton" id="button_cancel">
-            <property name="can_focus">True</property>
-            <property name="has_focus">True</property>
-            <property name="focus_on_click">False</property>
-            <property name="receives_default">True</property>
-            <property name="no_show_all">True</property>
+            <property name="can-focus">True</property>
+            <property name="has-focus">True</property>
+            <property name="focus-on-click">False</property>
+            <property name="receives-default">True</property>
+            <property name="no-show-all">True</property>
             <property name="halign">end</property>
             <property name="valign">start</property>
             <property name="relief">none</property>
@@ -200,7 +245,7 @@
             <child>
               <object class="GtkImage" id="cancel_icon">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="stock">gtk-cancel</property>
               </object>
             </child>
@@ -211,11 +256,11 @@
         </child>
         <child type="overlay">
           <object class="GtkImage" id="wine_icon">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="halign">start</property>
             <property name="valign">start</property>
-            <property name="margin_start">2</property>
-            <property name="margin_top">2</property>
+            <property name="margin-start">2</property>
+            <property name="margin-top">2</property>
           </object>
           <packing>
             <property name="index">2</property>
@@ -223,11 +268,11 @@
         </child>
         <child type="overlay">
           <object class="GtkImage" id="update_icon">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="halign">start</property>
             <property name="valign">start</property>
-            <property name="margin_start">2</property>
-            <property name="margin_top">2</property>
+            <property name="margin-start">2</property>
+            <property name="margin-top">2</property>
           </object>
           <packing>
             <property name="index">3</property>
@@ -242,10 +287,10 @@
     </child>
     <child>
       <object class="GtkButton" id="button">
-        <property name="width_request">196</property>
+        <property name="width-request">196</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
         <property name="halign">center</property>
         <property name="valign">end</property>
         <signal name="clicked" handler="on_button_clicked" swapped="no"/>
@@ -256,7 +301,7 @@
       <packing>
         <property name="expand">False</property>
         <property name="fill">False</property>
-        <property name="pack_type">end</property>
+        <property name="pack-type">end</property>
         <property name="position">1</property>
       </packing>
     </child>

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -39,6 +39,7 @@ class GameTile(Gtk.Box):
     menu_button_update = Gtk.Template.Child()
     menu_button_dlc = Gtk.Template.Child()
     dlc_horizontal_box = Gtk.Template.Child()
+    menu_button_options = Gtk.Template.Child()
 
     state = Enum('state',
                  'DOWNLOADABLE INSTALLABLE UPDATABLE QUEUED DOWNLOADING INSTALLING INSTALLED NOTLAUNCHABLE UNINSTALLING'
@@ -508,6 +509,7 @@ class GameTile(Gtk.Box):
             self.image.set_sensitive(True)
             self.menu_button.show()
             self.button_cancel.hide()
+            self.menu_button_options.show()
             self.game.install_dir = self.__get_install_dir()
 
             if self.game.platform == "linux":


### PR DESCRIPTION
Hello,
This commit is for aesthetic. As you can see the buttons are "ugly" currently when you use MiniGalaxy. Especially with "DLC" button and the others. I reorganized the menu, "DLC / Uninstall / Update / Settings / Open Files" are now in "Options"

Before : 
![Before](https://user-images.githubusercontent.com/3606036/102882058-18414280-444e-11eb-94ef-658bcdfa943a.png)

After : 
![After](https://user-images.githubusercontent.com/3606036/102882078-21caaa80-444e-11eb-80c6-79b67f1cd0e9.png)


