### PR TITLE
Fix 226

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -19,8 +19,10 @@ def install_game(game, installer):
         error_message = move_and_overwrite(game, tmp_dir, game.install_dir)
     if not error_message:
         error_message = copy_thumbnail(game)
-    error_message2 = remove_installer(installer)
-    error_message = error_message2 if not error_message else error_message
+    if not error_message:
+        error_message = remove_installer(installer)
+    else:
+        remove_installer(installer)
     if error_message:
         print(error_message)
     return error_message

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -19,8 +19,8 @@ def install_game(game, installer):
         error_message = move_and_overwrite(game, tmp_dir, game.install_dir)
     if not error_message:
         error_message = copy_thumbnail(game)
-    if not error_message:
-        error_message = remove_installer(installer)
+    error_message2 = remove_installer(installer)
+    error_message = error_message2 if not error_message else error_message
     if error_message:
         print(error_message)
     return error_message

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -291,7 +291,7 @@ class GameTile(Gtk.Box):
             install_success = True
             self.game.set_status("version", self.api.get_version(self.game, dlc_name=dlc_title), dlc_title=dlc_title)
         else:
-            self.parent.parent.show_error(_("Failed to install {}").format(self.game.name), err_msg)
+            GLib.idle_add(self.parent.parent.show_error, _("Failed to install {}").format(self.game.name), err_msg)
             GLib.idle_add(self.update_to_state, failed_state)
             install_success = False
         return install_success

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -142,7 +142,8 @@ class GameTile(Gtk.Box):
 
     @Gtk.Template.Callback("on_menu_button_open_clicked")
     def on_menu_button_open_files(self, widget):
-        subprocess.call(["xdg-open", self.__get_install_dir()])
+        self.__set_install_dir()
+        subprocess.call(["xdg-open", self.game.install_dir])
 
     @Gtk.Template.Callback("on_menu_button_support_clicked")
     def on_menu_button_support(self, widget):
@@ -178,7 +179,8 @@ class GameTile(Gtk.Box):
         return True
 
     def __set_image(self):
-        thumbnail_install_dir = os.path.join(self.__get_install_dir(), "thumbnail.jpg")
+        self.__set_install_dir()
+        thumbnail_install_dir = os.path.join(self.game.install_dir, "thumbnail.jpg")
         thumbnail_cache_dir = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
         if os.path.isfile(thumbnail_install_dir):
             GLib.idle_add(self.image.set_from_file, thumbnail_install_dir)
@@ -265,7 +267,7 @@ class GameTile(Gtk.Box):
         return download_success
 
     def __install_game(self):
-        self.game.install_dir = self.__get_install_dir()
+        self.__set_install_dir()
         install_success = self.__install()
         if install_success:
             self.__check_for_dlc(self.api.get_info(self.game))
@@ -423,13 +425,13 @@ class GameTile(Gtk.Box):
         self.set_center_widget(self.progress_bar)
         self.progress_bar.set_fraction(0.0)
 
-    def __get_install_dir(self):
-        if self.game.install_dir:
-            return self.game.install_dir
-        return os.path.join(Config.get("install_dir"), self.game.get_install_directory_name())
+    def __set_install_dir(self):
+        if not self.game.install_dir:
+            self.game.install_dir = os.path.join(Config.get("install_dir"), self.game.get_install_directory_name())
+            self.game.status_file_path = os.path.join(self.game.install_dir, self.game.status_file_name)
 
     def reload_state(self):
-        self.game.install_dir = self.__get_install_dir()
+        self.__set_install_dir()
         dont_act_in_states = [self.state.QUEUED, self.state.DOWNLOADING, self.state.INSTALLING, self.state.UNINSTALLING,
                               self.state.UPDATING, self.state.DOWNLOADING]
         if self.current_state in dont_act_in_states:
@@ -494,7 +496,7 @@ class GameTile(Gtk.Box):
             self.menu_button.hide()
             self.button_cancel.hide()
 
-            self.game.install_dir = self.__get_install_dir()
+            self.__set_install_dir()
 
             if self.progress_bar:
                 self.progress_bar.destroy()
@@ -508,7 +510,7 @@ class GameTile(Gtk.Box):
             self.image.set_sensitive(True)
             self.menu_button.show()
             self.button_cancel.hide()
-            self.game.install_dir = self.__get_install_dir()
+            self.__set_install_dir()
 
             if self.game.platform == "linux":
                 self.menu_button_settings.hide()


### PR DESCRIPTION
So, I did some research about #226 
It seams that if I manually corrupt installer it still reports:
```
Verifying archive integrity... MD5 checksums are OK. All good.
```
So it seems that this check is just for show?

Exception from issue is already addressed since:
https://github.com/sharkwouter/minigalaxy/commit/543bd9696f138f754faf540be4bfd8e069436eed
But we ended up in calling MessageDialog in non thread safe way, which crashes minigalaxy.
- This issue is addressed in this pull request
- I also altered installer to make sure, that damaged installer is removed after failed installation
- And finally we need to make sure that game.install_dir is always updated together with game.status_file_path to be sure that minigalaxy-info.json is in the same dir as game.

That said, I still don't know why corrupted installer is downloaded in #226 

In order to check this this pull request:
- Make sure that Beneath a Steel Sky is uninstalled
- Download Beneath a Steel Sky installer manually
- Corrupt installer
- Put it in "~/.cache/minigalaxy/download/Beneath a Steel Sky/"
- Try to install Beneath a Steel Sky