### PR TITLE
Allow to download Windows/Linux version if available (Linux games only)

### DIFF
--- a/data/ui/os_version.ui
+++ b/data/ui/os_version.ui
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <template class="OS_Version" parent="GtkDialog">
+    <property name="can-focus">False</property>
+    <property name="type-hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="button_os_version_linux">
+                <property name="label" translatable="yes">Linux</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="on_button_os_version_linux_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_os_version_windows">
+                <property name="label" translatable="yes">Windows</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="on_button_os_version_windows_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Linux and Windows are available for this game.
+Which version do you want to install ?</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -145,7 +145,7 @@ class Api:
                 possible_downloads.append(installer)
         if not possible_downloads:
             if operating_system == "linux":
-                return self.get_download_info(game, "windows")
+                return self.get_download_info(game)
             else:
                 raise NoDownloadLinkFound("Error: {} with id {} couldn't be installed".format(game.name, game.id))
 

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -132,7 +132,8 @@ class Api:
         return response
 
     # This returns a unique download url and a link to the checksum of the download
-    def get_download_info(self, game: Game, operating_system="linux", dlc_installers="") -> tuple:
+    def get_download_info(self, game: Game, dlc_installers="") -> tuple:
+        operating_system = Config.get("OS_Version")
         if dlc_installers:
             installers = dlc_installers
         else:
@@ -217,3 +218,11 @@ class Api:
             print("Response body: {}".format(response.text))
             print("")
         return response.json()
+
+    # Get os version version for which game
+    def get_os_game(self,game):
+        response = self.get_info(game)
+        installers = response["downloads"]["installers"]
+        for installer in installers:
+            game_os = installer["os"]
+        return game_os

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -33,7 +33,8 @@ DEFAULT_CONFIGURATION = {
     "keep_installers": False,
     "stay_logged_in": True,
     "show_fps": False,
-    "show_windows_games": False
+    "show_windows_games": False,
+    "OS_Version": "linux"
 }
 
 # Game IDs to ignore when received by the API

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -31,7 +31,7 @@ def verify_installer_integrity(game, installer):
     if not os.path.exists(installer):
         error_message = _("{} failed to download.").format(installer)
     if not error_message:
-        if game.platform == "linux":
+        if game.platform == "linux" and Config.get("OS_Version") == "linux":
             try:
                 print("Executing integrity check for {}".format(installer))
                 os.chmod(installer, 0o744)
@@ -60,7 +60,7 @@ def make_tmp_dir(game):
 def extract_installer(game, installer, temp_dir):
     # Extract the installer
     error_message = ""
-    if game.platform == "linux":
+    if game.platform == "linux" and Config.get("OS_Version") == "linux":
         command = ["unzip", "-qq", installer, "-d", temp_dir]
     else:
         # Set the prefix for Windows games
@@ -69,7 +69,7 @@ def extract_installer(game, installer, temp_dir):
             os.makedirs(prefix_dir, mode=0o755)
 
         # It's possible to set install dir as argument before installation
-        command = ["WINEPREFIX={}".format(prefix_dir), "wine", installer, "/dir={}".format(temp_dir)]
+        command = ["env", "WINEPREFIX={}".format(prefix_dir), "wine", installer, "/dir={}".format(temp_dir)]
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     process.wait()
     stdout, stderr = process.communicate()
@@ -86,7 +86,7 @@ def extract_installer(game, installer, temp_dir):
 def move_and_overwrite(game, temp_dir, target_dir):
     # Copy the game files into the correct directory
     error_message = ""
-    if game.platform == "linux":
+    if game.platform == "linux" and Config.get("OS_Version") == "linux":
         source_dir = os.path.join(temp_dir, "data/noarch")
     else:
         source_dir = temp_dir

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -69,7 +69,7 @@ def extract_installer(game, installer, temp_dir):
             os.makedirs(prefix_dir, mode=0o755)
 
         # It's possible to set install dir as argument before installation
-        command = ["env", "WINEPREFIX={}".format(prefix_dir), "wine", installer, "/dir={}".format(temp_dir)]
+        command = ["WINEPREFIX={}".format(prefix_dir), "wine", installer, "/dir={}".format(temp_dir)]
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     process.wait()
     stdout, stderr = process.communicate()

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -21,6 +21,7 @@ from minigalaxy.css import CSS_PROVIDER
 from minigalaxy.paths import ICON_WINE_PATH
 from minigalaxy.paths import ICON_UPDATE_PATH
 from minigalaxy.api import NoDownloadLinkFound
+from minigalaxy.ui.os_version import OS_Version
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "gametile.ui"))
@@ -114,6 +115,7 @@ class GameTile(Gtk.Box):
             install_thread = threading.Thread(target=self.__install_game)
             install_thread.start()
         elif self.current_state == self.state.DOWNLOADABLE:
+            self.available_version()
             download_thread = threading.Thread(target=self.__download_game)
             download_thread.start()
         if err_msg:
@@ -162,6 +164,19 @@ class GameTile(Gtk.Box):
     def on_menu_button_update(self, widget):
         download_thread = threading.Thread(target=self.__download_update)
         download_thread.start()
+
+    def __show_os_version(self):
+        os_version_window = OS_Version(self)
+        os_version_window.run()
+        os_version_window.destroy()
+
+    def available_version(self):
+        os_version = self.api.get_os_game(self.game)
+        if Config.get("show_windows_games") == True:
+            if os_version == "linux":
+                self.__show_os_version()
+            else:
+                Config.set("OS_Version", "windows")
 
     def load_thumbnail(self):
         if self.__set_image():

--- a/minigalaxy/ui/os_version.py
+++ b/minigalaxy/ui/os_version.py
@@ -1,0 +1,28 @@
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+import os
+from minigalaxy.translation import _
+from minigalaxy.paths import UI_DIR
+from minigalaxy.config import Config
+
+@Gtk.Template.from_file(os.path.join(UI_DIR, "os_version.ui"))
+class OS_Version(Gtk.Dialog):
+    __gtype_name__ = "OS_Version"
+
+    button_os_version_linux = Gtk.Template.Child()
+    button_os_version_windows = Gtk.Template.Child()
+
+    def __init__(self, parent):
+        Gtk.Dialog.__init__(self, title=_("OS Version available"), modal=True)
+        self.parent = parent
+
+    @Gtk.Template.Callback("on_button_os_version_linux_clicked")
+    def os_version_linux(self, widget):
+        Config.set("OS_Version", "linux")
+        self.destroy()
+
+    @Gtk.Template.Callback("on_button_os_version_windows_clicked")
+    def os_version_windows(self, widget):
+        Config.set("OS_Version", "windows")
+        self.destroy()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ m_config = MagicMock()
 sys.modules['minigalaxy.constants'] = m_constants
 sys.modules['minigalaxy.config'] = m_config
 from minigalaxy.api import Api
+from minigalaxy.game import Game
 
 API_GET_INFO_TOONSTRUCK = {'downloads': {'installers': [{'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]},
                                     {'id': 'installer_mac_en', 'name': 'Toonstruck', 'os': 'mac', 'language': 'en', 'language_full': 'English', 'version': 'gog-3', 'total_size': 975175680, 'files': [{'id': 'en2installer0', 'size': 975175680, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en2installer0'}]},
@@ -50,7 +51,8 @@ class TestApi(TestCase):
         api.get_info.return_value = API_GET_INFO_TOONSTRUCK
         m_config.Config.get.return_value = "pl"
         exp = {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]}
-        obs = api.get_download_info("Test Game")
+        test_game = Game("Test Game")
+        obs = api.get_download_info(test_game)
         self.assertEqual(exp, obs)
 
     def test2_get_download_info(self):
@@ -59,7 +61,8 @@ class TestApi(TestCase):
         api.get_info.return_value = API_GET_INFO_TOONSTRUCK
         m_config.Config.get.return_value = "fr"
         exp = {'id': 'installer_linux_fr', 'name': 'Toonstruck', 'os': 'linux', 'language': 'fr', 'language_full': 'français', 'version': 'gog-2', 'total_size': 1011875840, 'files': [{'id': 'fr3installer0', 'size': 1011875840, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr3installer0'}]}
-        obs = api.get_download_info("Test Game")
+        test_game = Game("Test Game")
+        obs = api.get_download_info(test_game)
         self.assertEqual(exp, obs)
     
     def test3_get_download_info(self):
@@ -69,15 +72,16 @@ class TestApi(TestCase):
                                     {'id': 'installer_mac_en', 'name': 'Toonstruck', 'os': 'mac', 'language': 'en', 'language_full': 'English', 'version': 'gog-3', 'total_size': 975175680, 'files': [{'id': 'en2installer0', 'size': 975175680, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en2installer0'}]},
                                     {'id': 'installer_windows_fr', 'name': 'Toonstruck', 'os': 'windows', 'language': 'fr', 'language_full': 'français', 'version': '1.0', 'total_size': 985661440, 'files': [{'id': 'fr1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer0'}, {'id': 'fr1installer1', 'size': 984612864, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer1'}]},
                                     {'id': 'installer_mac_fr', 'name': 'Toonstruck', 'os': 'mac', 'language': 'fr', 'language_full': 'français', 'version': 'gog-3', 'total_size': 1023410176, 'files': [{'id': 'fr2installer0', 'size': 1023410176, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr2installer0'}]}]}}
-        m_config.Config.get.return_value = "en"
+        m_config.Config.get.side_effect = ["linux", "en"]
         exp = {'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]}
-        obs = api.get_download_info("Test Game")
+        test_game = Game("Test Game")
+        obs = api.get_download_info(test_game)
         self.assertEqual(exp, obs)
 
     def test4_get_download_info(self):
         api = Api()
         dlc_test_installer = API_GET_INFO_TOONSTRUCK["downloads"]["installers"]
-        m_config.Config.get.return_value = "en"
+        m_config.Config.get.side_effect = ["linux", "en"]
         exp = {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]}
         obs = api.get_download_info("Test Game", dlc_installers=dlc_test_installer)
         self.assertEqual(exp, obs)


### PR DESCRIPTION
Hello,

I did this implementation to choose between Linux and Windows for a game when it's available.
Each Linux game has a Windows version and sometimes, the Windows version is better than the Linux version.

Example :

- The Witcher 2 has a bad OpenGL port on Linux and works better with Wine/DXVK with Windows version.
- Graveyard Keeper has a mouse bug issue (never fixed) and not the Windows version. And the performance are better with DXVK too.

I'm not too familiar with Python so maybe there is a better approach. But it works at this moment.

Thanks for your reviews.