### PR TITLE
Simplify keeping installers

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -19,10 +19,10 @@ def install_game(game, installer):
         error_message = move_and_overwrite(game, tmp_dir, game.install_dir)
     if not error_message:
         error_message = copy_thumbnail(game)
-
-    if not Config.get("keep_installers"):
+    if not error_message:
+        error_message = remove_installer(installer)
+    else:
         remove_installer(installer)
-
     if error_message:
         print(error_message)
     return error_message
@@ -122,8 +122,14 @@ def copy_thumbnail(game):
 
 
 def remove_installer(installer):
-    directory = os.path.dirname(installer)
-    shutil.rmtree(directory, ignore_errors=True)
+    error_message = ""
+    if not Config.get("keep_installers"):
+        installer_directory = os.path.dirname(installer)
+        if os.path.isdir(installer_directory):
+            shutil.rmtree(installer_directory, ignore_errors=True)
+        else:
+            error_message = "No installer directory is present: {}".format(installer_directory)
+    return error_message
 
 
 def uninstall_game(game):

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -19,10 +19,10 @@ def install_game(game, installer):
         error_message = move_and_overwrite(game, tmp_dir, game.install_dir)
     if not error_message:
         error_message = copy_thumbnail(game)
-    if not error_message:
-        error_message = remove_installer(installer)
-    else:
+
+    if not Config.get("keep_installers"):
         remove_installer(installer)
+
     if error_message:
         print(error_message)
     return error_message
@@ -122,21 +122,8 @@ def copy_thumbnail(game):
 
 
 def remove_installer(installer):
-    error_message = ""
-    if Config.get("keep_installers"):
-        keep_dir = os.path.join(Config.get("install_dir"), "installer")
-        download_dir = os.path.join(CACHE_DIR, "download")
-        if not os.path.exists(keep_dir):
-            os.makedirs(keep_dir, mode=0o755)
-        try:
-            # It's needed for multiple files
-            for file in os.listdir(download_dir):
-                shutil.move(download_dir + '/' + file, keep_dir + '/' + file)
-        except Exception as ex:
-            print("Encountered error while copying {} to {}. Got error: {}".format(installer, keep_dir, ex))
-    elif os.path.exists(installer):
-        os.remove(installer)
-    return error_message
+    directory = os.path.dirname(installer)
+    shutil.rmtree(directory, ignore_errors=True)
 
 
 def uninstall_game(game):


### PR DESCRIPTION
This fixes issue #245 and it simplifies the removal process of
installers. It does, however, change the location in which the
installers are stored, which some people will not like.

To summarize this PR:

- Makes remove_installer always remove all installer files.
- Makes sure kept installers are never redownloaded.
- Changes the location of kept installers to ``~/.cache./minigalaxy/download``.
- Simplifies the code for keeping the installer after installation.