### PR TITLE
Change icons from default Gtk icon theme to Adwaita symbolic.

### DIFF
--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -368,7 +368,7 @@ class GameTile(Gtk.Box):
         if title not in self.dlc_dict:
             dlc_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
             image = Gtk.Image()
-            image.set_from_icon_name("gtk-cdrom", 1)
+            image.set_from_icon_name("media-optical-symbolic.symbolic", 1)
             dlc_box.pack_start(image, False, True, 0)
             label = Gtk.Label(label=title, xalign=0)
             dlc_box.pack_start(label, True, True, 0)
@@ -381,13 +381,13 @@ class GameTile(Gtk.Box):
             self.get_async_image_dlc_icon(icon, title)
         download_info = self.api.get_download_info(self.game, dlc_installers=installer)
         if self.game.is_installed(dlc_title=title):
-            icon_name = "gtk-ok"
+            icon_name = "emblem-default-symbolic.symbolic"
             self.dlc_dict[title][0].set_sensitive(False)
         elif self.game.is_update_available(version_from_api=download_info["version"], dlc_title=title):
             icon_name = ICON_UPDATE_PATH
             self.dlc_dict[title][0].set_sensitive(True)
         else:
-            icon_name = "gtk-goto-bottom"
+            icon_name = "go-bottom-symbolic.symbolic"
             self.dlc_dict[title][0].set_sensitive(True)
         install_button_image = Gtk.Image()
         if icon_name in [ICON_UPDATE_PATH]:


### PR DESCRIPTION
On my system:
Gtk icon theme (current):
![icons_before](https://user-images.githubusercontent.com/1833284/104055344-e9b5bc80-51ee-11eb-80cd-3dccd17f25dd.png)
Adwaita full color:
![icons_non_symbolic](https://user-images.githubusercontent.com/1833284/104055433-15d13d80-51ef-11eb-8fb0-31d497a4a6cd.png)
Adwaita symbolic:
![icons_symbolic](https://user-images.githubusercontent.com/1833284/104055459-22559600-51ef-11eb-8531-6ea24470edcc.png)

As pointed in #251 Debian does not come with Gtk icon theme, so our best solution is to switch to Adwaita.
I consider this pull request as important one as mentioned issue is blocker from our side to be incorporated into Debian repository (and as a result to Ubuntu, Mint, etc.).
I consider this pull request as having little regression risk.

As it goes to icons themselves I consider full color to be prettier, but was prompted that they are going to be legacy so symbolic is more future proof choice.
I am also a little bit confused about using symbolic icon. If I use icon-name-symbolic I got full color instead. To get symbolic I need to use icon-name-symbolic.symbolic. Is this a right approach?

Please let me know if you consider that some icons could be better chosen.
Best regards,