### PR TITLE
Icons part 2

### DIFF
--- a/data/images/dialog-apply.svg
+++ b/data/images/dialog-apply.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg2841" width="22" height="22" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs2843">
+  <radialGradient id="radialGradient4811" cx="11.25" cy="19.031" r="8.0625" gradientTransform="matrix(1 0 0 .28295 0 13.646)" gradientUnits="userSpaceOnUse">
+   <stop id="stop2487" style="stop-color:#0d0d0d" offset="0"/>
+   <stop id="stop2489" style="stop-color:#0d0d0d;stop-opacity:0" offset="1"/>
+  </radialGradient>
+  <linearGradient id="linearGradient4813" x1="-86.129" x2="-93.088" y1="2.0691" y2="31.138" gradientTransform="matrix(.51128 -.12167 .12241 .50821 56.783 -3.2077)" gradientUnits="userSpaceOnUse">
+   <stop id="stop2266" style="stop-color:#d7e866" offset="0"/>
+   <stop id="stop2268" style="stop-color:#8cab2a" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3597" x1="20.494" x2="20.494" y1="6.0098" y2="47.76" gradientTransform="matrix(.50259 0 0 .49957 1.194 .76653)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3402" style="stop-color:#fff" offset="0"/>
+   <stop id="stop3404" style="stop-color:#fff;stop-opacity:0" offset="1"/>
+  </linearGradient>
+ </defs>
+ <g id="layer1" transform="translate(-2,-2)">
+  <path id="path4346" transform="matrix(1.4884 0 0 1.4466 -4.7442 -6.8302)" d="m19.312 19.031a8.0625 2.2812 0 1 1-16.125 0 8.0625 2.2812 0 1 1 16.125 0z" style="fill:url(#radialGradient4811);opacity:.16292"/>
+  <path id="path1542" d="m18.175 3.5051c-0.28132-0.028378-0.561 0.10858-0.70554 0.3715l-6.1584 11.2-3.9594-3.1293c-0.35269-0.19156-0.79273-0.068328-0.98545 0.28224l-1.7756 2.2659c-0.19272 0.35056-0.063069 0.78783 0.28962 0.97939 0 0 7.2294 5.935 7.2384 5.9394 0.08266 0.0449 0.1691 0.06749 0.25697 0.07853 0.28704 0.03605 0.58079-0.098 0.72834-0.3664l8.3054-15.105c0.19272-0.35057 0.06307-0.78783-0.28962-0.97939l-2.6649-1.4536c-0.08817-0.047891-0.186-0.074167-0.27977-0.083626z" style="fill:url(#linearGradient4813);stroke-linecap:round;stroke-linejoin:round;stroke-width:1.0028;stroke:#699536"/>
+  <path id="path1544" d="m18.214 4.6151-6.5932 11.979-4.5781-3.6009c-0.49997 0.59962-0.84889 1.0916-1.4161 1.7997 0 0 6.6812 5.4506 6.7617 5.5344 0.25102-0.4046 7.8917-14.328 8.0035-14.541-0.16743-0.11534-2.1201-1.1252-2.1778-1.1715z" style="fill:none;opacity:.4;stroke-linecap:round;stroke-width:1.0028;stroke:url(#linearGradient3597)"/>
+ </g>
+</svg>

--- a/data/images/go-bottom.svg
+++ b/data/images/go-bottom.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3734" width="22" height="22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <metadata id="metadata29">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs id="defs3736">
+  <linearGradient id="linearGradient4456">
+   <stop id="stop4458" style="stop-color:#f6daae" offset="0"/>
+   <stop id="stop4460" style="stop-color:#f0c178;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3390-178-986-453-4-5">
+   <stop id="stop3624-8-6" style="stop-color:#bb2b12" offset="0"/>
+   <stop id="stop3626-1-1" style="stop-color:#cd7233" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3732" x1="-55.189" x2="-31.523" y1="191.52" y2="182.48" gradientTransform="matrix(.92957 0 0 .99594 51.302 -181.74)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient3390-178-986-453-4-5"/>
+  <linearGradient id="linearGradient7012-661-145-733-759-865-745-661-970-94-1-0">
+   <stop id="stop3618-1-9" style="stop-color:#f0c178" offset="0"/>
+   <stop id="stop3270-5-6" style="stop-color:#e18941" offset=".5"/>
+   <stop id="stop3620-9-3" style="stop-color:#ec4f18" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4322" x1="-31.523" x2="-55.189" y1="182.48" y2="191.52" gradientTransform="matrix(.92957 0 0 .99594 51.302 -181.74)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7012-661-145-733-759-865-745-661-970-94-1-0"/>
+  <linearGradient id="linearGradient4462" x1="22" x2="0" y1="-8.8818e-16" y2="9" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4456"/>
+  <linearGradient id="linearGradient4040-8-9-7-4-2" x1="-86.552" x2="-83.371" y1="185.44" y2="197.31" gradientTransform="matrix(0,-1,1,0,-272,102)" gradientUnits="userSpaceOnUse">
+   <stop id="stop4036-9-1-5-2-5" style="stop-color:#eeeeec" offset="0"/>
+   <stop id="stop4038-0-5-5-6-2" style="stop-color:#babdb6" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2979" x1="-88" x2="-82" y1="159" y2="181" gradientTransform="matrix(0 -1 1 0 -272.58 80)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3618-1-9-8-2-8" style="stop-color:#f0c178" offset="0"/>
+   <stop id="stop3270-5-6-3-8-7" style="stop-color:#e18941" offset=".5"/>
+   <stop id="stop3620-9-3-0-8-9" style="stop-color:#ec4f18" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2908" x1="-51.577" x2="-73.577" y1="162" y2="168" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient3390-178-986-453-4-5"/>
+  <linearGradient id="linearGradient3072" x1="-33.577" x2="-55.577" y1="162" y2="167" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient3390-178-986-453-4-5"/>
+ </defs>
+ <g id="g6115-7" transform="matrix(0 1 -1 0 176 74.577)" style="enable-background:new">
+  <g id="g4018-8" transform="translate(-1)" style="stroke:url(#linearGradient3072)">
+   <path id="path3395-1" d="m-53.577 158v14" style="enable-background:new;fill:none;stroke-linecap:round;stroke-width:4;stroke:url(#linearGradient2908)"/>
+  </g>
+ </g>
+ <g id="layer1" transform="matrix(0,-1,1,0,6,21)">
+  <path id="path3169-2-3" d="m7.65-0.525-5.15 5.5249 5.15 5.5251" style="enable-background:new;fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:5;stroke:url(#linearGradient3732)"/>
+  <path id="path3765" d="m18 5-11.5-7e-5" style="enable-background:new;fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:6;stroke:url(#linearGradient3732)"/>
+  <path id="path4277" d="m7.7501-0.62517-5.2501 5.6251 5.2502 5.6251" style="enable-background:new;fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:3;stroke:url(#linearGradient4322)"/>
+  <path id="path4279" d="m18 5-11.5-7e-5" style="enable-background:new;fill:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:4;stroke:url(#linearGradient4322)"/>
+  <path id="path4454" d="m8.2812 9.6438-1.7812-1.6438c-1.0393-0.95908 0-1.5 1.5-1.5h9.4c3 0 2.5-3 0-3h-8.9c-1.5 0-3 0-2-1.5l1.6438-1.2312c1.5-2-0.5-2.5-1.5-1.5l-4.6438 4.7312c-0.5 0.5-0.52756 1.3333 0 2l4.7812 5.1438c1 1 3.059-0.06138 1.5-1.5z" style="enable-background:new;fill:none;opacity:.4;stroke-linecap:round;stroke-linejoin:round;stroke:url(#linearGradient4462)"/>
+  <path id="path4464" d="m6.5 2 1.85-1.5062c1.5-2-0.5-2.5-1.5-1.5l-4.85 5.0062m0 2 4.7125 5.2812c1 1 2.9702 0.02922 1.5-1.5l-1.7125-1.7812" style="enable-background:new;fill:none;opacity:.4;stroke-linecap:round;stroke-linejoin:round;stroke:url(#linearGradient4462)"/>
+  <path id="path4466" d="m8.7264-0.093372-2.4201 2.4603" style="enable-background:new;fill:none;opacity:.51;stroke-linecap:round;stroke-linejoin:round;stroke:#f6daae"/>
+ </g>
+ <g id="g4030-5" transform="matrix(0 1 -1 0 176 113.58)" style="enable-background:new;stroke:url(#linearGradient4040-8-9-7-4-2)">
+  <path id="path3397-3" d="m-93.577 158v14" style="enable-background:new;fill:none;stroke-linecap:round;stroke-width:2;stroke:url(#linearGradient2979)"/>
+ </g>
+ <path id="path3397-6-7" d="m13.2 19.5 4.8-4e-6m-14.5 0.406c0.0437-0.2292 0.2667-0.41011 0.5-0.406l4.6308 4e-6" style="block-progression:tb;color:#000000;enable-background:new;fill:none;opacity:.4;stroke-linecap:round;stroke:#f6daae;text-indent:0;text-transform:none"/>
+</svg>

--- a/data/images/media-optical.svg
+++ b/data/images/media-optical.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg2890" width="22" height="22" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs2892">
+  <linearGradient id="linearGradient6036">
+   <stop id="stop6038" style="stop-color:#fff" offset="0"/>
+   <stop id="stop6040" style="stop-color:#fff;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3519">
+   <stop id="stop3521" style="stop-color:#fcd9cd" offset="0"/>
+   <stop id="stop3523" style="stop-color:#fcd9cd;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3511">
+   <stop id="stop3513" style="stop-color:#ebeec7" offset="0"/>
+   <stop id="stop3515" style="stop-color:#ebeec7;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3503">
+   <stop id="stop3505" style="stop-color:#c4ebdd" offset="0"/>
+   <stop id="stop3507" style="stop-color:#c4ebdd;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3495">
+   <stop id="stop3497" style="stop-color:#c1cbe4" offset="0"/>
+   <stop id="stop3499" style="stop-color:#c1cbe4;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3487">
+   <stop id="stop3489" style="stop-color:#e6cde2" offset="0"/>
+   <stop id="stop3491" style="stop-color:#e6cde2;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3456" x1="12.274" x2="35.391" y1="32.416" y2="14.203" gradientTransform="matrix(0 .60001 -.60001 0 25.86 -2.4001)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3265" style="stop-color:#dedbde" offset="0"/>
+   <stop id="stop3267" style="stop-color:#e6e6e6" offset=".5"/>
+   <stop id="stop3269" style="stop-color:#d2d2d2" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3458" x1="-21.916" x2="-21.916" y1="3" y2="45.033" gradientTransform="matrix(.5122 0 0 .5122 25.453 -.29268)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3774" style="stop-color:#b4b4b4" offset="0"/>
+   <stop id="stop3776" style="stop-color:#969696" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3460" x1="21.448" x2="21.448" y1="15.5" y2="32.509" gradientTransform="matrix(.4375 0 0 .4375 1.5 1.5)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3430" style="stop-color:#aaa" offset="0"/>
+   <stop id="stop3432" style="stop-color:#d4d4d4" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3462" x1="18.776" x2="18.203" y1="4.0378" y2="45.962" gradientTransform="matrix(.2273 0 0 .2273 6.4659 6.3175)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient6036"/>
+  <linearGradient id="linearGradient3464" x1="20.58" x2="24.274" y1="10.775" y2="9.8622" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient3487"/>
+  <linearGradient id="linearGradient3466" x1="17.495" x2="21.047" y1="11.2" y2="9.7956" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient3495"/>
+  <linearGradient id="linearGradient3468" x1="14.085" x2="16.994" y1="13.046" y2="10.732" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient3503"/>
+  <linearGradient id="linearGradient3470" x1="12.372" x2="14.609" y1="16.188" y2="13.462" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient3511"/>
+  <linearGradient id="linearGradient3472" x1="10.609" x2="9.7298" y1="17.886" y2="20.613" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient3519"/>
+  <linearGradient id="linearGradient3474" x1="10.502" x2="48.799" y1="3.61" y2="54.698" gradientTransform="matrix(.48201 0 0 .48201 .26461 -.050137)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient6036"/>
+ </defs>
+ <g id="layer1">
+  <g id="g3437" transform="translate(-1 -1)">
+   <path id="path2781" d="m22.5 12c0-5.8201-4.6799-10.5-10.5-10.5-5.8201 0-10.5 4.6799-10.5 10.5-1.1e-6 5.8201 4.6799 10.5 10.5 10.5 5.8201-1e-6 10.5-4.6799 10.5-10.5zm-7 0c0 1.9711-1.57 3.5-3.5 3.5-1.9713 0-3.5-1.655-3.5-3.5 0-1.8863 1.4638-3.5 3.5-3.5 2.0775 0 3.5 1.4877 3.5 3.5z" style="fill:url(#linearGradient3456);stroke:url(#linearGradient3458)"/>
+   <path id="path2474" d="m12 8.0851c-2.161 0-3.9149 1.7539-3.9149 3.9149 0 2.161 1.7539 3.9149 3.9149 3.9149 2.161 0 3.9149-1.7539 3.9149-3.9149 0-2.161-1.7539-3.9149-3.9149-3.9149zm0 1.9574c1.0805 0 1.9574 0.87694 1.9574 1.9574s-0.87694 1.9574-1.9574 1.9574-1.9574-0.87694-1.9574-1.9574 0.87694-1.9574 1.9574-1.9574z" style="fill:#fff;opacity:.5"/>
+   <path id="path3418" d="m12 8.5c-1.932 0-3.5 1.568-3.5 3.5s1.568 3.5 3.5 3.5 3.5-1.568 3.5-3.5-1.568-3.5-3.5-3.5zm0 1.75c0.966 0 1.75 0.784 1.75 1.75 0 0.966-0.784 1.75-1.75 1.75-0.966 0-1.75-0.784-1.75-1.75 0-0.966 0.784-1.75 1.75-1.75z" style="fill:none;stroke-linejoin:round;stroke:url(#linearGradient3460)"/>
+   <path id="path3281" d="m12 7.5c-2.4943 0-4.5 2.0057-4.5 4.5 0 2.4943 2.0057 4.5 4.5 4.5 2.4943 0 4.5-2.0057 4.5-4.5 0-2.4943-2.0057-4.5-4.5-4.5z" style="fill:none;opacity:.8;stroke:url(#linearGradient3462)"/>
+   <g id="g3527" transform="matrix(.48936 0 0 .48936 .2553 .2553)">
+    <path id="path3296" transform="matrix(.9996 .028243 -.028243 .9996 .69241 -.67083)" d="m15.857 5.7308 4.7681 10.613c1.0354-0.45856 2.1703-0.71875 3.375-0.71875 0.03206 0 0.06178-3.6e-4 0.09375 0l0.01426-11.62c-2.9422-0.070687-5.543 0.65729-8.2511 1.726z" style="fill:url(#linearGradient3464);opacity:.8"/>
+    <path id="path3308" d="m12.121 7.906 6.931 9.3601c0.91311-0.66976 1.9659-1.1671 3.1426-1.4252 0.03132-0.0069 0.06026-0.01359 0.09157-0.02009l-2.4295-11.395c-2.889 0.56132-5.3195 1.8556-7.7357 3.4797z" style="fill:url(#linearGradient3466);opacity:.8"/>
+    <path id="path3310" d="m8.2524 11.647 9.2137 7.1558c0.70865-0.88326 1.5969-1.6361 2.6667-2.19 0.02847-0.01474 0.05469-0.02872 0.08325-0.0431l-5.3502-10.319c-2.6453 1.2899-4.7 3.2018-6.6135 5.3959z" style="fill:url(#linearGradient3468);opacity:.8"/>
+    <path id="path3312" d="m5.6329 16.074c7.1748 2.2422 7.8503 7.0315 12.777 1.7541l-7.9097-8.696c-2.2213 1.9306-3.5867 4.3272-4.8671 6.9418z" style="fill:url(#linearGradient3470);opacity:.8"/>
+    <path id="path3314" d="m7.1553 13.193c-1.1831 1.752-1.9077 3.6364-2.5251 5.6439l11.339 2.9754c0.21551-0.763 0.51805-1.5148 0.96875-2.2188 0.01729-0.027 0.04496-0.06702 0.0625-0.09375l-9.8447-6.3068z" style="fill:url(#linearGradient3472);opacity:.8"/>
+   </g>
+   <path id="path3272" d="m12 2.4574c-5.2893 0-9.5426 4.2533-9.5426 9.5426 0 5.2893 4.2533 9.5426 9.5426 9.5426 5.2893 0 9.5426-4.2533 9.5426-9.5426 0-5.2893-4.2533-9.5426-9.5426-9.5426z" style="fill:none;opacity:.5;stroke:url(#linearGradient3474)"/>
+   <g id="g3297" transform="matrix(-.48936 0 0 -.48936 23.745 23.74)">
+    <path id="path3299" transform="matrix(.9996 .028243 -.028243 .9996 .69241 -.67083)" d="m15.857 5.7308 4.7681 10.613c1.0354-0.45856 2.1703-0.71875 3.375-0.71875 0.03206 0 0.06178-3.6e-4 0.09375 0l0.01426-11.62c-2.9422-0.070687-5.543 0.65729-8.2511 1.726z" style="fill:url(#linearGradient3464);opacity:.8"/>
+    <path id="path3301" d="m12.121 7.906 6.931 9.3601c0.91311-0.66976 1.9659-1.1671 3.1426-1.4252 0.03132-0.0069 0.06026-0.01359 0.09157-0.02009l-2.4295-11.395c-2.889 0.56132-5.3195 1.8556-7.7357 3.4797z" style="fill:url(#linearGradient3466);opacity:.8"/>
+    <path id="path3303" d="m8.2524 11.647 9.2137 7.1558c0.70865-0.88326 1.5969-1.6361 2.6667-2.19 0.02847-0.01474 0.05469-0.02872 0.08325-0.0431l-5.3502-10.319c-2.6453 1.2899-4.7 3.2018-6.6135 5.3959z" style="fill:url(#linearGradient3468);opacity:.8"/>
+    <path id="path3305" d="m5.6329 16.074c7.1748 2.2422 7.8503 7.0315 12.777 1.7541l-7.9097-8.696c-2.2213 1.9306-3.5867 4.3272-4.8671 6.9418z" style="fill:url(#linearGradient3470);opacity:.8"/>
+    <path id="path3307" d="m7.1553 13.193c-1.1831 1.752-1.9077 3.6364-2.5251 5.6439l11.339 2.9754c0.21551-0.763 0.51805-1.5148 0.96875-2.2188 0.01729-0.027 0.04496-0.06702 0.0625-0.09375l-9.8447-6.3068z" style="fill:url(#linearGradient3472);opacity:.8"/>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/data/images/process-stop.svg
+++ b/data/images/process-stop.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg2" width="22" height="22" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs4">
+  <linearGradient id="linearGradient2406" x1="63.397" x2="63.397" y1="-12.489" y2="5.4676" gradientTransform="matrix(1.0863 0 0 1.0862 -56.567 14.814)" gradientUnits="userSpaceOnUse">
+   <stop id="stop4875" style="stop-color:#fff" offset="0"/>
+   <stop id="stop4877" style="stop-color:#fff;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2411" x1="18.379" x2="18.379" y1="44.98" y2="3.0816" gradientTransform="matrix(.51604 0 0 .51604 -1.385 -1.385)" gradientUnits="userSpaceOnUse">
+   <stop id="stop2492" style="stop-color:#791235" offset="0"/>
+   <stop id="stop2494" style="stop-color:#dd3b27" offset="1"/>
+  </linearGradient>
+  <radialGradient id="radialGradient2409" cx="23.896" cy="3.99" r="20.397" gradientTransform="matrix(0 1.2316 -1.6257 0 17.487 -29.721)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3244" style="stop-color:#f8b17e" offset="0"/>
+   <stop id="stop3246" style="stop-color:#e35d4f" offset=".26238"/>
+   <stop id="stop3248" style="stop-color:#c6262e" offset=".66094"/>
+   <stop id="stop3250" style="stop-color:#690b54" offset="1"/>
+  </radialGradient>
+ </defs>
+ <g id="layer1">
+  <g id="g2502">
+   <path id="path2555" d="m11 0.50178c-5.7926 0-10.498 4.7057-10.498 10.498 0 5.7926 4.7057 10.498 10.498 10.498 5.7926 0 10.498-4.7057 10.498-10.498 0-5.7926-4.7057-10.498-10.498-10.498z" style="fill:url(#radialGradient2409);stroke-linecap:round;stroke-linejoin:round;stroke-width:1.0037;stroke:url(#linearGradient2411)"/>
+   <path id="path2463" d="m20.5 11c0 5.2469-4.2536 9.5003-9.4999 9.5003-5.2468 0-9.5001-4.2535-9.5001-9.5003 0-5.2466 4.2534-9.4997 9.5001-9.4997 5.2463 0 9.4999 4.253 9.4999 9.4997z" style="fill:none;opacity:.4;stroke:url(#linearGradient2406)"/>
+  </g>
+  <g id="g2478" transform="translate(-25.73 .027876)">
+   <path id="path3243" d="m33.308 4.9721-1.5781 1.5781 3.2558 3.2392c0.10002 0.10128 0.10002 0.26416 0 0.36545l-3.2558 3.2392 1.5781 1.5781 3.2392-3.2392c0.10128-0.10002 0.26416-0.10002 0.36545 0l3.2392 3.2392 1.5781-1.5781-3.2392-3.2392c-0.10002-0.10128-0.10002-0.26416 0-0.36545l3.2392-3.2392-1.5781-1.5781-3.2392 3.2392c-0.10128 0.10002-0.26416 0.10002-0.36545 0l-3.2392-3.2392z" style="fill-rule:evenodd;opacity:.2"/>
+   <path id="path3256" d="m33.308 5.9721-1.5781 1.5781 3.2558 3.2392c0.10002 0.10128 0.10002 0.26416 0 0.36545l-3.2558 3.2392 1.5781 1.5781 3.2392-3.2392c0.10128-0.10002 0.26416-0.10002 0.36545 0l3.2392 3.2392 1.5781-1.5781-3.2392-3.2392c-0.10002-0.10128-0.10002-0.26416 0-0.36545l3.2392-3.2392-1.5781-1.5781-3.2392 3.2392c-0.10128 0.10002-0.26416 0.10002-0.36545 0l-3.2392-3.2392z" style="fill-rule:evenodd;fill:#fff"/>
+  </g>
+ </g>
+</svg>

--- a/data/ui/gametile.ui
+++ b/data/ui/gametile.ui
@@ -201,7 +201,6 @@
               <object class="GtkImage" id="cancel_icon">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="stock">gtk-cancel</property>
               </object>
             </child>
           </object>

--- a/minigalaxy/paths.py
+++ b/minigalaxy/paths.py
@@ -28,6 +28,22 @@ ICON_UPDATE_PATH = os.path.abspath(os.path.join(LAUNCH_DIR, "../data/images/upda
 if not os.path.exists(ICON_UPDATE_PATH):
     ICON_UPDATE_PATH = os.path.abspath(os.path.join(LAUNCH_DIR, "../share/minigalaxy/images/update_available.png"))
 
+ICON_CANCEL_PATH_SVG = os.path.abspath(os.path.join(LAUNCH_DIR, "../data/images/process-stop.svg"))
+if not os.path.exists(ICON_CANCEL_PATH_SVG):
+    ICON_CANCEL_PATH_SVG = os.path.abspath(os.path.join(LAUNCH_DIR, "../share/minigalaxy/images/process-stop.svg"))
+
+ICON_OK_PATH_SVG = os.path.abspath(os.path.join(LAUNCH_DIR, "../data/images/dialog-apply.svg"))
+if not os.path.exists(ICON_OK_PATH_SVG):
+    ICON_OK_PATH_SVG = os.path.abspath(os.path.join(LAUNCH_DIR, "../share/minigalaxy/images/dialog-apply.svg"))
+
+ICON_DOWNLOAD_PATH_SVG = os.path.abspath(os.path.join(LAUNCH_DIR, "../data/images/go-bottom.svg"))
+if not os.path.exists(ICON_DOWNLOAD_PATH_SVG):
+    ICON_DOWNLOAD_PATH_SVG = os.path.abspath(os.path.join(LAUNCH_DIR, "../share/minigalaxy/images/go-bottom.svg"))
+
+ICON_CDROM_PATH_SVG = os.path.abspath(os.path.join(LAUNCH_DIR, "../data/images/media-optical.svg"))
+if not os.path.exists(ICON_CDROM_PATH_SVG):
+    ICON_CDROM_PATH_SVG = os.path.abspath(os.path.join(LAUNCH_DIR, "../share/minigalaxy/images/media-optical.svg"))
+
 LOCALE_DIR = os.path.abspath(os.path.join(LAUNCH_DIR, "../data/mo"))
 if not os.path.exists(LOCALE_DIR):
     LOCALE_DIR = os.path.abspath(os.path.join(LAUNCH_DIR, "../share/minigalaxy/translations"))


### PR DESCRIPTION
Lately we have replaced some Gtk icons with Adwaita symbolic ones. However Cancel icon remain Gtk icon, so we end up with mixed icons.
I am not also very happy with Adwaita icons symbolic as I don't think that they match Minigalaxy visual theme.
I am opening this pull request as some sort of opinion exchange platform what to do next with this issue. Please do not merge it too quickly.
In this pull request I have incorporated Humanity icons into Minigalaxy files and use those instead of system ones.
The result is:
![icons_humanity1](https://user-images.githubusercontent.com/1833284/104110324-00cfd980-52d7-11eb-8fa2-81a3c7cafaa6.png)
![icons_humanity2](https://user-images.githubusercontent.com/1833284/104110328-04fbf700-52d7-11eb-991c-6d484d7c28c5.png)

We should probably find an answer to the following questions:
- Do we want to bring icons by ourself instead of using system ones?
- Are there any icons missing in this pull request?
- Do we want to switch some of those icons to others?
- Do we want to change present png icons to svg for better quality (Wine, Update)

P.S. Humanity icons are on GPL 2:
https://launchpad.net/humanity
if we use those we should probably mention it somewhere in the files.