### PR TITLE
Don't crash with broken refresh_token in config.json

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -42,11 +42,14 @@ class Api:
         response = SESSION.get(request_url, params=params)
 
         response_params = response.json()
-        self.active_token = response_params['access_token']
-        expires_in = response_params["expires_in"]
-        self.active_token_expiration_time = time.time() + int(expires_in)
-
-        return response_params['refresh_token']
+        if "access_token" in response_params and "expires_in" in response_params and "refresh_token" in response_params:
+            self.active_token = response_params["access_token"]
+            expires_in = response_params["expires_in"]
+            self.active_token_expiration_time = time.time() + int(expires_in)
+            response_token = response_params["refresh_token"]
+        else:
+            response_token = ""
+        return response_token
 
     # Get a token based on the code returned by the login screen
     def __get_token(self, login_code: str) -> str:

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -163,6 +163,6 @@ class Window(Gtk.ApplicationWindow):
                 exit(0)
             if response == Gtk.ResponseType.NONE:
                 result = login.get_result()
-                authenticated = self.api.authenticate(refresh_token=token, login_code=result)
+                authenticated = self.api.authenticate(login_code=result)
 
         Config.set("refresh_token", authenticated)


### PR DESCRIPTION
On discord such an issue was reported:
![Bildschirmfoto_vom_2021-01-09_16-51-47](https://user-images.githubusercontent.com/1833284/104127225-27d2ed80-5361-11eb-8c4e-17ee58c1ece7.png)
This pull request is to fix it.

How to test:
1. open ~/.config/minigalaxy/config.json as regular text file and remove half of "refresh_token" value.
2. Start Minigalaxy. Crash from bug report will be obtained
3. Start Minigalaxy from this pull request. No error will be received and Minigalaxy will just ask for another login.