### PR TITLE
Actually perform DLC update check.

### DIFF
--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -381,12 +381,12 @@ class GameTile(Gtk.Box):
             dlc_box.show_all()
             self.get_async_image_dlc_icon(icon, title)
         download_info = self.api.get_download_info(self.game, dlc_installers=installer)
-        if self.game.is_installed(dlc_title=title):
-            icon_name = "emblem-default-symbolic.symbolic"
-            self.dlc_dict[title][0].set_sensitive(False)
-        elif self.game.is_update_available(version_from_api=download_info["version"], dlc_title=title):
+        if self.game.is_update_available(version_from_api=download_info["version"], dlc_title=title):
             icon_name = ICON_UPDATE_PATH
             self.dlc_dict[title][0].set_sensitive(True)
+        elif self.game.is_installed(dlc_title=title):
+            icon_name = "emblem-default-symbolic.symbolic"
+            self.dlc_dict[title][0].set_sensitive(False)
         else:
             icon_name = "go-bottom-symbolic.symbolic"
             self.dlc_dict[title][0].set_sensitive(True)


### PR DESCRIPTION
Well,
It seems that DLC update check was not perform, because if DLC was installed it never executed "elif" with update check.
This pull request fix that.

How to test it:
1. Install game with DLC (optionally two DLCs).
2. Exit Minigalaxy.
3. Open minigalaxy-info.json from game files and change version of one of DLCs.
4. Star Minigalaxy - all DLCs still are in installed state. Exit Minigalaxy.
5. Apply this patch and start Minigalaxy again - DLC with altered version will have update available.