### PR TITLE
Don't try to copy thumbnail if it already exists

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -110,14 +110,16 @@ def move_and_overwrite(game, temp_dir, target_dir):
 
 def copy_thumbnail(game):
     error_message = ""
+    new_thumbnail_path = os.path.join(game.install_dir, "thumbnail.jpg")
     # Copy thumbnail
-    try:
-        shutil.copyfile(
-                        os.path.join(THUMBNAIL_DIR, "{}.jpg".format(game.id)),
-                        os.path.join(game.install_dir, "thumbnail.jpg"),
-                        )
-    except Exception as e:
-        error_message = e
+    if not os.path.isfile(new_thumbnail_path):
+        try:
+            shutil.copyfile(
+                            os.path.join(THUMBNAIL_DIR, "{}.jpg".format(game.id)),
+                            new_thumbnail_path,
+                            )
+        except Exception as e:
+            error_message = e
     return error_message
 
 


### PR DESCRIPTION
Updating was failing for games because of the following error:
```
[Errno 2] No such file or directory: '/home/wouter/.cache/minigalaxy/thumbnails/1449569170.jpg'
Traceback (most recent call last):
  File "/home/wouter/Sources/minigalaxy/minigalaxy/ui/window.py", line 117, in show_error
    dialog.format_secondary_text(secondary_text)
  File "/usr/lib/python3/dist-packages/gi/overrides/Gtk.py", line 625, in format_secondary_text
    self.set_property('secondary-text', message_format)
TypeError: Must be string, not FileNotFoundError
```

This was because the thumbnail had already been moved and didn't exist in the cache anymore. This PR solves that.