### PR TITLE
Define active_token_expiration_time in Api() class constructor.

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -19,6 +19,7 @@ class Api:
         self.client_secret = "9d85c43b1482497dbbce61f6e4aa173a433796eeae2ca8c5f6129f2dc4de46d9"
         self.debug = os.environ.get("MG_DEBUG")
         self.active_token = False
+        self.active_token_expiration_time = time.time()
 
     # use a method to authenticate, based on the information we have
     # Returns an empty string if no information was entered


### PR DESCRIPTION
This is to fix #262 
I don't have test for it, but I have user confirmation that this fix his issue.
Anyhow, it is always good to define all class attributes in constructor, so this should not be controversial.