### PR TITLE
Fix 266

### DIFF
--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -156,5 +156,5 @@ class Library(Gtk.Viewport):
                 self.games.append(game)
             elif self.games[self.games.index(game)].id == 0:
                 self.games[self.games.index(game)].id = game.id
-                self.games[self.games.index(game)].image_url = game.image_url
+            self.games[self.games.index(game)].image_url = game.image_url
             self.games[self.games.index(game)].url = game.url


### PR DESCRIPTION
This one is to fix #266 
It is not easy either. game.image_url appear some time after gametile is created. So in case of lack of thumbnail, we will monitor for 10 seconds if game.image_url appear and if so download it.

Test:
1. Remove thumbnail.jpg from game and ~/.cache/minigalaxy/thumbnails directories.
2. Start Minigalaxy.