### PR TITLE
Fix 226 part2

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -166,7 +166,6 @@ class Api:
         return download_info
 
     def get_real_download_link(self, url):
-        self.get_download_file_md5(url)
         return self.__request(url)['downlink']
 
     def get_download_file_md5(self, url):

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -2,6 +2,7 @@ import os
 import time
 from urllib.parse import urlencode
 import requests
+import xml.etree.ElementTree as ET
 from minigalaxy.game import Game
 from minigalaxy.constants import IGNORE_GAME_IDS, SESSION
 from minigalaxy.config import Config
@@ -165,7 +166,14 @@ class Api:
         return download_info
 
     def get_real_download_link(self, url):
+        self.get_download_file_md5(url)
         return self.__request(url)['downlink']
+
+    def get_download_file_md5(self, url):
+        xml_link = self.__request(url)['checksum']
+        xml_string = SESSION.get(xml_link).text
+        root = ET.fromstring(xml_string)
+        return root.attrib['md5']
 
     def get_user_info(self) -> str:
         username = Config.get("username")

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -6,10 +6,11 @@ from minigalaxy.config import Config
 
 
 class Game:
-    def __init__(self, name: str, url: str = "", game_id: int = 0, install_dir: str = "", image_url="",
-                 platform="linux", dlcs=None):
+    def __init__(self, name: str, url: str = "", md5sum: str = "", game_id: int = 0, install_dir: str = "",
+                 image_url="", platform="linux", dlcs=None):
         self.name = name
         self.url = url
+        self.md5sum = md5sum
         self.id = game_id
         self.install_dir = install_dir
         self.image_url = image_url

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import hashlib
 from minigalaxy.translation import _
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR
 from minigalaxy.config import Config
@@ -33,18 +34,15 @@ def verify_installer_integrity(game, installer):
     if not os.path.exists(installer):
         error_message = _("{} failed to download.").format(installer)
     if not error_message:
-        if game.platform == "linux":
-            try:
-                print("Executing integrity check for {}".format(installer))
-                os.chmod(installer, 0o744)
-                result = subprocess.run([installer, "--check"])
-                if not result.returncode == 0:
-                    error_message = _("{} was corrupted. Please download it again.").format(installer)
-            except Exception as ex:
-                # Any exception means the archive doesn't work, so we don't care with the error is
-                print("Error, exception encountered: {}".format(ex))
-                error_message = _("{} was corrupted. Please download it again.").format(installer)
-        # TODO: Add verification for other platform
+        hash_md5 = hashlib.md5()
+        with open(installer, "rb") as installer_file:
+            for chunk in iter(lambda: installer_file.read(4096), b""):
+                hash_md5.update(chunk)
+        calculated_checksum = hash_md5.hexdigest()
+        if game.md5sum == calculated_checksum:
+            print("{} integrity is preserved. MD5 is: {}".format(installer, calculated_checksum))
+        else:
+            error_message = _("{} was corrupted. Please download it again.").format(installer)
     return error_message
 
 

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -215,8 +215,6 @@ class GameTile(Gtk.Box):
     def get_download_info(self):
         try:
             download_info = self.api.get_download_info(self.game)
-            self.game.md5sum = self.api.get_download_file_md5(download_info["files"][0]["downlink"])
-            print(self.game.md5sum)
             result = True
         except NoDownloadLinkFound as e:
             print(e)
@@ -247,6 +245,7 @@ class GameTile(Gtk.Box):
         for key, file_info in enumerate(download_info['files']):
             try:
                 download_url = self.api.get_real_download_link(file_info["downlink"])
+                self.game.md5sum = self.api.get_download_file_md5(file_info["downlink"])
             except ValueError as e:
                 print(e)
                 GLib.idle_add(self.parent.parent.show_error, _("Download error"), _(str(e)))

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -215,6 +215,8 @@ class GameTile(Gtk.Box):
     def get_download_info(self):
         try:
             download_info = self.api.get_download_info(self.game)
+            self.game.md5sum = self.api.get_download_file_md5(download_info["files"][0]["downlink"])
+            print(self.game.md5sum)
             result = True
         except NoDownloadLinkFound as e:
             print(e)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -113,6 +113,20 @@ class TestApi(TestCase):
         obs = api.get_version(game, gameinfo=API_GET_INFO_TOONSTRUCK, dlc_name=dlc_name)
         self.assertEqual(exp, obs)
 
+    def test_get_download_file_md5(self):
+        api = Api()
+        api._Api__request = MagicMock()
+        m_constants.SESSION.get.side_effect = MagicMock()
+        m_constants.SESSION.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="8acedf66c0d2986e7dee9af912b7df4f" chunks="4" timestamp="2015-07-30 17:11:12" total_size="36717998">
+    <chunk id="0" from="0" to="10485759" method="md5">7e62ce101221ccdae2e9bff5c16ed9e0</chunk>
+    <chunk id="1" from="10485760" to="20971519" method="md5">b80960a2546ce647bffea87f85385535</chunk>
+    <chunk id="2" from="20971520" to="31457279" method="md5">5464b4499cd4368bb83ea35f895d3560</chunk>
+    <chunk id="3" from="31457280" to="36717997" method="md5">0261b9225fc10c407df083f6d254c47b</chunk>
+</file>'''
+        exp = "8acedf66c0d2986e7dee9af912b7df4f"
+        obs = api.get_download_file_md5("url")
+        self.assertEqual(exp, obs)
+
 
 del sys.modules['minigalaxy.constants']
 del sys.modules['minigalaxy.config']

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,6 +1,6 @@
 import sys
 from unittest import TestCase, mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, mock_open
 
 m_config = MagicMock()
 sys.modules['minigalaxy.config'] = m_config
@@ -11,27 +11,34 @@ from minigalaxy.translation import _
 
 class Test(TestCase):
     @mock.patch('os.path.exists')
-    @mock.patch('os.chmod')
-    @mock.patch('subprocess.run')
-    def test1_verify_installer_integrity(self, mock_subprocess, mock_chmod, mock_is_file):
+    @mock.patch('hashlib.md5')
+    def test1_verify_installer_integrity(self, mock_hash, mock_is_file):
+        md5_sum = "5cc68247b61ba31e37e842fd04409d98"
         mock_is_file.return_value = True
-        mock_subprocess().returncode = 0
-        game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
-        installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
+        mock_hash().hexdigest.return_value = md5_sum
+        game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky",
+                    md5sum=md5_sum)
+        installer_path = "/home/user/.cache/minigalaxy/download/" \
+                         "Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         exp = ""
-        obs = installer.verify_installer_integrity(game, installer_path)
+        with patch("builtins.open", mock_open(read_data=b"")):
+            obs = installer.verify_installer_integrity(game, installer_path)
         self.assertEqual(exp, obs)
 
     @mock.patch('os.path.exists')
-    @mock.patch('os.chmod')
-    @mock.patch('subprocess.run')
-    def test2_verify_installer_integrity(self, mock_subprocess, mock_chmod, mock_is_file):
+    @mock.patch('hashlib.md5')
+    def test2_verify_installer_integrity(self, mock_hash, mock_is_file):
+        md5_sum = "5cc68247b61ba31e37e842fd04409d98"
+        corrupted_md5_sum = "99999947b61ba31e37e842fd04409d98"
         mock_is_file.return_value = True
-        mock_subprocess().returncode = 1
-        game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
-        installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
+        mock_hash().hexdigest.return_value = corrupted_md5_sum
+        game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky",
+                    md5sum=md5_sum)
+        installer_path = "/home/user/.cache/minigalaxy/download/" \
+                         "Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         exp = _("{} was corrupted. Please download it again.").format(installer_path)
-        obs = installer.verify_installer_integrity(game, installer_path)
+        with patch("builtins.open", mock_open(read_data=b"aaaa")):
+            obs = installer.verify_installer_integrity(game, installer_path)
         self.assertEqual(exp, obs)
 
     @mock.patch('os.path.exists')


### PR DESCRIPTION
This pull request is to finally fix #226 

Instead of relying on broken internal integrity check, we will get md5 checksum from Api and compare it to downloaded installer.

There was discussion on Discord regarding safety of using Python XML module. My conclusions were that it is safe in this case, but if this is not the case I can change it.

Unit tests are adapted to this new technique.