### PR TITLE
Don't show gog installer 

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -69,7 +69,7 @@ def extract_installer(game, installer, temp_dir):
             os.makedirs(prefix_dir, mode=0o755)
 
         # It's possible to set install dir as argument before installation
-        command = ["env", "WINEPREFIX={}".format(prefix_dir), "wine", installer, "/dir={}".format(temp_dir)]
+        command = ["env", "WINEPREFIX={}".format(prefix_dir), "wine", installer, "/dir={}".format(temp_dir), "/VERYSILENT"]
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     process.wait()
     stdout, stderr = process.communicate()


### PR DESCRIPTION
Hi,

For Windows games and Wine, Minigalaxy use "/dir=" command argument to force the installation in a specific folder.
I think we don't need to see the installation's window and install the game silently is better. A specific command argument exists to do that.
I try it and works correctly.

Example of installation's window for Windows games :
![Capture d’écran de 2021-02-13 11-27-05](https://user-images.githubusercontent.com/3606036/107847886-83284d80-6def-11eb-9910-ced0b0883cc2.png)
