### PR TITLE
Make 'Installed' filter permanent upon restarts.

### DIFF
--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -34,7 +34,8 @@ DEFAULT_CONFIGURATION = {
     "stay_logged_in": True,
     "show_fps": False,
     "show_windows_games": False,
-    "keep_window_maximized": False
+    "keep_window_maximized": False,
+    "installed_filter": False
 }
 
 # Game IDs to ignore when received by the API

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -25,7 +25,7 @@ class Library(Gtk.Viewport):
         Gtk.Viewport.__init__(self)
         self.parent = parent
         self.api = api
-        self.show_installed_only = False
+        self.show_installed_only = Config.get("installed_filter")
         self.search_string = ""
         self.offline = False
         self.games = []

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -28,13 +28,13 @@ class Window(Gtk.ApplicationWindow):
     def __init__(self, name="Minigalaxy"):
         Gtk.ApplicationWindow.__init__(self, title=name)
         self.api = Api()
-        self.show_installed_only = False
         self.search_string = ""
         self.offline = False
 
         # Set library
         self.library = Library(self, self.api)
         self.window_library.add(self.library)
+        self.header_installed.set_active(Config.get("installed_filter"))
 
         # Set the icon
         icon = GdkPixbuf.Pixbuf.new_from_file(LOGO_IMAGE_PATH)
@@ -57,6 +57,7 @@ class Window(Gtk.ApplicationWindow):
     @Gtk.Template.Callback("filter_library")
     def filter_library(self, switch, _=""):
         self.library.filter_library(switch)
+        Config.set("installed_filter", switch.get_active())
 
     @Gtk.Template.Callback("on_menu_preferences_clicked")
     def show_preferences(self, button):


### PR DESCRIPTION
As the titles indicates.
This pull request will make "Installed" filter to be preserved upon Minigalaxy restart.
I can't find issue about it, but I recall it was request on Discord.