### PR TITLE
Attempt to fix Config interuption for unittests

### DIFF
--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -11,15 +11,20 @@ from minigalaxy.constants import DEFAULT_CONFIGURATION
 # The config file is only read once upon starting up
 class __Config:
     def __init__(self):
+        self.first_run = False
+        self.__config = {}
         self.__config_file = CONFIG_FILE_PATH
-        self.__config = self.__load_config_file()
-        self.__add_missing_config_entries()
         self.__update_required = False
 
-        # Update the config file regularly to reflect the self.__config dictionary
-        keep_config_synced_thread = threading.Thread(target=self.__keep_config_synced)
-        keep_config_synced_thread.daemon = True
-        keep_config_synced_thread.start()
+    def first_run_init(self):
+        if not self.first_run:
+            self.first_run = True
+            self.__config = self.__load_config_file()
+            self.__add_missing_config_entries()
+            # Update the config file regularly to reflect the self.__config dictionary
+            keep_config_synced_thread = threading.Thread(target=self.__keep_config_synced)
+            keep_config_synced_thread.daemon = True
+            keep_config_synced_thread.start()
 
     def __keep_config_synced(self):
         while True:
@@ -70,16 +75,19 @@ class __Config:
             self.__config = self.__load_config_file()
 
     def set(self, key, value):
+        self.first_run_init()
         self.__config[key] = value
         self.__update_required = True
 
     def get(self, key):
+        self.first_run_init()
         try:
             return self.__config[key]
         except KeyError:
             return None
 
     def unset(self, key):
+        self.first_run_init()
         try:
             del self.__config[key]
             self.__update_required = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,8 @@ class TestConfig(TestCase):
         config = JSON_DEFAULT_CONFIGURATION
         with patch("builtins.open", mock_open(read_data=config)):
             from minigalaxy.config import Config
+            Config.first_run = True
+            Config._Config__config = DEFAULT_CONFIGURATION
             lang = Config.get("lang")
         exp = "en"
         obs = lang
@@ -44,6 +46,7 @@ class TestConfig(TestCase):
         config = JSON_DEFAULT_CONFIGURATION
         with patch("builtins.open", mock_open(read_data=config)):
             from minigalaxy.config import Config
+            Config.first_run = True
             Config.set("lang", "pl")
             lang = Config.get("lang")
         exp = "pl"
@@ -56,6 +59,7 @@ class TestConfig(TestCase):
         config = JSON_DEFAULT_CONFIGURATION
         with patch("builtins.open", mock_open(read_data=config)):
             from minigalaxy.config import Config
+            Config.first_run = True
             Config.unset("lang")
             lang = Config.get("lang")
         exp = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ class TestConfig(TestCase):
         mock_isdir.return_value = True
         with patch("builtins.open", mock_open()) as mock_config:
             from minigalaxy.config import Config
+            Config.get("")
         mock_c = mock_config.mock_calls
         write_string = ""
         for kall in mock_c:

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -374,4 +374,3 @@ en-US
 
 
 del sys.modules["minigalaxy.config"]
-del sys.modules["minigalaxy.game"]

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,9 +1,6 @@
-import sys
 from unittest import TestCase, mock
-from unittest.mock import MagicMock, patch, mock_open
+from unittest.mock import patch, mock_open
 
-m_config = MagicMock()
-sys.modules['minigalaxy.config'] = m_config
 from minigalaxy.game import Game
 from minigalaxy import installer
 from minigalaxy.translation import _
@@ -76,7 +73,3 @@ class Test(TestCase):
         exp = "The installation of /home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh failed. Please try again."
         obs = installer.extract_installer(game, installer_path, temp_dir)
         self.assertEqual(exp, obs)
-
-
-del sys.modules["minigalaxy.config"]
-del sys.modules["minigalaxy.game"]

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,10 +1,7 @@
 import subprocess
-import sys
 from unittest import TestCase, mock
 from unittest.mock import MagicMock
 
-m_config = MagicMock()
-sys.modules['minigalaxy.config'] = m_config
 from minigalaxy import launcher
 from minigalaxy.game import Game
 
@@ -149,7 +146,3 @@ makson    1006     2  0 lis24 ?        00:00:00 /bin/sh /home/makson/.paradoxlau
         exp = ""
         obs = launcher.check_if_game_start_process_spawned_final_process(err_msg, game)
         self.assertEqual(exp, obs)
-
-
-del sys.modules["minigalaxy.config"]
-del sys.modules["minigalaxy.game"]

--- a/tests/test_ui_library.py
+++ b/tests/test_ui_library.py
@@ -7,7 +7,6 @@ m_gi = MagicMock()
 m_window = MagicMock()
 m_preferences = MagicMock()
 m_gametile = MagicMock()
-m_config = MagicMock()
 
 
 class UnitTestGtkTemplate:
@@ -43,14 +42,13 @@ sys.modules['gi'] = m_gi
 sys.modules['minigalaxy.ui.window'] = m_window
 sys.modules['minigalaxy.ui.preferences'] = m_preferences
 sys.modules['minigalaxy.ui.gametile'] = m_gametile
-sys.modules['minigalaxy.config'] = m_config
 from minigalaxy.game import Game
 from minigalaxy.ui.library import Library
 
 SELF_GAMES = {"Neverwinter Nights: Enhanced Edition": "1097893768", "Beneath A Steel Sky": "1207658695",
               "Stellaris (English)": "1508702879"}
 API_GAMES = {"Neverwinter Nights: Enhanced Edition": "1097893768", "Beneath a Steel Sky": "1207658695",
-            "Dragonsphere": "1207658927", "Warsow": "1207659121", "Outlast": "1207660064", "Xenonauts": "1207664803",
+             "Dragonsphere": "1207658927", "Warsow": "1207659121", "Outlast": "1207660064", "Xenonauts": "1207664803",
              "Wasteland 2": "1207665783", "Baldur's Gate: Enhanced Edition": "1207666353",
              "Baldur's Gate II: Enhanced Edition": "1207666373", "Toonstruck": "1207666633",
              "Icewind Dale: Enhanced Edition": "1207666683", "Pillars of Eternity": "1207666813",
@@ -138,5 +136,3 @@ del sys.modules['gi.repository']
 del sys.modules['minigalaxy.ui.window']
 del sys.modules['minigalaxy.ui.preferences']
 del sys.modules['minigalaxy.ui.gametile']
-del sys.modules["minigalaxy.config"]
-del sys.modules["minigalaxy.game"]


### PR DESCRIPTION
In GitHub unittests fails semi randomly. It is because Config import already starts daemon thread, which fails in this artificial environment and as a result it might be received as unittest fail.
This pull request delay Config thread initialization to the moment get() set() or unset() are used for the first time. As a result, simple Config import does not start new threads and hopefully will make all unittests always pass.
End user should not fell any differences.