### PR TITLE
New game configuration directory

### DIFF
--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -3,6 +3,7 @@ import re
 import json
 
 from minigalaxy.config import Config
+from minigalaxy.paths import CONFIG_DIR
 
 
 class Game:
@@ -16,8 +17,8 @@ class Game:
         self.image_url = image_url
         self.platform = platform
         self.dlcs = [] if dlcs is None else dlcs
-        self.status_file_name = "minigalaxy-info.json"
-        self.status_file_path = os.path.join(self.install_dir, self.status_file_name)
+        self.status_file_name = "{}.json".format(self.get_install_directory_name())
+        self.status_file_path = os.path.join(CONFIG_DIR, self.status_file_name)
 
     def get_stripped_name(self):
         return self.__strip_string(self.name)
@@ -144,7 +145,6 @@ class Game:
     def set_install_dir(self):
         if not self.install_dir:
             self.install_dir = os.path.join(Config.get("install_dir"), self.get_install_directory_name())
-            self.status_file_path = os.path.join(self.install_dir, self.status_file_name)
 
     def __str__(self):
         return self.name

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -3,7 +3,7 @@ import re
 import json
 
 from minigalaxy.config import Config
-from minigalaxy.paths import CONFIG_DIR
+from minigalaxy.paths import CONFIG_GAMES_DIR
 
 
 class Game:
@@ -18,7 +18,7 @@ class Game:
         self.platform = platform
         self.dlcs = [] if dlcs is None else dlcs
         self.status_file_name = "{}.json".format(self.get_install_directory_name())
-        self.status_file_path = os.path.join(CONFIG_DIR, self.status_file_name)
+        self.status_file_path = os.path.join(CONFIG_GAMES_DIR, self.status_file_name)
 
     def get_stripped_name(self):
         return self.__strip_string(self.name)
@@ -35,6 +35,8 @@ class Game:
         return json_dict
 
     def save_minigalaxy_info_json(self, json_dict):
+        if not os.path.exists(CONFIG_GAMES_DIR):
+            os.makedirs(CONFIG_GAMES_DIR, mode=0o755)
         status_file = open(self.status_file_path, 'w')
         json.dump(json_dict, status_file)
         status_file.close()

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -48,11 +48,6 @@ class Game:
         if dlc_title:
             dlc_version = self.get_dlc_info("version", dlc_title)
             installed = True if dlc_version else False
-            # Start: Code for compatibility with minigalaxy 1.0
-            if not installed:
-                status = self.legacy_get_dlc_status(dlc_title)
-                installed = True if status in ["installed", "updatable"] else False
-            # End: Code for compatibility with minigalaxy 1.0
         else:
             if self.install_dir and os.path.exists(self.install_dir):
                 installed = True
@@ -62,11 +57,6 @@ class Game:
         update_available = False
         if dlc_title:
             installed_version = self.get_dlc_info("version", dlc_title)
-            # Start: Code for compatibility with minigalaxy 1.0
-            if not installed_version:
-                status = self.legacy_get_dlc_status(dlc_title, version_from_api)
-                update_available = True if status in ["updatable"] else False
-            # End: Code for compatibility with minigalaxy 1.0
         else:
             installed_version = self.get_info("version")
             if not installed_version:
@@ -75,30 +65,6 @@ class Game:
             update_available = True
 
         return update_available
-
-    # This function is for compatibility with minigalaxy 1.0. It can be removed, when decision to break compatibility
-    # is taken.
-    # This is not a big deal. After removal of this function all DLCs from minigalaxy 1.0 will be marked as uninstalled.
-    def legacy_get_dlc_status(self, dlc_title, available_version="0"):
-        dlc_status_list = ["not-installed", "installed", "updatable"]
-        dlc_status_file_name = "minigalaxy-dlc.json"
-        dlc_status_file_path = os.path.join(self.install_dir, dlc_status_file_name)
-        json_list = ["", ""]
-        status = dlc_status_list[0]
-        if os.path.isfile(dlc_status_file_path):
-            dlc_staus_file = open(dlc_status_file_path, 'r')
-            json_list = json.load(dlc_staus_file)
-            dlc_status_dict = json_list[0]
-            dlc_staus_file.close()
-            if dlc_title in dlc_status_dict:
-                status = dlc_status_dict[dlc_title]
-        if status == dlc_status_list[1]:
-            installed_version_dict = json_list[1]
-            if dlc_title in installed_version_dict:
-                installed_version = installed_version_dict[dlc_title]
-                if available_version != installed_version:
-                    status = dlc_status_list[2]
-        return status
 
     def fallback_read_installed_version(self):
         gameinfo = os.path.join(self.install_dir, "gameinfo")

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -97,6 +97,14 @@ class Game:
         json_dict = self.load_minigalaxy_info_json()
         if key in json_dict:
             value = json_dict[key]
+        # Start: Code for compatibility with minigalaxy 1.0.1 and 1.0.2
+        elif os.path.isfile(os.path.join(self.install_dir, "minigalaxy-info.json")):
+            staus_file = open(self.status_file_path, 'r')
+            json_dict = json.load(staus_file)
+            staus_file.close()
+            if key in json_dict:
+                value = json_dict[key]
+        # End: Code for compatibility with minigalaxy 1.0.1 and 1.0.2
         return value
 
     def get_dlc_info(self, key, dlc_title):
@@ -106,6 +114,16 @@ class Game:
             if dlc_title in json_dict["dlcs"]:
                 if key in json_dict["dlcs"][dlc_title]:
                     value = json_dict["dlcs"][dlc_title][key]
+        # Start: Code for compatibility with minigalaxy 1.0.1 and 1.0.2
+        if os.path.isfile(os.path.join(self.install_dir, "minigalaxy-info.json")) and not value:
+            staus_file = open(self.status_file_path, 'r')
+            json_dict = json.load(staus_file)
+            staus_file.close()
+            if "dlcs" in json_dict:
+                if dlc_title in json_dict["dlcs"]:
+                    if key in json_dict["dlcs"][dlc_title]:
+                        value = json_dict["dlcs"][dlc_title][key]
+        # End: Code for compatibility with minigalaxy 1.0.1 and 1.0.2
         return value
 
     def set_install_dir(self):

--- a/minigalaxy/paths.py
+++ b/minigalaxy/paths.py
@@ -6,6 +6,7 @@ if LAUNCH_DIR == "/bin" or LAUNCH_DIR == "/sbin":
     LAUNCH_DIR = "/usr" + LAUNCH_DIR
 
 CONFIG_DIR = os.path.join(os.getenv('XDG_CONFIG_HOME', os.path.expanduser('~/.config')), "minigalaxy")
+CONFIG_GAMES_DIR = os.path.join(CONFIG_DIR, "games")
 CONFIG_FILE_PATH = os.path.join(CONFIG_DIR, "config.json")
 CACHE_DIR = os.path.join(os.getenv('XDG_CACHE_HOME', os.path.expanduser('~/.cache')), "minigalaxy")
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -255,7 +255,7 @@ en-US
 
     @unittest.mock.patch('os.path.isfile')
     def test_get_dlc_info(self, mock_isfile):
-        mock_isfile.side_effect = [True]
+        mock_isfile.side_effect = [True, False]
         json_content = '{"dlcs": {"example_dlc" : {"example_key": "example_value"}}}'
         with patch("builtins.open", mock_open(read_data=json_content)):
             game = Game("Game Name test")
@@ -264,21 +264,89 @@ en-US
         observed = game_get_status
         self.assertEqual(expected, observed)
 
-    def test1_set_install_dir(self):
-        m_config.Config.get.return_value = "/home/user/GOG Games"
-        game = Game("Neverwinter Nights")
+    def test_set_install_dir(self):
+        install_directory = "/home/user/GOG Games"
+        install_game_name = "Neverwinter Nights"
+        m_config.Config.get.return_value = install_directory
+        game = Game(install_game_name)
         game.set_install_dir()
-        exp = "/home/user/GOG Games/Neverwinter Nights"
+        exp = os.path.join(install_directory, install_game_name)
         obs = game.install_dir
         self.assertEqual(exp, obs)
 
-    def test2_set_install_dir(self):
-        m_config.Config.get.return_value = "/home/user/GOG Games"
-        game = Game("Neverwinter Nights")
-        game.set_install_dir()
-        exp = os.path.join(CONFIG_DIR, "Neverwinter Nights.json")
-        obs = game.status_file_path
-        self.assertEqual(exp, obs)
+    @unittest.mock.patch('os.path.isfile')
+    def test1_get_info_legacy(self, mock_isfile):
+        mock_isfile.side_effect = [False, True]
+        json_content = '{"example_key": "example_value"}'
+        with patch("builtins.open", mock_open(read_data=json_content)):
+            game = Game("Game Name test")
+            game_get_status = game.get_info("example_key")
+        expected = "example_value"
+        observed = game_get_status
+        self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.path.isfile')
+    def test2_get_info_legacy(self, mock_isfile):
+        mock_isfile.side_effect = [True, True]
+        json_content = '{"example_key": "example_value"}'
+        with patch("builtins.open", mock_open(read_data=json_content)):
+            game = Game("Game Name test")
+            game.load_minigalaxy_info_json = MagicMock()
+            game.load_minigalaxy_info_json.return_value = {}
+            game_get_status = game.get_info("example_key")
+        expected = "example_value"
+        observed = game_get_status
+        self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.path.isfile')
+    def test3_get_info_legacy(self, mock_isfile):
+        mock_isfile.side_effect = [True, True]
+        json_content = '{"example_key": "example_value_legacy"}'
+        with patch("builtins.open", mock_open(read_data=json_content)):
+            game = Game("Game Name test")
+            game.load_minigalaxy_info_json = MagicMock()
+            game.load_minigalaxy_info_json.return_value = {"example_key": "example_value"}
+            game_get_status = game.get_info("example_key")
+        expected = "example_value"
+        observed = game_get_status
+        self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.path.isfile')
+    def test1_get_dlc_info_legacy(self, mock_isfile):
+        mock_isfile.side_effect = [False, True]
+        json_content = '{"dlcs": {"example_dlc" : {"example_key": "example_value"}}}'
+        with patch("builtins.open", mock_open(read_data=json_content)):
+            game = Game("Game Name test")
+            game_get_status = game.get_dlc_info("example_key", "example_dlc")
+        expected = "example_value"
+        observed = game_get_status
+        self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.path.isfile')
+    def test2_get_dlc_info_legacy(self, mock_isfile):
+        mock_isfile.side_effect = [True, True]
+        json_content = '{"dlcs": {"example_dlc" : {"example_key": "example_value"}}}'
+        with patch("builtins.open", mock_open(read_data=json_content)):
+            game = Game("Game Name test")
+            game.load_minigalaxy_info_json = MagicMock()
+            game.load_minigalaxy_info_json.return_value = {}
+            game_get_status = game.get_dlc_info("example_key", "example_dlc")
+        expected = "example_value"
+        observed = game_get_status
+        self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.path.isfile')
+    def test3_get_dlc_info_legacy(self, mock_isfile):
+        mock_isfile.side_effect = [True, True]
+        json_content = '{"dlcs": {"example_dlc" : {"example_key": "example_value_legacy"}}}'
+        with patch("builtins.open", mock_open(read_data=json_content)):
+            game = Game("Game Name test")
+            game.load_minigalaxy_info_json = MagicMock()
+            game.load_minigalaxy_info_json.return_value = {"dlcs": {"example_dlc": {"example_key": "example_value"}}}
+            game_get_status = game.get_dlc_info("example_key", "example_dlc")
+        expected = "example_value"
+        observed = game_get_status
+        self.assertEqual(expected, observed)
 
 
 del sys.modules["minigalaxy.config"]

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -280,6 +280,7 @@ en-US
         json_content = '{"example_key": "example_value"}'
         with patch("builtins.open", mock_open(read_data=json_content)):
             game = Game("Game Name test")
+            game.set_info = MagicMock()
             game_get_status = game.get_info("example_key")
         expected = "example_value"
         observed = game_get_status
@@ -291,6 +292,7 @@ en-US
         json_content = '{"example_key": "example_value"}'
         with patch("builtins.open", mock_open(read_data=json_content)):
             game = Game("Game Name test")
+            game.set_info = MagicMock()
             game.load_minigalaxy_info_json = MagicMock()
             game.load_minigalaxy_info_json.return_value = {}
             game_get_status = game.get_info("example_key")
@@ -317,6 +319,7 @@ en-US
         json_content = '{"dlcs": {"example_dlc" : {"example_key": "example_value"}}}'
         with patch("builtins.open", mock_open(read_data=json_content)):
             game = Game("Game Name test")
+            game.set_dlc_info = MagicMock()
             game_get_status = game.get_dlc_info("example_key", "example_dlc")
         expected = "example_value"
         observed = game_get_status
@@ -328,6 +331,7 @@ en-US
         json_content = '{"dlcs": {"example_dlc" : {"example_key": "example_value"}}}'
         with patch("builtins.open", mock_open(read_data=json_content)):
             game = Game("Game Name test")
+            game.set_dlc_info = MagicMock()
             game.load_minigalaxy_info_json = MagicMock()
             game.load_minigalaxy_info_json.return_value = {}
             game_get_status = game.get_dlc_info("example_key", "example_dlc")

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -88,16 +88,6 @@ class TestGame(unittest.TestCase):
         observed = game.is_update_available("82.8193.20.1", dlc_title="Neverwinter Nights: Wyvern Crown of Cormyr")
         self.assertEqual(expected, observed)
 
-    def test5_is_update_available(self):
-        game = Game("Version Test game")
-        game.load_minigalaxy_info_json = MagicMock()
-        game.load_minigalaxy_info_json.return_value = {'version': "91.8193.16", "dlcs": {}}
-        game.legacy_get_dlc_status = MagicMock()
-        game.legacy_get_dlc_status.return_value = "updatable"
-        expected = True
-        observed = game.is_update_available("82.8193.20.1", dlc_title="Neverwinter Nights: Wyvern Crown of Cormyr")
-        self.assertEqual(expected, observed)
-
     def test1_get_install_directory_name(self):
         game = Game("Get Install Directory Test1")
         expected = "Get Install Directory Test1"
@@ -143,47 +133,6 @@ en-US
         self.assertEqual(expected, observed)
 
     @unittest.mock.patch('os.path.isfile')
-    def test1_legacy_get_dlc_status(self, mock_isfile):
-        mock_isfile.side_effect = [True]
-        json_content = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "not-installed", ' \
-                       '"Neverwinter Nights: Infinite Dungeons": "updatable", "Neverwinter Nights: Pirates of ' \
-                       'the Sword Coast": "installed"}, {}]'
-        with patch("builtins.open", mock_open(read_data=json_content)):
-            game = Game("Game Name test1")
-            game.read_installed_version = MagicMock()
-            game.installed_version = "1"
-            dlc_status = game.legacy_get_dlc_status("Neverwinter Nights: Wyvern Crown of Cormyr", "")
-        expected = "not-installed"
-        observed = dlc_status
-        self.assertEqual(expected, observed)
-
-    @unittest.mock.patch('os.path.isfile')
-    def test2_legacy_get_dlc_status(self, mock_isfile):
-        mock_isfile.side_effect = [True]
-        json_content = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "not-installed", ' \
-                       '"Neverwinter Nights: Infinite Dungeons": "updatable", "Neverwinter Nights: Pirates of ' \
-                       'the Sword Coast": "installed"}, {}]'
-        with patch("builtins.open", mock_open(read_data=json_content)):
-            game = Game("Game Name test2")
-            dlc_status = game.legacy_get_dlc_status("Neverwinter Nights: Infinite Dungeons", "")
-        expected = "updatable"
-        observed = dlc_status
-        self.assertEqual(expected, observed)
-
-    @unittest.mock.patch('os.path.isfile')
-    def test3_legacy_get_dlc_status(self, mock_isfile):
-        mock_isfile.side_effect = [False]
-        json_content = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "not-installed", ' \
-                       '"Neverwinter Nights: Infinite Dungeons": "updatable", "Neverwinter Nights: Pirates of ' \
-                       'the Sword Coast": "installed"}, {}]'
-        with patch("builtins.open", mock_open(read_data=json_content)):
-            game = Game("Game Name test2")
-            dlc_status = game.legacy_get_dlc_status("Neverwinter Nights: Infinite Dungeons", "")
-        expected = "not-installed"
-        observed = dlc_status
-        self.assertEqual(expected, observed)
-
-    @unittest.mock.patch('os.path.isfile')
     def test1_set_info(self, mock_isfile):
         mock_isfile.return_value = True
         json_content = '{"version": "gog-2"}'
@@ -215,51 +164,6 @@ en-US
                 write_string = "{}{}".format(write_string, args[0])
         expected = '{"dlcs": {"Neverwinter Nights: Wyvern Crown of Cormyr": {"version": "82.8193.20.1"}}}'
         observed = write_string
-        self.assertEqual(expected, observed)
-
-    @unittest.mock.patch('os.path.isfile')
-    def test1_get_dlc_status_version(self, mock_isfile):
-        mock_isfile.side_effect = [True]
-        json_content = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "not-installed", ' \
-                       '"Neverwinter Nights: Infinite Dungeons": "installed", "Neverwinter Nights: Pirates of ' \
-                       'the Sword Coast": "installed"}, {"Neverwinter Nights: Wyvern Crown of Cormyr": ' \
-                       '"81.8193.16", "Neverwinter Nights: Infinite Dungeons": "81.8193.17", "Neverwinter Nights: ' \
-                       'Pirates of the Sword Coast": "81.8193.18"}] '
-        with patch("builtins.open", mock_open(read_data=json_content)):
-            game = Game("Game Name test2")
-            dlc_status = game.legacy_get_dlc_status("Neverwinter Nights: Infinite Dungeons", "81.8193.16")
-        expected = "updatable"
-        observed = dlc_status
-        self.assertEqual(expected, observed)
-
-    @unittest.mock.patch('os.path.isfile')
-    def test2_get_dlc_status_version(self, mock_isfile):
-        mock_isfile.side_effect = [True]
-        json_content = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "updatable", ' \
-                       '"Neverwinter Nights: Infinite Dungeons": "installed", "Neverwinter Nights: Pirates of ' \
-                       'the Sword Coast": "installed"}, {"Neverwinter Nights: Wyvern Crown of Cormyr": ' \
-                       '"81.8193.16", "Neverwinter Nights: Infinite Dungeons": "81.8193.17", "Neverwinter Nights: ' \
-                       'Pirates of the Sword Coast": "81.8193.18"}] '
-        with patch("builtins.open", mock_open(read_data=json_content)):
-            game = Game("Game Name test2")
-            dlc_status = game.legacy_get_dlc_status("Neverwinter Nights: Wyvern Crown of Cormyr", "")
-        expected = "updatable"
-        observed = dlc_status
-        self.assertEqual(expected, observed)
-
-    @unittest.mock.patch('os.path.isfile')
-    def test3_get_dlc_status_version(self, mock_isfile):
-        mock_isfile.side_effect = [True]
-        json_content = '[{"Neverwinter Nights: Wyvern Crown of Cormyr": "updatable", ' \
-                       '"Neverwinter Nights: Infinite Dungeons": "installed", "Neverwinter Nights: Pirates of ' \
-                       'the Sword Coast": "installed"}, {"Neverwinter Nights: Wyvern Crown of Cormyr": ' \
-                       '"81.8193.16", "Neverwinter Nights: Infinite Dungeons": "81.8193.17", "Neverwinter Nights: ' \
-                       'Pirates of the Sword Coast": "81.8193.18"}] '
-        with patch("builtins.open", mock_open(read_data=json_content)):
-            game = Game("Game Name test2")
-            dlc_status = game.legacy_get_dlc_status("Neverwinter Nights: Infinite Dungeons", "81.8193.17")
-        expected = "installed"
-        observed = dlc_status
         self.assertEqual(expected, observed)
 
     def test_get_stripped_name(self):
@@ -317,7 +221,7 @@ en-US
         self.assertEqual(exp, obs)
 
     @unittest.mock.patch('os.path.exists')
-    def test3_is_installed(self, mock_isfile):
+    def test2_is_installed(self, mock_isfile):
         mock_isfile.side_effect = [True]
         game = Game("Game Name Test", install_dir="Test Install Dir")
         game.load_minigalaxy_info_json = MagicMock()
@@ -327,7 +231,7 @@ en-US
         self.assertEqual(exp, obs)
 
     @unittest.mock.patch('os.path.exists')
-    def test4_is_installed(self, mock_isfile):
+    def test3_is_installed(self, mock_isfile):
         mock_isfile.side_effect = [True]
         game = Game("Game Name Test", install_dir="Test Install Dir")
         game.load_minigalaxy_info_json = MagicMock()

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,6 +1,10 @@
 import unittest
 import sys
+import os
 from unittest.mock import MagicMock, mock_open, patch
+
+from minigalaxy.paths import CONFIG_DIR
+
 m_config = MagicMock()
 sys.modules['minigalaxy.config'] = m_config
 from minigalaxy.game import Game
@@ -368,7 +372,7 @@ en-US
         m_config.Config.get.return_value = "/home/user/GOG Games"
         game = Game("Neverwinter Nights")
         game.set_install_dir()
-        exp = "/home/user/GOG Games/Neverwinter Nights/minigalaxy-info.json"
+        exp = os.path.join(CONFIG_DIR, "Neverwinter Nights.json")
         obs = game.status_file_path
         self.assertEqual(exp, obs)
 


### PR DESCRIPTION
This pull request moves games minigalaxy-info.json file to ~/.config/minigalaxy/<Game-Name>.json.
This allows us to do some configuration to games which are not yet install and as a result adds opportunity to implement for example:
Hiding games - #273 
Choosing between Windows and Linux game version to install - #277 

We preserve compatibility with previous minigalaxy-info.json files (Minigalaxy 1.0.1 and 1.0.2) and those configs are translated to new once.

We break compatibility with minigalaxy-dlc.json (Minigalaxy 1.0.0). If someone for some reason have such a config, DLCs will be marked as not installed. Upon reinstalling them everything should be back to normal.