### PR TITLE
Initial redesign of Properties Window

### DIFF
--- a/data/ui/properties.ui
+++ b/data/ui/properties.ui
@@ -10,8 +10,18 @@
     <child internal-child="vbox">
       <object class="GtkBox">
         <property name="can_focus">False</property>
-<property name="orientation">horizontal</property>
-        <property name="spacing">2</property>
+        <property name="orientation">horizontal</property>
+        <property name="spacing">18</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkImage" id="image">
             <property name="visible">True</property>
@@ -29,18 +39,20 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
+            <property name="spacing">18</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="spacing">5</property>
+                <property name="spacing">6</property>
                 <property name="homogeneous">True</property>
                 <child>
                   <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="row_spacing">5</property>
-                    <property name="column_spacing">5</property>
+                    <property name="margin_top">18</property>
+                    <property name="row_spacing">6</property>
+                    <property name="column_spacing">12</property>
                     <property name="row_homogeneous">True</property>
                     <property name="column_homogeneous">True</property>
                     <child>
@@ -74,7 +86,7 @@
                       <object class="GtkSwitch" id="switch_properties_show_fps">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="halign">center</property>
+                        <property name="halign">start</property>
                         <property name="valign">center</property>
                       </object>
                       <packing>
@@ -86,6 +98,7 @@
                       <object class="GtkEntry" id="entry_properties_command">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="halign">start</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -96,6 +109,7 @@
                       <object class="GtkEntry" id="entry_properties_variable">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="halign">start</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -106,7 +120,9 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Show FPS in game:</property>
+                        <property name="justify">fill</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -117,7 +133,9 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Variables flag</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Variables flag:</property>
+                        <property name="justify">fill</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -128,7 +146,9 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Commands flag</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Commands flag:</property>
+                        <property name="justify">fill</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -208,6 +228,8 @@
               <object class="GtkButtonBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="margin_bottom">18</property>
+                <property name="spacing">12</property>
                 <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="button_properties_cancel">

--- a/data/ui/properties.ui
+++ b/data/ui/properties.ui
@@ -1,217 +1,177 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <template class="Properties" parent="GtkDialog">
-    <property name="can-focus">False</property>
-    <property name="default-width">400</property>
-    <property name="default-height">250</property>
-    <property name="type-hint">dialog</property>
+    <property name="can_focus">False</property>
+    <property name="default_width">400</property>
+    <property name="default_height">250</property>
+    <property name="type_hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="can-focus">False</property>
-        <property name="orientation">vertical</property>
+        <property name="can_focus">False</property>
+<property name="orientation">horizontal</property>
         <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox">
-            <property name="can-focus">False</property>
-            <property name="layout-style">end</property>
-            <child>
-              <object class="GtkButton" id="button_properties_cancel">
-                <property name="label" translatable="yes">Cancel</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <signal name="clicked" handler="on_button_properties_cancel_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="button_properties_ok">
-                <property name="label" translatable="yes">OK</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <signal name="clicked" handler="on_button_properties_ok_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
+        <child>
+          <object class="GtkImage" id="image">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stock">gtk-missing-image</property>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="spacing">5</property>
                 <property name="homogeneous">True</property>
                 <child>
-                  <object class="GtkImage" id="image">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="stock">gtk-missing-image</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <!-- n-columns=2 n-rows=6 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="row-spacing">5</property>
-                    <property name="column-spacing">5</property>
-                    <property name="row-homogeneous">True</property>
-                    <property name="column-homogeneous">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="row_spacing">5</property>
+                    <property name="column_spacing">5</property>
+                    <property name="row_homogeneous">True</property>
+                    <property name="column_homogeneous">True</property>
                     <child>
                       <object class="GtkButton" id="button_properties_support">
                         <property name="label" translatable="yes">Support</property>
                         <property name="name">button_properties_support</property>
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
                         <signal name="clicked" handler="on_button_properties_support_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">0</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_store">
                         <property name="label" translatable="yes">Store</property>
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
                         <signal name="clicked" handler="on_button_properties_store_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">0</property>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkSwitch" id="switch_properties_show_fps">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
+                        <property name="can_focus">True</property>
                         <property name="halign">center</property>
                         <property name="valign">center</property>
                       </object>
                       <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">3</property>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">3</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkEntry" id="entry_properties_command">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
+                        <property name="can_focus">True</property>
                       </object>
                       <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">5</property>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">5</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkEntry" id="entry_properties_variable">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
+                        <property name="can_focus">True</property>
                       </object>
                       <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">4</property>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Show FPS in game:</property>
                       </object>
                       <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">3</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Variables flag</property>
                       </object>
                       <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">4</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Commands flag</property>
                       </object>
                       <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">5</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">5</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_winecfg">
                         <property name="label" translatable="yes">Winecfg</property>
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
                         <signal name="clicked" handler="on_button_properties_winecfg_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">1</property>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_regedit">
                         <property name="label" translatable="yes">Regedit</property>
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
                         <signal name="clicked" handler="on_button_properties_regedit_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">1</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_open_files">
                         <property name="label" translatable="yes">Open Files</property>
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
                         <signal name="clicked" handler="on_button_properties_open_files_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">2</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
                       </packing>
                     </child>
                     <child>
@@ -228,14 +188,67 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label_game_description">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="wrap">True</property>
+                <property name="selectable">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButtonBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="layout_style">end</property>
+                <child>
+                  <object class="GtkButton" id="button_properties_cancel">
+                    <property name="label" translatable="yes">Cancel</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <signal name="clicked" handler="on_button_properties_cancel_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="button_properties_ok">
+                    <property name="label" translatable="yes">OK</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <signal name="clicked" handler="on_button_properties_ok_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -224,3 +224,23 @@ class Api:
             print("Response body: {}".format(response.text))
             print("")
         return response.json()
+
+    @staticmethod
+    def __request_gamesdb(game: Game):
+        request_url = "https://gamesdb.gog.com/platforms/gog/external_releases/{}".format(game.id)
+        response = SESSION.get(request_url)
+        return response.json()
+
+    def get_gamesdb_info(self, game: Game) -> dict:
+        gamesdb_dict = {"cover": "", "vertical_cover": "", "background": ""}
+        response_json = self.__request_gamesdb(game)
+        if "game" in response_json:
+            for gamesdb_key in gamesdb_dict:
+                if gamesdb_key in response_json['game']:
+                    gamesdb_dict[gamesdb_key] = response_json["game"][gamesdb_key]["url_format"].replace(
+                        '{formatter}.{ext}', '.png')
+            gamesdb_dict["summary"] = response_json["game"]["summary"]["*"]
+        else:
+            gamesdb_dict["summary"] = " "
+        print(gamesdb_dict)
+        return gamesdb_dict

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -133,7 +133,7 @@ class Api:
         return response
 
     # This returns a unique download url and a link to the checksum of the download
-    def get_download_info(self, game: Game, operating_system="linux", dlc_installers="") -> tuple:
+    def get_download_info(self, game: Game, operating_system="linux", dlc_installers="") -> dict:
         if dlc_installers:
             installers = dlc_installers
         else:
@@ -197,7 +197,8 @@ class Api:
                 break
         return version
 
-    def can_connect(self) -> bool:
+    @staticmethod
+    def can_connect() -> bool:
         url = "https://embed.gog.com"
         try:
             SESSION.get(url, timeout=5)
@@ -246,5 +247,4 @@ class Api:
             gamesdb_dict["summary"] = response_json["game"]["summary"]["*"]
         else:
             gamesdb_dict["summary"] = ""
-        print(gamesdb_dict)
         return gamesdb_dict

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -228,8 +228,12 @@ class Api:
     @staticmethod
     def __request_gamesdb(game: Game):
         request_url = "https://gamesdb.gog.com/platforms/gog/external_releases/{}".format(game.id)
-        response = SESSION.get(request_url)
-        return response.json()
+        try:
+            response = SESSION.get(request_url)
+            respones_dict = response.json()
+        except (requests.exceptions.ConnectionError, ValueError):
+            respones_dict = {}
+        return respones_dict
 
     def get_gamesdb_info(self, game: Game) -> dict:
         gamesdb_dict = {"cover": "", "vertical_cover": "", "background": ""}
@@ -241,6 +245,6 @@ class Api:
                         '{formatter}.{ext}', '.png')
             gamesdb_dict["summary"] = response_json["game"]["summary"]["*"]
         else:
-            gamesdb_dict["summary"] = " "
+            gamesdb_dict["summary"] = ""
         print(gamesdb_dict)
         return gamesdb_dict

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -244,7 +244,13 @@ class Api:
                 if gamesdb_key in response_json['game']:
                     gamesdb_dict[gamesdb_key] = response_json["game"][gamesdb_key]["url_format"].replace(
                         '{formatter}.{ext}', '.png')
-            gamesdb_dict["summary"] = response_json["game"]["summary"]["*"]
+            gamesdb_dict["summary"] = {}
+            for summary_key in response_json["game"]["summary"]:
+                gamesdb_dict["summary"][summary_key] = response_json["game"]["summary"][summary_key]
+            gamesdb_dict["genre"] = {}
+            for genre_key in response_json["game"]["genres"][0]["name"]:
+                gamesdb_dict["genre"][genre_key] = response_json["game"]["genres"][0]["name"][genre_key]
         else:
-            gamesdb_dict["summary"] = ""
+            gamesdb_dict["summary"] = {}
+            gamesdb_dict["genre"] = {}
         return gamesdb_dict

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -5,12 +5,12 @@ import subprocess
 import webbrowser
 
 gi.require_version('Gtk', '3.0')
-
 from gi.repository import Gtk, GLib, Gio
 from gi.repository.GdkPixbuf import Pixbuf, InterpType
 from minigalaxy.paths import UI_DIR, THUMBNAIL_DIR
 from minigalaxy.translation import _
 from minigalaxy.launcher import config_game, regedit_game
+
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "properties.ui"))
 class Properties(Gtk.Dialog):
@@ -31,7 +31,8 @@ class Properties(Gtk.Dialog):
     label_game_description = Gtk.Template.Child()
 
     def __init__(self, parent, game, api):
-        Gtk.Dialog.__init__(self, title=_("Properties of {}").format(game.name), parent=parent.parent.parent, modal=True)
+        Gtk.Dialog.__init__(self, title=_("Properties of {}").format(game.name), parent=parent.parent.parent,
+                            modal=True)
         self.parent = parent
         self.game = game
         self.api = api
@@ -80,7 +81,7 @@ class Properties(Gtk.Dialog):
     def on_menu_button_support(self, widget):
         try:
             webbrowser.open(self.api.get_info(self.game)['links']['support'], new=2)
-        except:
+        except webbrowser.Error:
             self.parent.parent.show_error(
                 _("Couldn't open support page"),
                 _("Please check your internet connection")
@@ -90,7 +91,7 @@ class Properties(Gtk.Dialog):
     def on_menu_button_store(self, widget):
         try:
             webbrowser.open(self.gogBaseUrl + self.game.url)
-        except:
+        except webbrowser.Error:
             self.parent.parent.show_error(
                 _("Couldn't open store page"),
                 _("Please check your internet connection")

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -10,6 +10,7 @@ from gi.repository.GdkPixbuf import Pixbuf, InterpType
 from minigalaxy.paths import UI_DIR, THUMBNAIL_DIR
 from minigalaxy.translation import _
 from minigalaxy.launcher import config_game, regedit_game
+from minigalaxy.config import Config
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "properties.ui"))
@@ -111,12 +112,22 @@ class Properties(Gtk.Dialog):
             GLib.idle_add(self.image.set_from_file, thumbnail_path)
 
     def load_description(self):
+        lang = Config.get("lang")
         if self.gamesdb_info["summary"]:
-            description_len = 500
-            if len(self.gamesdb_info["summary"]) > description_len:
-                description = "{}...".format(self.gamesdb_info["summary"][:description_len])
+            desc_lang = "*"
+            for summary_key in self.gamesdb_info["summary"].keys():
+                if lang in summary_key:
+                    desc_lang = summary_key
+            description_len = 470
+            if len(self.gamesdb_info["summary"][desc_lang]) > description_len:
+                description = "{}...".format(self.gamesdb_info["summary"][desc_lang][:description_len])
             else:
-                description = self.gamesdb_info["summary"]
+                description = self.gamesdb_info["summary"][desc_lang]
+            genre_lang = "*"
+            for genre_key in self.gamesdb_info["genre"].keys():
+                if lang in genre_key:
+                    genre_lang = genre_key
+            description = "{}: {}\n{}".format(_("Genre"), self.gamesdb_info["genre"][genre_lang], description)
             GLib.idle_add(self.label_game_description.set_text, description)
 
     def button_sensitive(self, game):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ m_config = MagicMock()
 sys.modules['minigalaxy.constants'] = m_constants
 sys.modules['minigalaxy.config'] = m_config
 from minigalaxy.api import Api
+from minigalaxy.game import Game
 
 API_GET_INFO_TOONSTRUCK = {'downloads': {'installers': [{'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]},
                                     {'id': 'installer_mac_en', 'name': 'Toonstruck', 'os': 'mac', 'language': 'en', 'language_full': 'English', 'version': 'gog-3', 'total_size': 975175680, 'files': [{'id': 'en2installer0', 'size': 975175680, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en2installer0'}]},
@@ -49,8 +50,9 @@ class TestApi(TestCase):
         api.get_info = MagicMock()
         api.get_info.return_value = API_GET_INFO_TOONSTRUCK
         m_config.Config.get.return_value = "pl"
+        test_game = Game("Test Game")
         exp = {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]}
-        obs = api.get_download_info("Test Game")
+        obs = api.get_download_info(test_game)
         self.assertEqual(exp, obs)
 
     def test2_get_download_info(self):
@@ -58,8 +60,9 @@ class TestApi(TestCase):
         api.get_info = MagicMock()
         api.get_info.return_value = API_GET_INFO_TOONSTRUCK
         m_config.Config.get.return_value = "fr"
+        test_game = Game("Test Game")
         exp = {'id': 'installer_linux_fr', 'name': 'Toonstruck', 'os': 'linux', 'language': 'fr', 'language_full': 'français', 'version': 'gog-2', 'total_size': 1011875840, 'files': [{'id': 'fr3installer0', 'size': 1011875840, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr3installer0'}]}
-        obs = api.get_download_info("Test Game")
+        obs = api.get_download_info(test_game)
         self.assertEqual(exp, obs)
     
     def test3_get_download_info(self):
@@ -70,16 +73,18 @@ class TestApi(TestCase):
                                     {'id': 'installer_windows_fr', 'name': 'Toonstruck', 'os': 'windows', 'language': 'fr', 'language_full': 'français', 'version': '1.0', 'total_size': 985661440, 'files': [{'id': 'fr1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer0'}, {'id': 'fr1installer1', 'size': 984612864, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer1'}]},
                                     {'id': 'installer_mac_fr', 'name': 'Toonstruck', 'os': 'mac', 'language': 'fr', 'language_full': 'français', 'version': 'gog-3', 'total_size': 1023410176, 'files': [{'id': 'fr2installer0', 'size': 1023410176, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr2installer0'}]}]}}
         m_config.Config.get.return_value = "en"
+        test_game = Game("Test Game")
         exp = {'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]}
-        obs = api.get_download_info("Test Game")
+        obs = api.get_download_info(test_game)
         self.assertEqual(exp, obs)
 
     def test4_get_download_info(self):
         api = Api()
         dlc_test_installer = API_GET_INFO_TOONSTRUCK["downloads"]["installers"]
         m_config.Config.get.return_value = "en"
+        test_game = Game("Test Game")
         exp = {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]}
-        obs = api.get_download_info("Test Game", dlc_installers=dlc_test_installer)
+        obs = api.get_download_info(test_game, dlc_installers=dlc_test_installer)
         self.assertEqual(exp, obs)
 
     def test1_get_library(self):
@@ -96,21 +101,19 @@ class TestApi(TestCase):
 
     def test1_get_version(self):
         api = Api()
-        game = MagicMock()
-        game.platform = "linux"
+        test_game = Game("Test Game", platform="linux")
         exp = "gog-2"
-        obs = api.get_version(game, gameinfo=API_GET_INFO_TOONSTRUCK)
+        obs = api.get_version(test_game, gameinfo=API_GET_INFO_TOONSTRUCK)
         self.assertEqual(exp, obs)
 
     def test2_get_version(self):
         api = Api()
-        game = MagicMock()
-        game.platform = "linux"
+        test_game = Game("Test Game", platform="linux")
         dlc_name = "Test DLC"
         game_info = API_GET_INFO_TOONSTRUCK
         game_info["expanded_dlcs"] = [{"title": dlc_name, "downloads": {"installers": [{"os": "linux", "version": "1.2.3.4"}]}}]
         exp = "1.2.3.4"
-        obs = api.get_version(game, gameinfo=API_GET_INFO_TOONSTRUCK, dlc_name=dlc_name)
+        obs = api.get_version(test_game, gameinfo=API_GET_INFO_TOONSTRUCK, dlc_name=dlc_name)
         self.assertEqual(exp, obs)
 
     def test_get_download_file_md5(self):
@@ -125,6 +128,24 @@ class TestApi(TestCase):
 </file>'''
         exp = "8acedf66c0d2986e7dee9af912b7df4f"
         obs = api.get_download_file_md5("url")
+        self.assertEqual(exp, obs)
+
+    def test1_get_gamesdb_info(self):
+        api = Api()
+        api._Api__request_gamesdb = MagicMock()
+        api._Api__request_gamesdb.side_effect = [{}]
+        test_game = Game("Test Game")
+        exp = {"cover": "", "vertical_cover": "", "background": "", "genre": {}, "summary": {}}
+        obs = api.get_gamesdb_info(test_game)
+        self.assertEqual(exp, obs)
+
+    def test2_get_gamesdb_info(self):
+        api = Api()
+        api._Api__request_gamesdb = MagicMock()
+        api._Api__request_gamesdb.side_effect = [{'id': '51622789000874509', 'game_id': '51154268886064420', 'platform_id': 'gog', 'external_id': '1508702879', 'game': {'genres': [{'id': '51071904337940794', 'name': {'*': 'Strategy', 'en-US': 'Strategy'}, 'slug': 'strategy'}], 'summary': {'*': 'Stellaris description'}, 'visible_in_library': True, 'aggregated_rating': 78.5455, 'game_modes': [{'id': '53051895165351137', 'name': 'Single player', 'slug': 'single-player'}, {'id': '53051908711988230', 'name': 'Multiplayer', 'slug': 'multiplayer'}], 'horizontal_artwork': {'url_format': 'https://images.gog.com/742acfb77ec51ca48c9f96947bf1fc0ad8f0551c9c9f338021e8baa4f08e449f{formatter}.{ext}?namespace=gamesdb'}, 'background': {'url_format': 'https://images.gog.com/742acfb77ec51ca48c9f96947bf1fc0ad8f0551c9c9f338021e8baa4f08e449f{formatter}.{ext}?namespace=gamesdb'}, 'vertical_cover': {'url_format': 'https://images.gog.com/8d822a05746670fb2540e9c136f0efaed6a2d5ab698a9f8bd7f899d21f2022d2{formatter}.{ext}?namespace=gamesdb'}, 'cover': {'url_format': 'https://images.gog.com/8d822a05746670fb2540e9c136f0efaed6a2d5ab698a9f8bd7f899d21f2022d2{formatter}.{ext}?namespace=gamesdb'}, 'logo': {'url_format': 'https://images.gog.com/c50a5d26c42d84b4b884976fb89d10bb3e97ebda0c0450285d92b8c50844d788{formatter}.{ext}?namespace=gamesdb'}, 'icon': {'url_format': 'https://images.gog.com/c85cf82e6019dd52fcdf1c81d17687dd52807835f16aa938abd2a34e5d9b99d0{formatter}.{ext}?namespace=gamesdb'}, 'square_icon': {'url_format': 'https://images.gog.com/c3adc81bf37f1dd89c9da74c13967a08b9fd031af4331750dbc65ab0243493c8{formatter}.{ext}?namespace=gamesdb'}}}]
+        test_game = Game("Stellaris")
+        exp = {'cover': 'https://images.gog.com/8d822a05746670fb2540e9c136f0efaed6a2d5ab698a9f8bd7f899d21f2022d2.png?namespace=gamesdb', 'vertical_cover': 'https://images.gog.com/8d822a05746670fb2540e9c136f0efaed6a2d5ab698a9f8bd7f899d21f2022d2.png?namespace=gamesdb', 'background': 'https://images.gog.com/742acfb77ec51ca48c9f96947bf1fc0ad8f0551c9c9f338021e8baa4f08e449f.png?namespace=gamesdb', 'summary': {'*': 'Stellaris description'}, 'genre': {'*': 'Strategy', 'en-US': 'Strategy'}}
+        obs = api.get_gamesdb_info(test_game)
         self.assertEqual(exp, obs)
 
 


### PR DESCRIPTION
This pull request is to address #106
It is done by redesigning Properties Window, which can be also shown for not installed games.
My vision is pretty much complete so I am ready for some output if look needs some changes:
![new_properties](https://user-images.githubusercontent.com/1833284/113886878-4d855c80-97c1-11eb-980a-8fe6b7755317.png)
This is only draft as code still needs some polish:
- offline mode won't work
- no unit tests
- some PEP-8 improvements should be also put here
- description is available in multiple languages, so we should use it
- Do we want to download picture asynchronous from the rest of the window (performance)?

So what do you think about it?