### PR TITLE
Fix error with empty library

### DIFF
--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -144,13 +144,12 @@ class Library(Gtk.Viewport):
         return games
 
     def __add_games_from_api(self):
-        retrieved_games = self.api.get_library()
-        if retrieved_games:
+        retrieved_games, err_msg = self.api.get_library()
+        if not err_msg:
             self.offline = False
         else:
-            retrieved_games = []
             self.offline = True
-            GLib.idle_add(self.parent.show_error, _("Failed to retrieve library"), _("Couldn't connect to GOG servers"))
+            GLib.idle_add(self.parent.show_error, _("Failed to retrieve library"), _(err_msg))
         for game in retrieved_games:
             if game not in self.games:
                 self.games.append(game)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -84,14 +84,26 @@ class TestApi(TestCase):
 
     def test1_get_library(self):
         api = Api()
-        api.active_token = "True"
+        api.active_token = True
         response_dict = {'totalPages': 1, 'products': [{'id': 1097893768, 'title': 'Neverwinter Nights: Enhanced Edition', 'image': '//images-2.gog-statics.com/8706f7fb87a4a41bc34254f3b49f59f96cf13d067b2c8bbfd8d41c327392052a', 'url': '/game/neverwinter_nights_enhanced_edition_pack', 'worksOn': {'Windows': True, 'Mac': True, 'Linux': True}}]}
         api.active_token_expiration_time = time.time() + 10.0
         response_mock = MagicMock()
         response_mock.json.return_value = response_dict
         m_constants.SESSION.get.return_value = response_mock
         exp = "Neverwinter Nights: Enhanced Edition"
-        obs = api.get_library()[0].name
+        retrieved_games, err_msg = api.get_library()
+        obs = retrieved_games[0].name
+        self.assertEqual(exp, obs)
+
+    def test2_get_library(self):
+        api = Api()
+        api.active_token = False
+        api.active_token_expiration_time = time.time() + 10.0
+        response_mock = MagicMock()
+        response_mock.json.return_value = {}
+        m_constants.SESSION.get.return_value = response_mock
+        exp = "Couldn't connect to GOG servers"
+        retrieved_games, obs = api.get_library()
         self.assertEqual(exp, obs)
 
     def test1_get_version(self):

--- a/tests/test_ui_library.py
+++ b/tests/test_ui_library.py
@@ -65,8 +65,9 @@ class TestLibrary(TestCase):
         api_games = []
         for game in API_GAMES:
             api_games.append(Game(name=game, game_id=int(API_GAMES[game]),))
+        err_msg = ""
         api_mock = MagicMock()
-        api_mock.get_library.return_value = api_games
+        api_mock.get_library.return_value = api_games, err_msg
         test_library = Library(MagicMock(), api_mock)
         test_library.games = self_games
         test_library._Library__add_games_from_api()
@@ -81,8 +82,9 @@ class TestLibrary(TestCase):
         api_games = []
         for game in API_GAMES:
             api_games.append(Game(name=game, game_id=int(API_GAMES[game]),))
+        err_msg = ""
         api_mock = MagicMock()
-        api_mock.get_library.return_value = api_games
+        api_mock.get_library.return_value = api_games, err_msg
         test_library = Library(MagicMock(), api_mock)
         test_library.games = self_games
         test_library._Library__add_games_from_api()
@@ -100,8 +102,9 @@ class TestLibrary(TestCase):
             api_games.append(Game(name=game, game_id=int(API_GAMES[game]),))
         api_gmae_with_id = Game(name="Game without ID", game_id=1234567890)
         api_games.append(api_gmae_with_id)
+        err_msg = ""
         api_mock = MagicMock()
-        api_mock.get_library.return_value = api_games
+        api_mock.get_library.return_value = api_games, err_msg
         test_library = Library(MagicMock(), api_mock)
         test_library.games = self_games
         test_library._Library__add_games_from_api()
@@ -121,8 +124,9 @@ class TestLibrary(TestCase):
         for game in API_GAMES:
             api_games.append(Game(name=game, game_id=int(API_GAMES[game]), url="http://test_url{}".format(str(url_nr))))
             url_nr += 1
+        err_msg = ""
         api_mock = MagicMock()
-        api_mock.get_library.return_value = api_games
+        api_mock.get_library.return_value = api_games, err_msg
         test_library = Library(MagicMock(), api_mock)
         test_library.games = self_games
         test_library._Library__add_games_from_api()


### PR DESCRIPTION
This pull request is to address issue #271 
Empty retrieved_games list is no reason to display errors (user for example can have only Windows games, which are not displayed by default).
But I still want to preserve possibility for get_library() to return error message if something went wrong. As a result I moved some things a little bit around.