### PR TITLE
Game version in Properties

### DIFF
--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -118,6 +118,7 @@ class Properties(Gtk.Dialog):
             GLib.idle_add(self.image.set_from_file, thumbnail_path)
 
     def load_description(self):
+        description = ""
         lang = Config.get("lang")
         if self.gamesdb_info["summary"]:
             desc_lang = "*"
@@ -134,7 +135,9 @@ class Properties(Gtk.Dialog):
                 if lang in genre_key:
                     genre_lang = genre_key
             description = "{}: {}\n{}".format(_("Genre"), self.gamesdb_info["genre"][genre_lang], description)
-            GLib.idle_add(self.label_game_description.set_text, description)
+        if self.game.is_installed:
+            description = "{}: {}\n{}".format(_("Version"), self.game.get_info("version"), description)
+        GLib.idle_add(self.label_game_description.set_text, description)
 
     def button_sensitive(self, game):
         if not game.is_installed():

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -135,7 +135,7 @@ class Properties(Gtk.Dialog):
                 if lang in genre_key:
                     genre_lang = genre_key
             description = "{}: {}\n{}".format(_("Genre"), self.gamesdb_info["genre"][genre_lang], description)
-        if self.game.is_installed:
+        if self.game.is_installed():
             description = "{}: {}\n{}".format(_("Version"), self.game.get_info("version"), description)
         GLib.idle_add(self.label_game_description.set_text, description)
 


### PR DESCRIPTION
After yesterdays big Stellaris update, I figured out that it would be great if game version would be displayed in Properties for installed games.
![version](https://user-images.githubusercontent.com/1833284/114988519-b5f5cd00-9e96-11eb-88af-2f6c1c7334d3.png)
