### PR TITLE
Adapting Windows games to run native Linux

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 import requests
 import xml.etree.ElementTree as ET
 from minigalaxy.game import Game
-from minigalaxy.constants import IGNORE_GAME_IDS, SESSION
+from minigalaxy.constants import IGNORE_GAME_IDS, ADAPTED_GAMES, SESSION
 from minigalaxy.config import Config
 
 
@@ -84,13 +84,15 @@ class Api:
                 }
                 response = self.__request(url, params=params)
                 total_pages = response["totalPages"]
-
+                adapted_games_ids = []
+                for adapted_game in ADAPTED_GAMES:
+                    adapted_games_ids.append(adapted_game["id"])
                 for product in response["products"]:
                     if product["id"] not in IGNORE_GAME_IDS:
                         # Only support Linux unless the show_windows_games setting is enabled
                         if product["worksOn"]["Linux"]:
                             platform = "linux"
-                        elif Config.get("show_windows_games"):
+                        elif Config.get("show_windows_games") or product["id"] in adapted_games_ids:
                             platform = "windows"
                         else:
                             continue

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -46,6 +46,11 @@ IGNORE_GAME_IDS = [
     1486144755,  # Cyberpunk 2077 Goodies Collection
 ]
 
+# GOG provides only Windows support for those games, but we can make them native on Linux
+ADAPTED_GAMES = [
+    {"name": "Theme Hospital", "id": 1207659026, "require": ["dosbox"]}
+]
+
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB
 
 # This is the file size needed for the download manager to consider resuming worthwhile

--- a/minigalaxy/custom_installers/theme_hospital.py
+++ b/minigalaxy/custom_installers/theme_hospital.py
@@ -1,0 +1,42 @@
+import os
+
+
+def start(game):
+    err_msg = ""
+    create_save_dir(game)
+    change_language_to_en(game)
+    create_start_script(game)
+    return err_msg
+
+
+def create_save_dir(game):
+    hospital_saves_dir = os.path.join(game.install_dir, "SAVE")
+    if not os.path.isdir(hospital_saves_dir):
+        os.makedirs(hospital_saves_dir)
+
+
+def change_language_to_en(game):
+    hospital_cfg_file = os.path.join(game.install_dir, "HOSPITAL.CFG")
+    if os.path.isfile(hospital_cfg_file):
+        cfg_file = open(hospital_cfg_file, "r")
+        cfg_content = cfg_file.readlines()
+        cfg_file.close()
+        cfg_content_mod = []
+        for cfg_line in cfg_content:
+            if "LANGUAGE=" in cfg_line:
+                cfg_content_mod.append("LANGUAGE=EN\n")
+            else:
+                cfg_content_mod.append(cfg_line)
+        cfg_file = open(hospital_cfg_file, "w")
+        for cfg_line in cfg_content_mod:
+            cfg_file.write(cfg_line)
+        cfg_file.close()
+
+
+def create_start_script(game):
+    hospital_start_file = os.path.join(game.install_dir, "minigalaxy-start.sh")
+    start_script = '#!/bin/bash\ndosbox  "{}/HOSPITAL.EXE" -exit -fullscreen'.format(game.install_dir)
+    start_file = open(hospital_start_file, "w")
+    start_file.write(start_script)
+    start_file.close()
+    os.chmod(hospital_start_file, 0o775)

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -1,9 +1,11 @@
 import os
 import re
 import json
+import shutil
 
 from minigalaxy.config import Config
 from minigalaxy.paths import CONFIG_GAMES_DIR
+from minigalaxy.constants import ADAPTED_GAMES
 
 
 class Game:
@@ -19,6 +21,7 @@ class Game:
         self.dlcs = [] if dlcs is None else dlcs
         self.status_file_name = "{}.json".format(self.get_install_directory_name())
         self.status_file_path = os.path.join(CONFIG_GAMES_DIR, self.status_file_name)
+        self.adapted = self.get_is_adapted()
 
     def get_stripped_name(self):
         return self.__strip_string(self.name)
@@ -80,6 +83,26 @@ class Game:
         else:
             version = "0"
         return version
+
+    def get_is_adapted(self):
+        is_adapted = False
+        adapted_names = []
+        adapted_require = []
+        adapted_game_nr = -1
+        for adapted_game in ADAPTED_GAMES:
+            adapted_game_nr += 1
+            adapted_names.append(adapted_game["name"])
+            adapted_require.append(adapted_game["require"])
+        if self.platform == "windows":
+            if self.get_info("adapted"):
+                is_adapted = True
+            elif not self.is_installed() and self.name in adapted_names:
+                is_adapted = True
+        if is_adapted:
+            for require in adapted_require[adapted_game_nr]:
+                if not shutil.which(require):
+                    is_adapted = False
+        return is_adapted
 
     def set_info(self, key, value):
         json_dict = self.load_minigalaxy_info_json()

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -8,6 +8,7 @@ from minigalaxy.constants import SESSION, DOWNLOAD_CHUNK_SIZE
 from minigalaxy.translation import _
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR
 from minigalaxy.config import Config
+from minigalaxy.custom_installers import theme_hospital
 
 
 def install_game(game, installer):
@@ -181,5 +182,7 @@ def extract_by_wine(game, installer, temp_dir):
 def additional_configuration(game):
     err_msg = ""
     if game.adapted:
+        if game.id in [1207659026]:
+            err_msg = theme_hospital.start(game)
         game.set_info("adapted", True)
     return err_msg

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -38,7 +38,7 @@ def start_game(game):
 
 def get_execute_command(game) -> list:
     files = os.listdir(game.install_dir)
-    launcher_type = determine_launcher_type(files)
+    launcher_type = determine_launcher_type(game, files)
     if launcher_type in ["windows"]:
         exe_cmd = get_windows_exe_cmd(game, files)
     elif launcher_type in ["dosbox"]:
@@ -47,6 +47,8 @@ def get_execute_command(game) -> list:
         exe_cmd = get_scummvm_exe_cmd(game, files)
     elif launcher_type in ["start_script", "wine"]:
         exe_cmd = get_start_script_exe_cmd(game, files)
+    elif launcher_type in ["adapted"]:
+        exe_cmd = get_adapted_exe_cmd(game, files)
     elif launcher_type in ["final_resort"]:
         exe_cmd = get_final_resort_exe_cmd(game, files)
     else:
@@ -56,9 +58,11 @@ def get_execute_command(game) -> list:
     return exe_cmd
 
 
-def determine_launcher_type(files):
+def determine_launcher_type(game, files):
     launcher_type = "unknown"
-    if "unins000.exe" in files:
+    if "minigalaxy-start.sh" in files and game.adapted:
+        launcher_type = "adapted"
+    elif "unins000.exe" in files:
         launcher_type = "windows"
     elif "dosbox" in files and shutil.which("dosbox"):
         launcher_type = "dosbox"
@@ -137,6 +141,12 @@ def get_scummvm_exe_cmd(game, files):
 
 def get_start_script_exe_cmd(game, files):
     start_sh = "start.sh"
+    exec_start = [os.path.join(game.install_dir, start_sh)] if start_sh in files else [""]
+    return exec_start
+
+
+def get_adapted_exe_cmd(game, files):
+    start_sh = "minigalaxy-start.sh"
     exec_start = [os.path.join(game.install_dir, start_sh)] if start_sh in files else [""]
     return exec_start
 

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -77,7 +77,7 @@ class GameTile(Gtk.Box):
         self.resume_download_if_expected()
 
         # Icon for Windows games
-        if self.game.platform == "windows":
+        if self.game.platform == "windows" and not self.game.adapted:
             self.image.set_tooltip_text("{} (Wine)".format(self.game.name))
             self.wine_icon.set_from_file(ICON_WINE_PATH)
             self.wine_icon.show()


### PR DESCRIPTION
At this point it is proof of concept, that requires further development.

It works like this:
In constants.py beside "IGNORE_GAME_IDS" there is also "ADAPTED_GAMES", which is the list of games that are adapted to nativly run on Linux. For each game, list contains info about its name, id and require. In case of Theme Hospital, the requirement is dosbox. If requirement is met, the game is listed with other native titles (no wine icon, etc.):
![innoextract1a](https://user-images.githubusercontent.com/1833284/114992849-7b426380-9e9b-11eb-86ce-222ff09c77f7.png)
When "download" button is pressed, game is normally downloaded:
![innoextract2a](https://user-images.githubusercontent.com/1833284/114992968-9ca34f80-9e9b-11eb-90f9-c51234e71859.png)
then innoextract (downloaded from web) is used to extract game data.
During installation, there is additional step "additional_configuration()", which will run custom script for each adapted game. Script will result in creating "minigalaxy-start.sh" which will be universal name for scripts to launch adapted games.
When you press "play" this script will run:
![innoextract4b](https://user-images.githubusercontent.com/1833284/114993922-906bc200-9e9c-11eb-8076-214c69e143f4.png)

So what now?
- Switching between extracting Windows games by wine and innoextract requires improvements.
- Choosing between Linux, Windows and Adapted game version needs to be added to "Properties".
- Add unit tests.
- Add more games to this mechanic.

This is still early stage, so I am curious about your opinion. At this point it will be still easy to change some stuffs.