### PR TITLE
Remove game config together with game uninstall.

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -139,3 +139,5 @@ def remove_installer(installer):
 
 def uninstall_game(game):
     shutil.rmtree(game.install_dir, ignore_errors=True)
+    if os.path.isfile(game.status_file_path):
+        os.remove(game.status_file_path)


### PR DESCRIPTION
When game config was in game directory it was removed together with game uninstall.
Now it stays even if game is uninstalled.
Some really bad consequences of this behaviour is that DLC info is stored in this config file. So if game is installed again (without DLCs), Minigalaxy will think that DLCs are installed, because it will use old config.

This pull request solves this issue by removing game config file together with game uninstall.