### PR TITLE
Workaround for Wasteland 3.

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 import requests
 import xml.etree.ElementTree as ET
 from minigalaxy.game import Game
-from minigalaxy.constants import IGNORE_GAME_IDS, SESSION
+from minigalaxy.constants import IGNORE_GAME_IDS, SESSION, SUPPORTED_GAME_IDS
 from minigalaxy.config import Config
 
 
@@ -88,7 +88,7 @@ class Api:
                 for product in response["products"]:
                     if product["id"] not in IGNORE_GAME_IDS:
                         # Only support Linux unless the show_windows_games setting is enabled
-                        if product["worksOn"]["Linux"]:
+                        if product["worksOn"]["Linux"] or product["id"] in SUPPORTED_GAME_IDS:
                             platform = "linux"
                         elif Config.get("show_windows_games"):
                             platform = "windows"

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -46,6 +46,10 @@ IGNORE_GAME_IDS = [
     2005648906,  # Spring Sale Goodies Collection #1
     1486144755,  # Cyberpunk 2077 Goodies Collection
 ]
+# Due to GOG bugs those games provides Linux installers but don't report Linux as supported OS
+SUPPORTED_GAME_IDS = [
+    2057748185,  # Wasteland 3
+]
 
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB
 


### PR DESCRIPTION
Wasteland 3 does provide installers for Linux but Api informs that Linux is not supported:
"
{"isGalaxyCompatible":true,"tags":[],"id":2057748185,"availability":{"isAvailable":false,"isAvailableInAccount":true},"title":"Wasteland 3","image":"\/\/images-3.gog-statics.com\/98c31dc241550da776013bd669c95fc349ac7a73ecec568a6bf0595490b4b91b","url":"\/game\/wasteland_3_deluxe_edition","worksOn":{"Windows":true,"Mac":false,**"Linux":false**},"category":"Role-playing","rating":0,"isComingSoon":false,"isMovie":false,"isGame":true,"slug":"wasteland_3_game","updates":0,"isNew":false,"dlcCount":0,"releaseDate":{"date":"2020-08-28 00:00:00.000000","timezone_type":3,"timezone":"Europe\/Nicosia"},"isBaseProductMissing":false,"isHidingDisabled":false,"isInDevelopment":false,"isHidden":false}],"updatedProductsCount":20,"hiddenUpdatedProductsCount":0,"appliedFilters":{"tags":null},"hasHiddenProducts":true}
"
I have reported this issue to GOG support.
In a meanwhile I propose to workaround this issue with this pull request.