### PR TITLE
Show Uninstall button after game installation.

### DIFF
--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -511,6 +511,7 @@ class GameTile(Gtk.Box):
         self.button.set_sensitive(True)
         self.image.set_sensitive(True)
         self.menu_button.show()
+        self.menu_button_uninstall.show()
         self.button_cancel.hide()
         self.game.set_install_dir()
 


### PR DESCRIPTION
At the moment after game installation "Uninstall" button remain hidden. Uninstall button is only shown after Minigalaxy restart.

This pull request fixes this isssue by showing "Uninstall" button, when gametile status is changed to "installed".