### PR TITLE
Adds creation of desktop icons to Preferences dialog

### DIFF
--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -316,9 +316,6 @@
             <child>
               <placeholder/>
             </child>
-            <child>
-              <placeholder/>
-            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -51,7 +51,7 @@
           </packing>
         </child>
         <child>
-          <!-- n-columns=2 n-rows=7 -->
+          <!-- n-columns=3 n-rows=8 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -265,6 +265,41 @@
                 <property name="left-attach">1</property>
                 <property name="top-attach">7</property>
               </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="switch_create_applications_file">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="show_windows_games_tooltip">Whether shortcuts are created for newly installed games or not</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="show_windows_games" comments="Has to end with &quot;: &quot;">Create desktop shortcuts: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
             </child>
             <child>
               <placeholder/>

--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -293,6 +293,41 @@
               </packing>
             </child>
             <child>
+              <object class="GtkSwitch" id="switch_create_applications_file">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="show_windows_games_tooltip">Whether shortcuts are created for newly installed games or not</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="show_windows_games" comments="Has to end with &quot;: &quot;">Create desktop shortcuts: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
               <placeholder/>
             </child>
             <child>

--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -51,7 +51,7 @@
           </packing>
         </child>
         <child>
-          <!-- n-columns=3 n-rows=8 -->
+          <!-- n-columns=3 n-rows=9 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -275,7 +275,7 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">7</property>
+                <property name="top-attach">8</property>
               </packing>
             </child>
             <child>
@@ -289,40 +289,8 @@
               </object>
               <packing>
                 <property name="left-attach">0</property>
-                <property name="top-attach">7</property>
+                <property name="top-attach">8</property>
               </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="switch_create_applications_file">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="show_windows_games_tooltip">Whether shortcuts are created for newly installed games or not</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="show_windows_games" comments="Has to end with &quot;: &quot;">Create desktop shortcuts: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
             </child>
             <child>
               <placeholder/>

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -56,7 +56,8 @@ DEFAULT_CONFIGURATION = {
     "show_hidden_games": False,
     "show_windows_games": False,
     "keep_window_maximized": False,
-    "installed_filter": False
+    "installed_filter": False,
+    "create_applications_file": False
 }
 
 # Game IDs to ignore when received by the API

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -39,7 +39,7 @@ def check_diskspace(required_size, location):
     return diskspace_available >= installed_game_size
 
 
-def install_game(game, installer):
+def install_game(game, installer): # noqa: C901
     error_message = ""
     tmp_dir = ""
     if not error_message:

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -57,7 +57,7 @@ def install_game(game, installer):
     if not error_message:
         error_message = create_applications_file(game)
     if not error_message:
-        error_message = remove_installer(installer)
+        error_message = remove_installer(game, installer)
     else:
         remove_installer(game, installer)
     if not error_message:
@@ -208,9 +208,13 @@ def create_applications_file(game):
     error_message = ""
     if Config.get("create_applications_file"):
         path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
+        exe_cmd_list = get_execute_command(game)
+        for element in exe_cmd_list:
+          element = element.replace(" ", "\\ ")
+        exe_cmd = element
         # Create desktop file definition
         desktop_context = {
-            "game_bin_path": get_execute_command(game),
+            "game_bin_path": exe_cmd,
             "game_name": game.name,
             "game_icon_path": os.path.join(game.install_dir, 'support/icon.png')
             }
@@ -219,7 +223,7 @@ def create_applications_file(game):
             Type=Application
             Terminal=false
             StartupNotify=true
-            Exec="{game_bin_path}"
+            Exec=/bin/bash -c "{game_bin_path}"
             Name={game_name}
             Icon={game_icon_path}""".format(**desktop_context)
         if not os.path.isfile(path_to_shortcut):
@@ -246,33 +250,6 @@ def remove_installer(game, installer):
         shutil.rmtree(installer_directory, ignore_errors=True)
     else:
         error_message = "No installer directory is present: {}".format(installer_directory)
-    if Config.get("create_applications_file") and not error_message:
-        path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
-        exe_cmd_list = get_execute_command(game)
-        for element in exe_cmd_list:
-          element = element.replace(" ", "\\ ")
-        exe_cmd = element
-        # Create desktop file definition
-        desktop_context = {
-            "game_bin_path": exe_cmd,
-            "game_name": game.name,
-            "game_icon_path": os.path.join(game.install_dir, 'support/icon.png')
-            }
-        desktop_definition = """\
-            [Desktop Entry]
-            Type=Application
-            Terminal=false
-            StartupNotify=true
-            Exec=/bin/bash -c "{game_bin_path}"
-            Name={game_name}
-            Icon={game_icon_path}""".format(**desktop_context)
-        if not os.path.isfile(path_to_shortcut):
-            try:
-                with open(path_to_shortcut, 'w+') as desktop_file:
-                    desktop_file.writelines(textwrap.dedent(desktop_definition))
-            except Exception as e:
-                os.remove(path_to_shortcut)
-                error_message = e
     return error_message
 
 

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -215,9 +215,13 @@ def create_applications_file(game):
     error_message = ""
     if Config.get("create_applications_file"):
         path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
+        exe_cmd_list = get_execute_command(game)
+        for element in exe_cmd_list:
+          element = element.replace(" ", "\\ ")
+        exe_cmd = element
         # Create desktop file definition
         desktop_context = {
-            "game_bin_path": get_execute_command(game),
+            "game_bin_path": exe_cmd,
             "game_name": game.name,
             "game_icon_path": os.path.join(game.install_dir, 'support/icon.png')
             }
@@ -226,7 +230,7 @@ def create_applications_file(game):
             Type=Application
             Terminal=false
             StartupNotify=true
-            Exec="{game_bin_path}"
+            Exec=/bin/bash -c "{game_bin_path}"
             Name={game_name}
             Icon={game_icon_path}""".format(**desktop_context)
         if not os.path.isfile(path_to_shortcut):

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -4,6 +4,7 @@ import subprocess
 import hashlib
 import textwrap
 from minigalaxy.translation import _
+from minigalaxy.launcher import get_execute_command
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, APPLICATIONS_DIR
 from minigalaxy.config import Config
 
@@ -209,12 +210,11 @@ def copy_thumbnail(game):
 
 def create_applications_file(game):
     error_message = ""
-    preferences_switch = Config.get("create_applications_file")
-    if game.platform == "linux" and preferences_switch:
+    if Config.get("create_applications_file"):
         path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
         # Create desktop file definition
         desktop_context = {
-            "game_bin_path": os.path.join(game.install_dir, 'start.sh'),
+            "game_bin_path": get_execute_command(game),
             "game_name": game.name,
             "game_icon_path": os.path.join(game.install_dir, 'support/icon.png')
             }

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -204,14 +204,18 @@ def copy_thumbnail(game):
     return error_message
 
 
+def get_exec_line(game):
+    exe_cmd_list = get_execute_command(game)
+    for i in range(len(exe_cmd_list)):
+        exe_cmd_list[i] = exe_cmd_list[i].replace(" ", "\\ ")
+    return " ".join(exe_cmd_list)
+
+
 def create_applications_file(game):
     error_message = ""
     if Config.get("create_applications_file"):
         path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
-        exe_cmd_list = get_execute_command(game)
-        for element in exe_cmd_list:
-            element = element.replace(" ", "\\ ")
-        exe_cmd = element
+        exe_cmd = get_exec_line(game)
         # Create desktop file definition
         desktop_context = {
             "game_bin_path": exe_cmd,

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -4,7 +4,10 @@ import subprocess
 import hashlib
 import textwrap
 from minigalaxy.translation import _
+<<<<<<< HEAD
 from minigalaxy.launcher import get_execute_command
+=======
+>>>>>>> 3ce2e1f (adds create_desktop_dir option)
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, APPLICATIONS_DIR
 from minigalaxy.config import Config
 
@@ -56,8 +59,11 @@ def install_game(game, installer):
         error_message = copy_thumbnail(game)
     if not error_message:
 <<<<<<< HEAD
+<<<<<<< HEAD
         error_message = remove_installer(game, installer)
 =======
+=======
+>>>>>>> 3ce2e1f (adds create_desktop_dir option)
         error_message = create_applications_file(game)
     if not error_message:
         error_message = remove_installer(installer)

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -4,10 +4,7 @@ import subprocess
 import hashlib
 import textwrap
 from minigalaxy.translation import _
-<<<<<<< HEAD
 from minigalaxy.launcher import get_execute_command
-=======
->>>>>>> 3ce2e1f (adds create_desktop_dir option)
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, APPLICATIONS_DIR
 from minigalaxy.config import Config
 

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -211,7 +211,7 @@ def create_applications_file(game):
     error_message = ""
     preferences_switch = Config.get("create_applications_file")
     if game.platform == "linux" and preferences_switch:
-        path_to_shortcut = os.path.join(APPLICATIONS_DIR, game.name+".desktop")
+        path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
         # Create desktop file definition
         desktop_context = {
             "game_bin_path": os.path.join(game.install_dir, 'start.sh'),

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -3,6 +3,7 @@ import shutil
 import subprocess
 import hashlib
 import textwrap
+
 from minigalaxy.translation import _
 from minigalaxy.launcher import get_execute_command
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, APPLICATIONS_DIR
@@ -55,16 +56,7 @@ def install_game(game, installer):
     if not error_message:
         error_message = copy_thumbnail(game)
     if not error_message:
-<<<<<<< HEAD
-<<<<<<< HEAD
-        error_message = remove_installer(game, installer)
-=======
-=======
->>>>>>> 3ce2e1f (adds create_desktop_dir option)
         error_message = create_applications_file(game)
-    if not error_message:
-        error_message = remove_installer(installer)
->>>>>>> be2191d (adds create_desktop_dir option)
     else:
         remove_installer(game, installer)
     if not error_message:

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -210,7 +210,7 @@ def create_applications_file(game):
         path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
         exe_cmd_list = get_execute_command(game)
         for element in exe_cmd_list:
-          element = element.replace(" ", "\\ ")
+            element = element.replace(" ", "\\ ")
         exe_cmd = element
         # Create desktop file definition
         desktop_context = {

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -220,6 +220,7 @@ def create_applications_file(game):
         desktop_context = {
             "game_bin_path": exe_cmd,
             "game_name": game.name,
+            "game_install_dir": game.install_dir,
             "game_icon_path": os.path.join(game.install_dir, 'support/icon.png')
             }
         desktop_definition = """\
@@ -227,7 +228,8 @@ def create_applications_file(game):
             Type=Application
             Terminal=false
             StartupNotify=true
-            Exec=/bin/bash -c "{game_bin_path}"
+            Exec={game_bin_path}
+            Path={game_install_dir}
             Name={game_name}
             Icon={game_icon_path}""".format(**desktop_context)
         if not os.path.isfile(path_to_shortcut):

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -4,6 +4,7 @@ import subprocess
 import hashlib
 import textwrap
 from minigalaxy.translation import _
+from minigalaxy.launcher import get_execute_command
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, APPLICATIONS_DIR
 from minigalaxy.config import Config
 
@@ -205,12 +206,11 @@ def copy_thumbnail(game):
 
 def create_applications_file(game):
     error_message = ""
-    preferences_switch = Config.get("create_applications_file")
-    if game.platform == "linux" and preferences_switch:
+    if Config.get("create_applications_file"):
         path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
         # Create desktop file definition
         desktop_context = {
-            "game_bin_path": os.path.join(game.install_dir, 'start.sh'),
+            "game_bin_path": get_execute_command(game),
             "game_name": game.name,
             "game_icon_path": os.path.join(game.install_dir, 'support/icon.png')
             }

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -207,7 +207,7 @@ def create_applications_file(game):
     error_message = ""
     preferences_switch = Config.get("create_applications_file")
     if game.platform == "linux" and preferences_switch:
-        path_to_shortcut = os.path.join(APPLICATIONS_DIR, game.name+".desktop")
+        path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
         # Create desktop file definition
         desktop_context = {
             "game_bin_path": os.path.join(game.install_dir, 'start.sh'),

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -274,8 +274,8 @@ def uninstall_game(game):
     shutil.rmtree(game.install_dir, ignore_errors=True)
     if os.path.isfile(game.status_file_path):
         os.remove(game.status_file_path)
-    if os.path.isfile(os.path.join(APPLICATIONS_DIR, game.name+".desktop")):
-        os.remove(os.path.join(APPLICATIONS_DIR, game.name+".desktop"))
+    if os.path.isfile(os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))):
+        os.remove(os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name)))
 
 
 def _exe_cmd(cmd):

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -39,7 +39,7 @@ def check_diskspace(required_size, location):
     return diskspace_available >= installed_game_size
 
 
-def install_game(game, installer): # noqa: C901
+def install_game(game, installer):  # noqa: C901
     error_message = ""
     tmp_dir = ""
     if not error_message:

--- a/minigalaxy/paths.py
+++ b/minigalaxy/paths.py
@@ -11,6 +11,7 @@ CONFIG_FILE_PATH = os.path.join(CONFIG_DIR, "config.json")
 CACHE_DIR = os.path.join(os.getenv('XDG_CACHE_HOME', os.path.expanduser('~/.cache')), "minigalaxy")
 
 THUMBNAIL_DIR = os.path.join(CACHE_DIR, "thumbnails")
+APPLICATIONS_DIR = os.path.expanduser("~/.local/share/applications")
 DEFAULT_INSTALL_DIR = os.path.expanduser("~/GOG Games")
 
 UI_DIR = os.path.abspath(os.path.join(LAUNCH_DIR, "../data/ui"))

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -21,6 +21,7 @@ class Preferences(Gtk.Dialog):
     switch_stay_logged_in = Gtk.Template.Child()
     switch_show_hidden_games = Gtk.Template.Child()
     switch_show_windows_games = Gtk.Template.Child()
+    switch_create_applications_file = Gtk.Template.Child()
     switch_use_dark_theme = Gtk.Template.Child()
     button_cancel = Gtk.Template.Child()
     button_save = Gtk.Template.Child()
@@ -37,6 +38,7 @@ class Preferences(Gtk.Dialog):
         self.switch_use_dark_theme.set_active(Config.get("use_dark_theme"))
         self.switch_show_hidden_games.set_active(Config.get("show_hidden_games"))
         self.switch_show_windows_games.set_active(Config.get("show_windows_games"))
+        self.switch_create_applications_file.set_active(Config.get("create_applications_file"))
 
         # Set tooltip for keep installers label
         installer_dir = os.path.join(self.button_file_chooser.get_filename(), "installer")
@@ -151,6 +153,7 @@ class Preferences(Gtk.Dialog):
         Config.set("keep_installers", self.switch_keep_installers.get_active())
         Config.set("stay_logged_in", self.switch_stay_logged_in.get_active())
         Config.set("show_hidden_games", self.switch_show_hidden_games.get_active())
+        Config.set("create_applications_file", self.switch_create_applications_file.get_active())
         self.parent.library.filter_library()
 
         if self.switch_show_windows_games.get_active() != Config.get("show_windows_games"):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -272,3 +272,20 @@ class Test(TestCase):
         exp = 159236636
         obs = installer.get_game_size_from_unzip(installer_path)
         self.assertEqual(exp, obs)
+
+    @mock.patch('shutil.which')
+    @mock.patch('os.listdir')
+    def test_get_exec_line(self, mock_list_dir, mock_which):
+        mock_which.return_value = True
+
+        game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
+        mock_list_dir.return_value = ["data", "docs", "scummvm", "support", "beneath.ini", "gameinfo", "start.sh"]
+
+        result1 = installer.get_exec_line(game1)
+        self.assertEqual(result1, "scummvm -c beneath.ini")
+
+        game2 = Game("Blocks That Matter", install_dir="/home/test/GOG Games/Blocks That Matter", platform="linux")
+        mock_list_dir.return_value = ["data", "docs", "support", "gameinfo", "start.sh"]
+
+        result2 = installer.get_exec_line(game2)
+        self.assertEqual(result2, "./start.sh")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -288,4 +288,4 @@ class Test(TestCase):
         mock_list_dir.return_value = ["data", "docs", "support", "gameinfo", "start.sh"]
 
         result2 = installer.get_exec_line(game2)
-        self.assertEqual(result2, "/home/test/GOG\ Games/Blocks\ That\ Matter/start.sh")
+        self.assertEqual(result2, "/home/test/GOG\\ Games/Blocks\\ That\\ Matter/start.sh")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -288,4 +288,4 @@ class Test(TestCase):
         mock_list_dir.return_value = ["data", "docs", "support", "gameinfo", "start.sh"]
 
         result2 = installer.get_exec_line(game2)
-        self.assertEqual(result2, "./start.sh")
+        self.assertEqual(result2, "/home/test/GOG\ Games/Blocks\ That\ Matter/start.sh")


### PR DESCRIPTION
- Adds a new function that handles the creation of .desktop files for Linux games.
- The function is called during installation and the file is removed after uninstalling the game.
- The function depends on a setting found in Preferences. The setting has two states - Enabled / Disabled. If enabled, newly installed games get a .desktop shortcut.

This PR is split from PR #332 and closes issue #54 

