### PR TITLE
Fix execution of installer for multipart downloads.

### DIFF
--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -145,6 +145,8 @@ class __DownloadManger:
                         progress = int(downloaded_size / file_size * 100)
                         download.set_progress(progress)
                 save_file.close()
+        else:
+            download.set_progress(100)
         return result
 
     def __is_same_download_as_before(self, download):

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -253,10 +253,11 @@ class GameTile(Gtk.Box):
                 finish_func=finish_func if download_path == executable_path else None,
                 progress_func=self.set_progress,
                 cancel_func=lambda: self.__cancel(to_state=cancel_to_state),
-                number=key + 1,
+                number=number_of_files - key,
                 out_of_amount=number_of_files
             )
             self.download_list.append(download)
+        self.download_list.reverse()
 
         if check_diskspace(total_file_size, Config.get("install_dir")):
             DownloadManager.download(self.download_list)


### PR DESCRIPTION
Since changes in 70791bd28fc, for multipart download the `finish_func` is not called. Download stays in DOWNLOADING state forever. Probably explains #362.

In this PR:
- Reverse the order of downloads to make sure that the executable part is downloaded last and proper path is passed to `finish_func`.
- Fix progress reporting for restarted downloads where parts were finished previously.