### PR TITLE
translation.py: call locale.textdomain

### DIFF
--- a/minigalaxy/translation.py
+++ b/minigalaxy/translation.py
@@ -13,6 +13,11 @@ try:
 except AttributeError:
     print("Couldn't run locale.bindtextdomain. Translations might not work correctly.")
 
+try:
+    locale.textdomain(TRANSLATION_DOMAIN)
+except AttributeError:
+    print("Couldn't run locale.textdomain. Translations might not work correctly.")
+
 gettext.bindtextdomain(TRANSLATION_DOMAIN, LOCALE_DIR)
 gettext.textdomain(TRANSLATION_DOMAIN)
 _ = gettext.gettext


### PR DESCRIPTION
Closes #372.

Adding a call to 'locale.textdomain' seems to do the trick.
I also added some error handling which might need to be tested (see #139).