### PR TITLE
Fix translations not being applied

### DIFF
--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -2,8 +2,23 @@ import os
 import threading
 import json
 import time
-from minigalaxy.paths import CONFIG_DIR, CONFIG_FILE_PATH
-from minigalaxy.constants import DEFAULT_CONFIGURATION
+from minigalaxy.paths import CONFIG_DIR, CONFIG_FILE_PATH, DEFAULT_INSTALL_DIR
+
+# The default values for new configuration files
+DEFAULT_CONFIGURATION = {
+    "locale": "",
+    "lang": "en",
+    "install_dir": DEFAULT_INSTALL_DIR,
+    "keep_installers": False,
+    "stay_logged_in": True,
+    "show_fps": False,
+    "use_dark_theme": False,
+    "show_hidden_games": False,
+    "show_windows_games": False,
+    "keep_window_maximized": False,
+    "installed_filter": False,
+    "create_applications_file": False
+}
 
 
 # Make sure you never spawn two instances of this class

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -2,7 +2,6 @@ import requests
 import platform
 from minigalaxy.translation import _
 from minigalaxy.version import VERSION
-from minigalaxy.paths import DEFAULT_INSTALL_DIR
 
 SUPPORTED_DOWNLOAD_LANGUAGES = [
     ["br", _("Brazilian Portuguese")],
@@ -45,22 +44,6 @@ SUPPORTED_LOCALES = [
     ["tr", _("Turkish")],
     ["uk", _("Ukrainian")],
 ]
-
-# The default values for new configuration files
-DEFAULT_CONFIGURATION = {
-    "locale": "",
-    "lang": "en",
-    "install_dir": DEFAULT_INSTALL_DIR,
-    "keep_installers": False,
-    "stay_logged_in": True,
-    "show_fps": False,
-    "use_dark_theme": False,
-    "show_hidden_games": False,
-    "show_windows_games": False,
-    "keep_window_maximized": False,
-    "installed_filter": False,
-    "create_applications_file": False
-}
 
 # Game IDs to ignore when received by the API
 IGNORE_GAME_IDS = [

--- a/minigalaxy/translation.py
+++ b/minigalaxy/translation.py
@@ -1,5 +1,6 @@
 import gettext
 import locale
+from minigalaxy.config import Config
 from minigalaxy.paths import LOCALE_DIR
 
 TRANSLATION_DOMAIN = "minigalaxy"
@@ -20,5 +21,11 @@ except AttributeError:
 
 gettext.bindtextdomain(TRANSLATION_DOMAIN, LOCALE_DIR)
 gettext.textdomain(TRANSLATION_DOMAIN)
-_ = gettext.gettext
-gettext.install(TRANSLATION_DOMAIN, LOCALE_DIR)
+
+current_locale = Config.get("locale")
+default_locale = locale.getdefaultlocale()[0]
+if current_locale == '':
+    lang = gettext.translation(TRANSLATION_DOMAIN, LOCALE_DIR, languages=[default_locale], fallback=True)
+else:
+    lang = gettext.translation(TRANSLATION_DOMAIN, LOCALE_DIR, languages=[current_locale], fallback=True)
+_ = lang.gettext

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import sys
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, patch, mock_open
-from minigalaxy.constants import DEFAULT_CONFIGURATION
+from minigalaxy.config import DEFAULT_CONFIGURATION
 JSON_DEFAULT_CONFIGURATION = str(DEFAULT_CONFIGURATION).replace("'", "\"").replace("False", "false").replace("True", "true")
 
 m_thread = MagicMock()
@@ -29,6 +29,7 @@ class TestConfig(TestCase):
         mock_isdir.return_value = True
         with patch("builtins.open", mock_open()) as mock_config:
             from minigalaxy.config import Config
+            Config.first_run = False
             Config.get("")
         mock_c = mock_config.mock_calls
         write_string = ""


### PR DESCRIPTION
Closes #373.

Not sure if this is the best way.
Moved DEFAULT_CONFIGURATION from constants to config to avoid circular dependencies.

Some further notes/questions:

https://github.com/sharkwouter/minigalaxy/blob/bf7a7f3c3a4b6ab5487374cdb10e7391e6bdeb7d/minigalaxy/translation.py#L6-L9
and
https://github.com/sharkwouter/minigalaxy/blob/bf7a7f3c3a4b6ab5487374cdb10e7391e6bdeb7d/minigalaxy/ui/gametile.py#L44-L52
might not be needed.

https://github.com/sharkwouter/minigalaxy/blob/bf7a7f3c3a4b6ab5487374cdb10e7391e6bdeb7d/minigalaxy/ui/window.py#L36
should be locale.Error?