### PR TITLE
DLC Download Queuing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,4 +8,5 @@ exclude =
     data,
     debian,
     dist,
-    *.egg-info
+    *.egg-info,
+    site-packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**1.2.0**
+- Allow DLC to be queued up for downloading (thanks to flagrama)
+
 **1.1.0**
 - Improve integrity check after downloading (thanks to makson96)
 - Show an error showing Windows games cannot be enabled 

--- a/data/ui/gametile.ui
+++ b/data/ui/gametile.ui
@@ -1,100 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.38.2 -->
 <interface domain="minigalaxy">
   <requires lib="gtk+" version="3.20"/>
-  <object class="GtkPopover" id="dlc_popover">
-    <property name="can_focus">False</property>
-    <child>
-      <object class="GtkBox" id="dlc_horizontal_box">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <placeholder/>
-        </child>
-      </object>
-    </child>
-  </object>
-  <object class="GtkPopover" id="menu">
-    <property name="can_focus">False</property>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkMenuButton" id="menu_button_dlc">
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="relief">none</property>
-            <property name="direction">left</property>
-            <property name="popover">dlc_popover</property>
-            <child>
-              <object class="GtkLabel" id="label_button_dlc">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">DLC</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="menu_button_update">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes">Update</property>
-            <property name="centered">True</property>
-            <signal name="clicked" handler="on_menu_button_update_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="menu_button_uninstall">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes">Uninstall</property>
-            <property name="centered">True</property>
-            <signal name="clicked" handler="on_menu_button_uninstall_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="menu_button_properties">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes">Properties</property>
-            <property name="centered">True</property>
-            <signal name="clicked" handler="on_menu_button_properties_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-  </object>
   <template class="GameTile" parent="GtkBox">
-    <property name="width_request">196</property>
+    <property name="width-request">196</property>
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="halign">start</property>
     <property name="valign">start</property>
     <property name="hexpand">False</property>
@@ -103,78 +14,88 @@
     <child>
       <object class="GtkOverlay">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="GtkImage" id="image">
-            <property name="width_request">196</property>
-            <property name="height_request">110</property>
+            <property name="width-request">196</property>
+            <property name="height-request">110</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="icon_name">dialog-warning-symbolic</property>
+            <property name="can-focus">False</property>
+            <property name="icon-name">dialog-warning-symbolic</property>
             <property name="icon_size">0</property>
           </object>
           <packing>
-            <property name="pass_through">True</property>
+            <property name="pass-through">True</property>
             <property name="index">-1</property>
           </packing>
         </child>
         <child type="overlay">
-          <object class="GtkMenuButton" id="menu_button">
-            <property name="can_focus">True</property>
-            <property name="has_focus">True</property>
-            <property name="focus_on_click">False</property>
-            <property name="receives_default">True</property>
-            <property name="no_show_all">True</property>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
             <property name="halign">end</property>
             <property name="valign">start</property>
-            <property name="relief">none</property>
-            <property name="use_popover">False</property>
-            <property name="popover">menu</property>
             <child>
-              <object class="GtkImage" id="menu_icon">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="icon_name">applications-system-symbolic</property>
-                <property name="icon_size">3</property>
+              <object class="GtkButton" id="button_cancel">
+                <property name="can-focus">True</property>
+                <property name="focus-on-click">False</property>
+                <property name="receives-default">True</property>
+                <property name="no-show-all">True</property>
+                <property name="halign">end</property>
+                <property name="valign">start</property>
+                <property name="relief">none</property>
+                <signal name="clicked" handler="on_button_cancel_clicked" swapped="no"/>
+                <child>
+                  <object class="GtkImage" id="cancel_icon">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="icon-name">process-stop</property>
+                  </object>
+                </child>
               </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkMenuButton" id="menu_button">
+                <property name="can-focus">True</property>
+                <property name="focus-on-click">False</property>
+                <property name="receives-default">True</property>
+                <property name="no-show-all">True</property>
+                <property name="halign">end</property>
+                <property name="valign">start</property>
+                <property name="relief">none</property>
+                <property name="use-popover">False</property>
+                <property name="popover">menu</property>
+                <child>
+                  <object class="GtkImage" id="menu_icon">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="icon-name">applications-system-symbolic</property>
+                    <property name="icon_size">3</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
-          <packing>
-            <property name="index">2</property>
-          </packing>
-        </child>
-        <child type="overlay">
-          <object class="GtkButton" id="button_cancel">
-            <property name="can_focus">True</property>
-            <property name="has_focus">True</property>
-            <property name="focus_on_click">False</property>
-            <property name="receives_default">True</property>
-            <property name="no_show_all">True</property>
-            <property name="halign">end</property>
-            <property name="valign">start</property>
-            <property name="relief">none</property>
-            <signal name="clicked" handler="on_button_cancel_clicked" swapped="no"/>
-            <child>
-              <object class="GtkImage" id="cancel_icon">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">process-stop</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="index">1</property>
-          </packing>
         </child>
         <child type="overlay">
           <object class="GtkImage" id="wine_icon">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="halign">start</property>
             <property name="valign">start</property>
-            <property name="margin_start">2</property>
-            <property name="margin_top">2</property>
+            <property name="margin-start">2</property>
+            <property name="margin-top">2</property>
           </object>
           <packing>
             <property name="index">2</property>
@@ -182,11 +103,11 @@
         </child>
         <child type="overlay">
           <object class="GtkImage" id="update_icon">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="halign">start</property>
             <property name="valign">start</property>
-            <property name="margin_start">2</property>
-            <property name="margin_top">2</property>
+            <property name="margin-start">2</property>
+            <property name="margin-top">2</property>
           </object>
           <packing>
             <property name="index">3</property>
@@ -201,10 +122,10 @@
     </child>
     <child>
       <object class="GtkButton" id="button">
-        <property name="width_request">196</property>
+        <property name="width-request">196</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
         <property name="halign">center</property>
         <property name="valign">end</property>
         <signal name="clicked" handler="on_button_clicked" swapped="no"/>
@@ -215,7 +136,7 @@
       <packing>
         <property name="expand">False</property>
         <property name="fill">False</property>
-        <property name="pack_type">end</property>
+        <property name="pack-type">end</property>
         <property name="position">1</property>
       </packing>
     </child>
@@ -223,4 +144,93 @@
       <placeholder/>
     </child>
   </template>
+  <object class="GtkPopover" id="dlc_popover">
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox" id="dlc_horizontal_box">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkPopover" id="menu">
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkMenuButton" id="menu_button_dlc">
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <property name="direction">left</property>
+            <property name="popover">dlc_popover</property>
+            <child>
+              <object class="GtkLabel" id="label_button_dlc">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">DLC</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="menu_button_update">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Update</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_menu_button_update_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="menu_button_uninstall">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Uninstall</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_menu_button_uninstall_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="menu_button_properties">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Properties</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_menu_button_properties_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
 </interface>

--- a/minigalaxy/download.py
+++ b/minigalaxy/download.py
@@ -3,7 +3,7 @@ from zipfile import BadZipFile
 
 class Download:
     def __init__(self, url, save_location, finish_func=None, progress_func=None, cancel_func=None, number=1,
-                 out_of_amount=1):
+                 out_of_amount=1, game=None):
         self.url = url
         self.save_location = save_location
         self.__finish_func = finish_func
@@ -11,6 +11,7 @@ class Download:
         self.__cancel_func = cancel_func
         self.number = number
         self.out_of_amount = out_of_amount
+        self.game = game
 
     def set_progress(self, percentage: int) -> None:
         if self.__progress_func:

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -3,7 +3,6 @@ import shutil
 import time
 import threading
 import queue
-from os.path import exists
 
 from requests.exceptions import ConnectionError
 from minigalaxy.config import Config

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -3,6 +3,8 @@ import shutil
 import time
 import threading
 import queue
+from os.path import exists
+
 from requests.exceptions import ConnectionError
 from minigalaxy.config import Config
 from minigalaxy.constants import DOWNLOAD_CHUNK_SIZE, MINIMUM_RESUME_SIZE, SESSION
@@ -110,7 +112,8 @@ class __DownloadManger:
             shutil.rmtree(save_location)
             print("{} is a directory. Will remove it, to make place for installer.".format(save_location))
 
-        open(save_location, 'a+').close()
+        if not exists(save_location):
+            open(save_location, 'w').close()
 
     def get_start_point_and_download_mode(self, download):
         # Resume the previous download if possible

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -50,6 +50,8 @@ class __DownloadManger:
                     queued_download = self.__queue.get()
                     if download == queued_download:
                         download.cancel()
+                    elif download.game == queued_download.game:
+                        download.cancel()
                     else:
                         new_queue.put(queued_download)
                 self.__queue = new_queue

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -114,9 +114,6 @@ class __DownloadManger:
             shutil.rmtree(save_location)
             print("{} is a directory. Will remove it, to make place for installer.".format(save_location))
 
-        if not exists(save_location):
-            open(save_location, 'w').close()
-
     def get_start_point_and_download_mode(self, download):
         # Resume the previous download if possible
         start_point = 0

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -110,6 +110,8 @@ class __DownloadManger:
             shutil.rmtree(save_location)
             print("{} is a directory. Will remove it, to make place for installer.".format(save_location))
 
+        open(save_location, 'a+').close()
+
     def get_start_point_and_download_mode(self, download):
         # Resume the previous download if possible
         start_point = 0

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -285,7 +285,9 @@ def remove_installer(game, installer):
             except Exception as e:
                 error_message = str(e)
     else:
-        shutil.rmtree(installer_directory, ignore_errors=True)
+        os.remove(installer)
+        if len(os.listdir(installer_directory)) == 0:
+            os.rmdir(installer_directory)
 
     return error_message
 

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -286,8 +286,6 @@ def remove_installer(game, installer):
                 error_message = str(e)
     else:
         os.remove(installer)
-        if len(os.listdir(installer_directory)) == 0:
-            os.rmdir(installer_directory)
 
     return error_message
 

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -303,6 +303,7 @@ class GameTile(Gtk.Box):
         return install_success
 
     def __cancel(self, to_state):
+        self.download_list = []
         GLib.idle_add(self.update_to_state, to_state)
         GLib.idle_add(self.reload_state)
 
@@ -396,7 +397,8 @@ class GameTile(Gtk.Box):
             self.dlc_dict[title][0].set_sensitive(False)
         else:
             icon_name = "document-save"
-            self.dlc_dict[title][0].set_sensitive(True)
+            if not self.download_list:
+                self.dlc_dict[title][0].set_sensitive(True)
         install_button_image = Gtk.Image()
         install_button_image.set_from_icon_name(icon_name, Gtk.IconSize.BUTTON)
         self.dlc_dict[title][0].set_image(install_button_image)

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -381,8 +381,7 @@ class GameTile(Gtk.Box):
             install_button = Gtk.Button()
             dlc_box.pack_start(install_button, False, True, 0)
             self.dlc_dict[title] = [install_button, image]
-            self.dlc_dict[title][0].connect("clicked", lambda x: threading.Thread(target=self.__download_dlc,
-                                                                                  args=(installer,)).start())
+            self.dlc_dict[title][0].connect("clicked", self.__dlc_button_clicked, installer)
             self.dlc_horizontal_box.pack_start(dlc_box, False, True, 0)
             dlc_box.show_all()
             self.get_async_image_dlc_icon(icon, title)
@@ -399,6 +398,10 @@ class GameTile(Gtk.Box):
         install_button_image = Gtk.Image()
         install_button_image.set_from_icon_name(icon_name, Gtk.IconSize.BUTTON)
         self.dlc_dict[title][0].set_image(install_button_image)
+
+    def __dlc_button_clicked(self, button, installer):
+        button.set_sensitive(False)
+        threading.Thread(target=self.__download_dlc, args=(installer,)).start()
 
     def get_async_image_dlc_icon(self, icon, title):
         if icon:

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -228,6 +228,7 @@ class GameTile(Gtk.Box):
         number_of_files = len(download_info['files'])
         total_file_size = 0
         executable_path = None
+        download_files = []
         for key, file_info in enumerate(download_info['files']):
             try:
                 download_url = self.api.get_real_download_link(file_info["downlink"])
@@ -257,11 +258,11 @@ class GameTile(Gtk.Box):
                 out_of_amount=number_of_files,
                 game=self.game
             )
-            self.download_list.append(download)
-        self.download_list.reverse()
+            download_files.insert(0, download)
+        self.download_list.extend(download_files)
 
         if check_diskspace(total_file_size, Config.get("install_dir")):
-            DownloadManager.download(self.download_list)
+            DownloadManager.download(download_files)
             ds_msg_title = ""
             ds_msg_text = ""
         else:

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -274,6 +274,7 @@ class GameTile(Gtk.Box):
         return download_success
 
     def __install_game(self, save_location):
+        self.download_list = []
         self.game.set_install_dir()
         install_success = self.__install(save_location)
         if install_success:

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -381,7 +381,8 @@ class GameTile(Gtk.Box):
             install_button = Gtk.Button()
             dlc_box.pack_start(install_button, False, True, 0)
             self.dlc_dict[title] = [install_button, image]
-            self.dlc_dict[title][0].connect("clicked", lambda x: self.__download_dlc(installer))
+            self.dlc_dict[title][0].connect("clicked", lambda x: threading.Thread(target=self.__download_dlc,
+                                                                                  args=(installer,)).start())
             self.dlc_horizontal_box.pack_start(dlc_box, False, True, 0)
             dlc_box.show_all()
             self.get_async_image_dlc_icon(icon, title)

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -482,7 +482,8 @@ class GameTile(Gtk.Box):
         self.button.set_label(_("in queue…"))
         self.button.set_sensitive(False)
         self.image.set_sensitive(False)
-        self.menu_button.hide()
+        self.menu_button_uninstall.hide()
+        self.menu_button_update.hide()
         self.button_cancel.show()
         self.__create_progress_bar()
 
@@ -490,7 +491,8 @@ class GameTile(Gtk.Box):
         self.button.set_label(_("downloading…"))
         self.button.set_sensitive(False)
         self.image.set_sensitive(False)
-        self.menu_button.hide()
+        self.menu_button_uninstall.hide()
+        self.menu_button_update.hide()
         self.button_cancel.show()
         if not self.progress_bar:
             self.__create_progress_bar()
@@ -500,7 +502,8 @@ class GameTile(Gtk.Box):
         self.button.set_label(_("installing…"))
         self.button.set_sensitive(False)
         self.image.set_sensitive(True)
-        self.menu_button.hide()
+        self.menu_button_uninstall.hide()
+        self.menu_button_update.hide()
         self.button_cancel.hide()
 
         self.game.set_install_dir()

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -412,8 +412,9 @@ class GameTile(Gtk.Box):
         self.dlc_dict[user_data][1].set_from_pixbuf(pixbuf)
 
     def set_progress(self, percentage: int):
-        if self.current_state == self.state.QUEUED:
+        if self.current_state in [self.state.QUEUED, self.state.INSTALLED]:
             GLib.idle_add(self.update_to_state, self.state.DOWNLOADING)
+            self.__create_progress_bar()
         if self.progress_bar:
             GLib.idle_add(self.progress_bar.set_fraction, percentage / 100)
 

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -254,7 +254,8 @@ class GameTile(Gtk.Box):
                 progress_func=self.set_progress,
                 cancel_func=lambda: self.__cancel(to_state=cancel_to_state),
                 number=number_of_files - key,
-                out_of_amount=number_of_files
+                out_of_amount=number_of_files,
+                game=self.game
             )
             self.download_list.append(download)
         self.download_list.reverse()

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -333,11 +333,12 @@ class Test(TestCase):
         exp = "No installer directory is present: /home/i/.cache/minigalaxy/download/Beneath a Steel Sky"
         self.assertEqual(obs, exp)
 
+    @mock.patch('os.remove')
     @mock.patch('shutil.rmtree')
     @mock.patch('minigalaxy.config.Config.get')
     @mock.patch('minigalaxy.installer.compare_directories')
     @mock.patch('os.path.isdir')
-    def test_remove_installer_no_keep(self, mock_os_path_isdir, mock_compare_directories, mock_config, mock_shutil_rmtree):
+    def test_remove_installer_no_keep(self, mock_os_path_isdir, mock_compare_directories, mock_config, mock_shutil_rmtree, mock_os_remove):
         """
         Disabled keep_installer
         """
@@ -348,14 +349,16 @@ class Test(TestCase):
         game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
         installer_path = "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         obs = installer.remove_installer(game1, installer_path)
-        assert mock_shutil_rmtree.called
+        assert mock_os_remove.called
+        assert not mock_shutil_rmtree.called
         self.assertEqual(obs, "")
 
+    @mock.patch('os.remove')
     @mock.patch('shutil.rmtree')
     @mock.patch('minigalaxy.config.Config.get')
     @mock.patch('minigalaxy.installer.compare_directories')
     @mock.patch('os.path.isdir')
-    def test_remove_installer_same_content(self, mock_os_path_isdir, mock_compare_directories, mock_config, mock_shutil_rmtree):
+    def test_remove_installer_same_content(self, mock_os_path_isdir, mock_compare_directories, mock_config, mock_shutil_rmtree, mock_os_remove):
         """
         Same content of installer and keep dir
         """
@@ -367,14 +370,16 @@ class Test(TestCase):
         installer_path = "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         obs = installer.remove_installer(game1, installer_path)
         assert not mock_shutil_rmtree.called
+        assert not mock_os_remove.called
         self.assertEqual(obs, "")
 
+    @mock.patch('os.remove')
     @mock.patch('shutil.move')
     @mock.patch('shutil.rmtree')
     @mock.patch('minigalaxy.config.Config.get')
     @mock.patch('minigalaxy.installer.compare_directories')
     @mock.patch('os.path.isdir')
-    def test_remove_installer_keep(self, mock_os_path_isdir, mock_compare_directories, mock_config, mock_shutil_rmtree, mock_shutil_move):
+    def test_remove_installer_keep(self, mock_os_path_isdir, mock_compare_directories, mock_config, mock_shutil_rmtree, mock_shutil_move, mock_os_remove):
         """
         Keep installer dir
         """
@@ -387,14 +392,16 @@ class Test(TestCase):
         obs = installer.remove_installer(game1, installer_path)
         assert mock_shutil_rmtree.called
         assert mock_shutil_move.called
+        assert not mock_os_remove.called
         self.assertEqual(obs, "")
 
+    @mock.patch('os.remove')
     @mock.patch('shutil.move')
     @mock.patch('shutil.rmtree')
     @mock.patch('minigalaxy.config.Config.get')
     @mock.patch('minigalaxy.installer.compare_directories')
     @mock.patch('os.path.isdir')
-    def test_remove_installer_from_keep(self, mock_os_path_isdir, mock_compare_directories, mock_config, mock_shutil_rmtree, mock_shutil_move):
+    def test_remove_installer_from_keep(self, mock_os_path_isdir, mock_compare_directories, mock_config, mock_shutil_rmtree, mock_shutil_move, mock_os_remove):
         """
         Called from keep dir
         """
@@ -407,4 +414,5 @@ class Test(TestCase):
         obs = installer.remove_installer(game1, installer_path)
         assert not mock_shutil_rmtree.called
         assert not mock_shutil_move.called
+        assert not mock_os_remove.called
         self.assertEqual(obs, "")


### PR DESCRIPTION
Made changes allowing DLC downloads to be queued up.

Should not delete the entire installer directory if other files exist in the directory. This would cause a race condition `remove_installer` in `installer.py` and `prepare_location` in `download_manager.py` so `prepare_location` will now create a placeholder file so that the directory will be much less likely be deleted between preparation and download starting.

The Menu button will not be hidden anymore, instead the Uninstall and Update buttons will be hidden while in a DOWNLOADING state, leaving Properties and DLC still accessible. Cancel button has been made to appear to the left of the Menu button now that they will appear together and would have overlapped previously.

`set_progress` in `gametile.py` has been modified to ensure downloads will update the tile's state back to DOWNLOADING with a progress bar after being left in INSTALLED after installing the previous download.

DLC Download buttons will be disabled after clicking on them.

Current Known Issues:
- ~~Canceling a download will say it is cancelling the download of the game, not the DLC, this is the same as current behaviour, but is more confusing now due to the queuing.~~
   - Cancels all downloads for a game now, a little overkill but makes sense regarding the message box. Can be improved in the future.
- ~~The change in `prepare_locations` may have introduced an issue where downloads may end up corrupt after downloading, though this could also easily be because of closing the application by killing the debugger.~~
   - Just not deleting the directory on install, similar to how cancelling a download doesn't delete the directory.
- ~~DLC Download button will not remain disabled. After a call to `__check_for_update_dlc` the buttons will be returned to their states dictated by `update_gtk_box_for_dlc`~~
- I have no idea what I'm doing with Glade. Hopefully I didn't break anything.