### PR TITLE
If locale cannot be determined, fallback to en translation

### DIFF
--- a/minigalaxy/translation.py
+++ b/minigalaxy/translation.py
@@ -29,7 +29,10 @@ os.unsetenv("LANGUAGE")
 current_locale = Config.get("locale")
 default_locale = locale.getdefaultlocale()[0]
 if current_locale == '':
-    lang = gettext.translation(TRANSLATION_DOMAIN, LOCALE_DIR, languages=[default_locale], fallback=True)
+    if default_locale is None:
+        lang = gettext.translation(TRANSLATION_DOMAIN, LOCALE_DIR, languages=['en'], fallback=True)
+    else:
+        lang = gettext.translation(TRANSLATION_DOMAIN, LOCALE_DIR, languages=[default_locale], fallback=True)
 else:
     lang = gettext.translation(TRANSLATION_DOMAIN, LOCALE_DIR, languages=[current_locale], fallback=True)
 _ = lang.gettext


### PR DESCRIPTION
https://docs.python.org/3/library/locale.html#locale.getdefaultlocale
"Except for the code 'C', the language code corresponds to RFC 1766. language
code and encoding may be None if their values cannot be determined."