### PR TITLE
Fix #412

### DIFF
--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -129,18 +129,7 @@ class Library(Gtk.Viewport):
                         game_id = int(game_id)
                 games.append(Game(name=name, game_id=game_id, install_dir=full_path))
             else:
-                game_files = os.listdir(full_path)
-                for file in game_files:
-                    if re.match(r'^goggame-[0-9]*\.info$', file):
-                        with open(os.path.join(full_path, file), 'r') as info_file:
-                            info = json.loads(info_file.read())
-                            game = Game(
-                                name=info["name"],
-                                game_id=int(info["gameId"]),
-                                install_dir=full_path,
-                                platform="windows"
-                            )
-                            games.append(game)
+                games.extend(get_installed_windows_games(full_path))
         return games
 
     def __add_games_from_api(self):
@@ -158,3 +147,20 @@ class Library(Gtk.Viewport):
                 self.games[self.games.index(game)].name = game.name
             self.games[self.games.index(game)].image_url = game.image_url
             self.games[self.games.index(game)].url = game.url
+
+
+def get_installed_windows_games(full_path):
+    games = []
+    game_files = os.listdir(full_path)
+    for file in game_files:
+        if re.match(r'^goggame-[0-9]*\.info$', file):
+            with open(os.path.join(full_path, file), 'rb') as info_file:
+                info = json.loads(info_file.read().decode('utf-8-sig'))
+                game = Game(
+                    name=info["name"],
+                    game_id=int(info["gameId"]),
+                    install_dir=full_path,
+                    platform="windows"
+                )
+                games.append(game)
+    return games

--- a/tests/test_ui_library.py
+++ b/tests/test_ui_library.py
@@ -1,6 +1,6 @@
 import sys
-from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest import TestCase, mock
+from unittest.mock import MagicMock, patch, mock_open
 
 m_gtk = MagicMock()
 m_gi = MagicMock()
@@ -52,7 +52,7 @@ sys.modules['minigalaxy.ui.window'] = m_window
 sys.modules['minigalaxy.ui.preferences'] = m_preferences
 sys.modules['minigalaxy.ui.gametile'] = m_gametile
 from minigalaxy.game import Game           # noqa: E402
-from minigalaxy.ui.library import Library  # noqa: E402
+from minigalaxy.ui.library import Library, get_installed_windows_games  # noqa: E402
 
 SELF_GAMES = {"Neverwinter Nights: Enhanced Edition": "1097893768", "Beneath A Steel Sky": "1207658695",
               "Stellaris (English)": "1508702879"}
@@ -171,6 +171,26 @@ class TestLibrary(TestCase):
         test_library._Library__add_games_from_api()
         exp = 1
         obs = len(test_library.games)
+        self.assertEqual(exp, obs)
+
+    @mock.patch('os.listdir')
+    def test1_get_installed_windows_game(self, mock_listdir):
+        mock_listdir.return_value = ["goggame-1207665883.info"]
+        game_json_data = '{ "gameId": "1207665883", "name": "Aliens vs Predator Classic 2000" }'.encode('utf-8')
+        with patch("builtins.open", mock_open(read_data=game_json_data)):
+            games = get_installed_windows_games("/example/path")
+        exp = "Aliens vs Predator Classic 2000"
+        obs = games[0].name
+        self.assertEqual(exp, obs)
+
+    @mock.patch('os.listdir')
+    def test2_get_installed_windows_game(self, mock_listdir):
+        mock_listdir.return_value = ["goggame-1207665883.info"]
+        game_json_data = '{ "gameId": "1207665883", "name": "Aliens vs Predator Classic 2000" }'.encode('utf-8-sig')
+        with patch("builtins.open", mock_open(read_data=game_json_data)):
+            games = get_installed_windows_games("/example/path")
+        exp = "Aliens vs Predator Classic 2000"
+        obs = games[0].name
         self.assertEqual(exp, obs)
 
 


### PR DESCRIPTION
This pull request is to address issue #412
It seems that gogame.info files (Windows) can be encoded both by utf-8 and utf-8-sig.
As utf-8-sig decoder can decode utf-8 files just fine we should always use it to open this type of files.
I have added unittests for this issue, as it is important - it cause app to crash.
I changed library.py a little bit to be easier to test, but if you prefer for "get_installed_windows_games()" to be static, private method inside Library() class, please let me know and I will change it.