### PR TITLE
Added Linux Mint 20+ to the requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Minigalaxy should work on the following distributions:
 
 - Debian Buster (10.0) or newer
 - Ubuntu 18.10 or newer
+- Linux Mint 20 or newer
 - Arch Linux
 - Manjaro
 - Fedora 31+


### PR DESCRIPTION
With Linux Mint 20.x being based on Ubuntu 20.04, it meets the requirements for full Minigalaxy functionality.