### PR TITLE
Prefer Wine instead of Innoextract to install Windows games.

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -115,7 +115,7 @@ def extract_installer(game, installer, temp_dir):
     if game.platform in ["linux"]:
         err_msg = extract_linux(installer, temp_dir)
     else:
-        err_msg = extract_windows(game, installer, temp_dir)
+        err_msg = extract_windows(game, installer)
     return err_msg
 
 
@@ -131,12 +131,9 @@ def extract_linux(installer, temp_dir):
     return err_msg
 
 
-def extract_windows(game, installer, temp_dir):
-    err_msg = extract_by_innoextract(installer, temp_dir)
-    if err_msg:
-        err_msg = extract_by_wine(game, installer, temp_dir)
+def extract_windows(game, installer):
+    err_msg = extract_by_wine(game, installer)
     return err_msg
-
 
 def extract_by_innoextract(installer, temp_dir):
     err_msg = ""
@@ -159,14 +156,14 @@ def extract_by_innoextract(installer, temp_dir):
     return err_msg
 
 
-def extract_by_wine(game, installer, temp_dir):
+def extract_by_wine(game, installer):
     err_msg = ""
     # Set the prefix for Windows games
     prefix_dir = os.path.join(game.install_dir, "prefix")
     if not os.path.exists(prefix_dir):
         os.makedirs(prefix_dir, mode=0o755)
     # It's possible to set install dir as argument before installation
-    command = ["env", "WINEPREFIX={}".format(prefix_dir), "wine", installer, "/dir={}".format(temp_dir), "/VERYSILENT"]
+    command = ["env", "WINEPREFIX={}".format(prefix_dir), "wine", installer, "/dir={}".format(game.install_dir)]
     stdout, stderr, exitcode = _exe_cmd(command)
     if exitcode not in [0]:
         err_msg = _("Wine extraction failed.")
@@ -186,8 +183,6 @@ def move_and_overwrite(game, temp_dir):
 
     # Remove the temporary directory
     shutil.rmtree(temp_dir, ignore_errors=True)
-    if game.platform in ["windows"] and "unins000.exe" not in os.listdir(game.install_dir):
-        open(os.path.join(game.install_dir, "unins000.exe"), "w").close()
     return error_message
 
 

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -110,42 +110,8 @@ class Test(TestCase):
         mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
-        temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
-        obs = installer.extract_windows(game, installer_path, temp_dir)
-        self.assertEqual(exp, obs)
-
-    @mock.patch('subprocess.Popen')
-    @mock.patch('shutil.which')
-    def test1_extract_by_innoextract(self, mock_which, mock_subprocess):
-        mock_which.return_value = True
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
-        installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
-        temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
-        exp = ""
-        obs = installer.extract_by_innoextract(installer_path, temp_dir)
-        self.assertEqual(exp, obs)
-
-    @mock.patch('shutil.which')
-    def test2_extract_by_innoextract(self, mock_which):
-        mock_which.return_value = False
-        installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
-        temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
-        exp = "Innoextract not installed."
-        obs = installer.extract_by_innoextract(installer_path, temp_dir)
-        self.assertEqual(exp, obs)
-
-    @mock.patch('subprocess.Popen')
-    @mock.patch('shutil.which')
-    def test3_extract_by_innoextract(self, mock_which, mock_subprocess):
-        mock_which.return_value = True
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
-        installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
-        temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
-        exp = "Innoextract extraction failed."
-        obs = installer.extract_by_innoextract(installer_path, temp_dir)
+        obs = installer.extract_windows(game, installer_path)
         self.assertEqual(exp, obs)
 
     @mock.patch('subprocess.Popen')
@@ -156,9 +122,8 @@ class Test(TestCase):
         mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
-        temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
-        obs = installer.extract_by_wine(game, installer_path, temp_dir)
+        obs = installer.extract_by_wine(game, installer_path)
         self.assertEqual(exp, obs)
 
     @mock.patch('subprocess.Popen')
@@ -169,9 +134,8 @@ class Test(TestCase):
         mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
-        temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = "Wine extraction failed."
-        obs = installer.extract_by_wine(game, installer_path, temp_dir)
+        obs = installer.extract_by_wine(game, installer_path)
         self.assertEqual(exp, obs)
 
     @mock.patch('subprocess.Popen')


### PR DESCRIPTION
Fix issue #427 and #428 

To fix the first and second point the issue #428, it's necessary to install the game directly in the game's install_dir instead of in a temp_dir and move it. With the actual solution with Wine, it's impossible to install a patch for "The Witcher 3" (MG does not detect it) and Fallout 3/New Vegas launcher think that the game is not installed.