### PR TITLE
Add the possibility to use custom Wine instead of Wine system.

### DIFF
--- a/data/ui/properties.ui
+++ b/data/ui/properties.ui
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <template class="Properties" parent="GtkDialog">
-    <property name="can_focus">False</property>
-    <property name="default_width">400</property>
-    <property name="default_height">250</property>
-    <property name="type_hint">dialog</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
+    <property name="can-focus">False</property>
+    <property name="default-width">400</property>
+    <property name="default-height">250</property>
+    <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">horizontal</property>
         <property name="spacing">18</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -28,7 +25,7 @@
         <child>
           <object class="GtkImage" id="image">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="stock">gtk-missing-image</property>
           </object>
           <packing>
@@ -40,189 +37,253 @@
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">18</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="spacing">6</property>
                 <property name="homogeneous">True</property>
                 <child>
+                  <!-- n-columns=3 n-rows=8 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_top">18</property>
-                    <property name="row_spacing">6</property>
-                    <property name="column_spacing">12</property>
-                    <property name="row_homogeneous">True</property>
-                    <property name="column_homogeneous">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-top">18</property>
+                    <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
+                    <property name="row-homogeneous">True</property>
+                    <property name="column-homogeneous">True</property>
                     <child>
                       <object class="GtkButton" id="button_properties_support">
                         <property name="label" translatable="yes">Support</property>
                         <property name="name">button_properties_support</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <signal name="clicked" handler="on_button_properties_support_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_store">
                         <property name="label" translatable="yes">Store</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <signal name="clicked" handler="on_button_properties_store_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkSwitch" id="switch_properties_show_fps">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">3</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">3</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Hide game:</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkSwitch" id="switch_properties_hide_game">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">4</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkEntry" id="entry_properties_command">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Added at the end of the command used to launch the game</property>
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Added at the end of the command used to launch the game</property>
                         <property name="halign">start</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">6</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">6</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkEntry" id="entry_properties_variable">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Added in front of the command used to launch the game</property>
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Added in front of the command used to launch the game</property>
                         <property name="halign">start</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">5</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">5</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Show FPS in game:</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">3</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">3</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Variable flags:</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">5</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">5</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Command flags:</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">6</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">6</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_winecfg">
                         <property name="label" translatable="yes">Winecfg</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <signal name="clicked" handler="on_button_properties_winecfg_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_regedit">
                         <property name="label" translatable="yes">Regedit</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <signal name="clicked" handler="on_button_properties_regedit_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_open_files">
                         <property name="label" translatable="yes">Open files</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <signal name="clicked" handler="on_button_properties_open_files_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">2</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">2</property>
                       </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_wine_custom">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Custom Wine : </property>
+                        <property name="justify">fill</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">7</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_properties_reset">
+                        <property name="label" translatable="yes">Reset</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="margin-right">84</property>
+                        <signal name="clicked" handler="on_button_properties_reset_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">2</property>
+                        <property name="top-attach">7</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkFileChooserButton" id="button_properties_wine">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Allow to choose a custom Wine version for this game instead of Wine system (Proton, Proton GE or your own build)</property>
+                        <property name="create-folders">False</property>
+                        <property name="title" translatable="yes"/>
+                        <signal name="file-set" handler="on_button_properties_wine_file_set" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">7</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                     <child>
                       <placeholder/>
@@ -244,7 +305,7 @@
             <child>
               <object class="GtkLabel" id="label_game_description">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="wrap">True</property>
                 <property name="selectable">True</property>
               </object>
@@ -257,16 +318,16 @@
             <child>
               <object class="GtkButtonBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_bottom">18</property>
+                <property name="can-focus">False</property>
+                <property name="margin-bottom">18</property>
                 <property name="spacing">12</property>
-                <property name="layout_style">end</property>
+                <property name="layout-style">end</property>
                 <child>
                   <object class="GtkButton" id="button_properties_cancel">
                     <property name="label" translatable="yes">Cancel</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
                     <signal name="clicked" handler="on_button_properties_cancel_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -279,8 +340,8 @@
                   <object class="GtkButton" id="button_properties_ok">
                     <property name="label" translatable="yes">OK</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
                     <signal name="clicked" handler="on_button_properties_ok_clicked" swapped="no"/>
                   </object>
                   <packing>

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -7,27 +7,22 @@ import glob
 from minigalaxy.translation import _
 
 
-def wine_path(game):
-    custom_path = game.get_info("custom_wine")
-    if custom_path == "":
-        custom_wine_path = shutil.which("wine")
-    else:
-        custom_wine_path = custom_path
-    return custom_wine_path
-
+def get_wine_path(game):
+    custom_wine_path = game.get_info("custom_wine")
+    return custom_wine_path if custom_wine_path else shutil.which("wine")
 
 def config_game(game):
     prefix = os.path.join(game.install_dir, "prefix")
 
     os.environ["WINEPREFIX"] = prefix
-    subprocess.Popen([wine_path(game), 'winecfg'])
+    subprocess.Popen([get_wine_path(game), 'winecfg'])
 
 
 def regedit_game(game):
     prefix = os.path.join(game.install_dir, "prefix")
 
     os.environ["WINEPREFIX"] = prefix
-    subprocess.Popen([wine_path(game), 'regedit'])
+    subprocess.Popen([get_wine_path(game), 'regedit'])
 
 
 def start_game(game):
@@ -108,16 +103,16 @@ def get_windows_exe_cmd(game, files):
                 # if we have the workingDir property, start the executable at that directory
                 if info["playTasks"]:
                     if "workingDir" in info["playTasks"][0] and info["playTasks"][0]["workingDir"]:
-                        exe_cmd = [wine_path(game), "start", "/b", "/wait", "/d", info["playTasks"][0]["workingDir"],
+                        exe_cmd = [get_wine_path(game), "start", "/b", "/wait", "/d", info["playTasks"][0]["workingDir"],
                                    info["playTasks"][0]["path"]]
                     else:
-                        exe_cmd = [wine_path(game), info["playTasks"][0]["path"]]
+                        exe_cmd = [get_wine_path(game), info["playTasks"][0]["path"]]
     if exe_cmd == [""]:
         # in case no goggame info file was found
         executables = glob.glob(game.install_dir + '/*.exe')
         executables.remove(os.path.join(game.install_dir, "unins000.exe"))
         filename = os.path.splitext(os.path.basename(executables[0]))[0] + '.exe'
-        exe_cmd = [wine_path(game), filename]
+        exe_cmd = [get_wine_path(game), filename]
 
     return exe_cmd
 

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -7,18 +7,27 @@ import glob
 from minigalaxy.translation import _
 
 
+def wine_path(game):
+    custom_path = game.get_info("custom_wine")
+    if custom_path == "":
+        custom_wine_path = shutil.which("wine")
+    else:
+        custom_wine_path = custom_path
+    return custom_wine_path
+
+
 def config_game(game):
     prefix = os.path.join(game.install_dir, "prefix")
 
     os.environ["WINEPREFIX"] = prefix
-    subprocess.Popen(['wine', 'winecfg'])
+    subprocess.Popen([wine_path(game), 'winecfg'])
 
 
 def regedit_game(game):
     prefix = os.path.join(game.install_dir, "prefix")
 
     os.environ["WINEPREFIX"] = prefix
-    subprocess.Popen(['wine', 'regedit'])
+    subprocess.Popen([wine_path(game), 'regedit'])
 
 
 def start_game(game):
@@ -99,16 +108,16 @@ def get_windows_exe_cmd(game, files):
                 # if we have the workingDir property, start the executable at that directory
                 if info["playTasks"]:
                     if "workingDir" in info["playTasks"][0] and info["playTasks"][0]["workingDir"]:
-                        exe_cmd = ["wine", "start", "/b", "/wait", "/d", info["playTasks"][0]["workingDir"],
+                        exe_cmd = [wine_path(game), "start", "/b", "/wait", "/d", info["playTasks"][0]["workingDir"],
                                    info["playTasks"][0]["path"]]
                     else:
-                        exe_cmd = ["wine", info["playTasks"][0]["path"]]
+                        exe_cmd = [wine_path(game), info["playTasks"][0]["path"]]
     if exe_cmd == [""]:
         # in case no goggame info file was found
         executables = glob.glob(game.install_dir + '/*.exe')
         executables.remove(os.path.join(game.install_dir, "unins000.exe"))
         filename = os.path.splitext(os.path.basename(executables[0]))[0] + '.exe'
-        exe_cmd = ["wine", filename]
+        exe_cmd = [wine_path(game), filename]
 
     return exe_cmd
 

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -81,7 +81,7 @@ class Properties(Gtk.Dialog):
 
     @Gtk.Template.Callback("on_button_properties_reset_clicked")
     def on_menu_button_reset(self, widget):
-        if self.game.get_info("custom_wine") is not None:
+        if self.game.get_info("custom_wine"):
             self.button_properties_wine.unselect_filename(self.game.get_info("custom_wine"))
             self.game.set_info("custom_wine", "")
 

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -23,11 +23,14 @@ class Properties(Gtk.Dialog):
     button_properties_open_files = Gtk.Template.Child()
     button_properties_winecfg = Gtk.Template.Child()
     button_properties_regedit = Gtk.Template.Child()
+    button_properties_wine = Gtk.Template.Child()
+    button_properties_reset = Gtk.Template.Child()
     switch_properties_show_fps = Gtk.Template.Child()
     switch_properties_hide_game = Gtk.Template.Child()
     entry_properties_variable = Gtk.Template.Child()
     entry_properties_command = Gtk.Template.Child()
     label_game_description = Gtk.Template.Child()
+    label_wine_custom = Gtk.Template.Child()
 
     def __init__(self, parent, game, api):
         Gtk.Dialog.__init__(self, title=_("Properties of {}").format(game.name), parent=parent.parent.parent,
@@ -44,9 +47,10 @@ class Properties(Gtk.Dialog):
         # Disable/Enable buttons
         self.button_sensitive(game)
 
-        # Retrieve variable & command each time Properties is open
+        # Retrieve variable, command & custom wine path each time Properties is open
         self.entry_properties_variable.set_text(self.game.get_info("variable"))
         self.entry_properties_command.set_text(self.game.get_info("command"))
+        self.button_properties_wine.set_filename(self.game.get_info("custom_wine"))
 
         # Keep switch FPS disabled/enabled
         self.switch_properties_show_fps.set_active(self.game.get_info("show_fps"))
@@ -70,6 +74,16 @@ class Properties(Gtk.Dialog):
         self.game.set_info("hide_game", self.switch_properties_hide_game.get_active())
         self.parent.parent.filter_library()
         self.destroy()
+
+    @Gtk.Template.Callback("on_button_properties_wine_file_set")
+    def on_button_properties_wine(self, widget):
+        self.game.set_info("custom_wine", str(self.button_properties_wine.get_filename()))
+
+    @Gtk.Template.Callback("on_button_properties_reset_clicked")
+    def on_menu_button_reset(self, widget):
+        if self.game.get_info("custom_wine") is not None:
+            self.button_properties_wine.unselect_filename(self.game.get_info("custom_wine"))
+            self.game.set_info("custom_wine", "")
 
     @Gtk.Template.Callback("on_button_properties_winecfg_clicked")
     def on_menu_button_winecfg(self, widget):
@@ -145,9 +159,14 @@ class Properties(Gtk.Dialog):
             self.button_properties_winecfg.set_sensitive(False)
             self.entry_properties_command.set_sensitive(False)
             self.entry_properties_variable.set_sensitive(False)
+            self.button_properties_wine.set_sensitive(False)
+            self.button_properties_reset.set_sensitive(False)
             self.button_properties_regedit.set_sensitive(False)
             self.switch_properties_show_fps.set_sensitive(False)
 
         if game.platform == 'linux':
             self.button_properties_winecfg.hide()
             self.button_properties_regedit.hide()
+            self.button_properties_wine.hide()
+            self.button_properties_reset.hide()
+            self.label_wine_custom.hide()


### PR DESCRIPTION
Hi,

With this PR, the user have the possibility to use a custom wine version for their game instead of wine system.

In my case, it's very interesting since i have a 4K monitor and old games do not have high resolution. Xorg is old too and does not set the game to fullscreen if the game's resolution is < desktop's resolution.
This screenshot can explain the issue : https://i.postimg.cc/WzkrZCs4/Capture-d-cran-de-2021-12-16-08-05-30.png

Wine-Wayland (which is still in active development and not upstream) or Proton have patches/solution to fix this kind of issue.
Of course if the game desktop's resolution is the same as game's resolution, you don't have this issue.

For users, it can be interesting to use Proton because it has more patches to increase game's performance which are not implemented in Wine.

To finish my explanation, a video to show you how it works : https://youtu.be/5MxLDiIK6Fw