### PR TITLE
Minor README tweaks and reformatted licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,12 +1,11 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 3, 29 June 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The GNU General Public License is a free, copyleft license for
 software and other kinds of works.
@@ -69,7 +68,7 @@ patents cannot be used to render the program non-free.
   The precise terms and conditions for copying, distribution and
 modification follow.
 
-		       TERMS AND CONDITIONS
+                       TERMS AND CONDITIONS
 
   0. Definitions.
 
@@ -77,7 +76,7 @@ modification follow.
 
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
- 
+
   "The Program" refers to any copyrightable work licensed under this
 License.  Each licensee is addressed as "you".  "Licensees" and
 "recipients" may be individuals or organizations.
@@ -510,7 +509,7 @@ actual knowledge that, but for the patent license, your conveying the
 covered work in a country, or your recipient's use of the covered work
 in a country, would infringe one or more identifiable patents in that
 country that you have reason to believe are valid.
-  
+
   If, pursuant to or in connection with a single transaction or
 arrangement, you convey, or propagate by procuring conveyance of, a
 covered work, and grant a patent license to some of the parties
@@ -619,9 +618,9 @@ an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
 
-		     END OF TERMS AND CONDITIONS
+                     END OF TERMS AND CONDITIONS
 
-	    How to Apply These Terms to Your New Programs
+            How to Apply These Terms to Your New Programs
 
   If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
@@ -646,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -665,12 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
-
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minigalaxy
 
-A simple GOG client for Linux
+A simple GOG client for Linux.
 
 ![screenshot](screenshot.jpg?raw=true)
 
@@ -10,24 +10,25 @@ The most important features of Minigalaxy:
 
 - Log in with your GOG account
 - Download the Linux games you own on GOG
-- Launch them
+- Launch them!
 
 In addition to that, Minigalaxy also allows you to:
 
 - Update your games
 - Install and update DLC
-- Select in which language you'd prefer to download your games
+- Select which language you'd prefer to download your games in
 - Change where games are installed
 - Search your GOG Linux library
 - Show all games or just the ones you've installed
 - View the error message if a game fails to launch
 - Enable displaying the FPS in games
-- Use the system's Scummvm or Dosbox installation
+- Use the system's ScummVM or DOSBox installation
 - Install Windows games using Wine
 
 ## Supported languages
 
-Currently Minigalaxy can be displayed in the following languages:
+Currently, Minigalaxy can be displayed in the following languages:
+
 - Brazilian Portuguese
 - Czech
 - English
@@ -51,16 +52,17 @@ Currently Minigalaxy can be displayed in the following languages:
 
 Minigalaxy should work on the following distributions:
 
-- Debian Buster (10.0) or newer
+- Debian 10 or newer
 - Ubuntu 18.10 or newer
 - Linux Mint 20 or newer
 - Arch Linux
 - Manjaro
-- Fedora 31+
-- openSUSE Tumbleweed
-- Gentoo
-- MX Linux 19
+- Fedora Linux 31 or newer
+- openSUSE Tumbleweed and Leap 15.2 or newer
+- Gentoo Linux
+- MX Linux 19 or newer
 - Solus
+- Void Linux
 
 Minigalaxy does **not** ship for the following distributions because they do not contain the required version of PyGObject:
 
@@ -82,10 +84,16 @@ Other Linux distributions may work as well. Minigalaxy requires the following de
     <img src="https://repology.org/badge/vertical-allrepos/minigalaxy.svg" alt="Packaging status" align="right">
 </a>
 
-<details><summary>Ubuntu/Debian</summary>
+<details><summary>Debian/Ubuntu</summary>
 
-Download the latest deb package from the <a href="https://github.com/sharkwouter/minigalaxy/releases">releases page</a> and install it.
+Available in the official repositories since Debian 11 and Ubuntu 21.04. You can install it with:
+<pre>
+sudo apt install minigalaxy
+</pre>
+
+You can also download the latest .deb package from the <a href="https://github.com/sharkwouter/minigalaxy/releases">releases page</a> and install it that way.
 </details>
+
 <details><summary>Arch/Manjaro</summary>
 
 Available the <a href="https://aur.archlinux.org/packages/minigalaxy">AUR</a>. You can use an AUR helper or use the following set of commands to install Minigalaxy on Arch:
@@ -98,7 +106,7 @@ makepkg -si
 
 <details><summary>Fedora</summary>
 
-Available in <a href="https://src.fedoraproject.org/rpms/minigalaxy">official repos</a> (F31+)
+Available in the <a href="https://src.fedoraproject.org/rpms/minigalaxy">official repositories</a> since Fedora 31. You can install it with:
 <pre>
 sudo dnf install minigalaxy
 </pre>
@@ -106,7 +114,12 @@ sudo dnf install minigalaxy
 
 <details><summary>openSUSE</summary>
 
-Available in official repos for openSUSE Tumbleweed. You can use the following set of commands to install Minigalaxy on openSUSE from the devel project on <a href="https://build.opensuse.org/package/show/games:tools/minigalaxy">OBS</a>:
+Available in the official repositories for openSUSE Tumbleweed and also Leap since 15.2. You can install it with:
+<pre>
+sudo zypper in minigalaxy
+</pre>
+
+Alternatively, you can use the following set of commands to install Minigalaxy on openSUSE from the devel project on <a href="https://build.opensuse.org/package/show/games:tools/minigalaxy">OBS</a>:
 <pre>
 sudo zypper ar -f obs://games:tools gamestools
 sudo zypper ref
@@ -116,24 +129,33 @@ sudo zypper in minigalaxy
 
 <details><summary>Gentoo</summary>
 
-Available in the <a href="https://github.com/metafarion/metahax">in the Metahax overlay</a>. Follow the instructions in the link to install Minigalaxy on Gentoo.
+Available in the <a href="https://github.com/metafarion/metahax">Metahax overlay</a>. Follow the instructions in the link to install Minigalaxy on Gentoo.
 </details>
 
 <details><summary>MX Linux</summary>
 
-Currently available in the <a href="http://mxrepo.com/mx/repo/pool/main/m/minigalaxy/">official repository</a>.  Please use MX Package Installer or Synaptic instead of manually installing the .deb from the repo.
+Available in the <a href="http://mxrepo.com/mx/repo/pool/main/m/minigalaxy/">official repository</a>.  Please use MX Package Installer or Synaptic instead of manually installing the .deb from the repo.
 </details>
+
 <details><summary>Solus</summary>
  
-Available in the official repositories. You can use the following command to install Minigalaxy on Solus:
+Available in the official repositories. You can install it with:
 <pre>
 sudo eopkg it minigalaxy
 </pre>
 </details>
 
+<details><summary>Void Linux</summary>
+
+Available in the official repositories. You can install it with:
+<pre>
+sudo xbps-install -S minigalaxy
+</pre>
+</details>
+
 <details><summary>Other distributions</summary>
 
-On other distributions Minigalaxy can be downloaded and started with the following commands:
+On other distributions, Minigalaxy can be downloaded and started with the following commands:
 <pre>
 git clone https://github.com/sharkwouter/minigalaxy.git
 cd minigalaxy
@@ -141,16 +163,17 @@ scripts/compile-translations.sh
 bin/minigalaxy
 </pre>
 
-This will be the development version. Alternatively a tarball of a specific release can be downloaded from the <a href="https://github.com/sharkwouter/minigalaxy/releases">releases page</a>.
+This will be the development version. Alternatively, a tarball of a specific release can be downloaded from the <a href="https://github.com/sharkwouter/minigalaxy/releases">releases page</a>.
 </details>
 
 ## Support
+
 If you need any help using Minigalaxy, feel free to join the [Minigalaxy Discord server](https://discord.gg/RC4cXVD).
 Bugs reports and feature requests can also be made [here](https://github.com/sharkwouter/minigalaxy/issues).
 
 ## Contribute
 
-Currently help is needed with the following:
+Currently, help is needed with the following:
 
 - Reporting bugs in the [issue tracker](https://github.com/sharkwouter/minigalaxy/issues).
 - Translating to different languages. Instructions [here](https://github.com/sharkwouter/minigalaxy/wiki/Translating-Minigalaxy).


### PR DESCRIPTION
Hi,

I made a few small changes to the README, including installation instructions for Void Linux, as well as updated installation information for Debian and Ubuntu (since Minigalaxy is in the official repositories for both of them now) and some minor grammar tweaks.

I also copied and pasted the licence text [directly from gnu.org](https://www.gnu.org/licenses/gpl-3.0.txt) so GitHub should correctly recognise it as the GPLv3.

Thanks and keep up the good work. Minigalaxy is a godsend!