### PR TITLE
Use thumbnail cache

### DIFF
--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -161,23 +161,27 @@ class GameTile(Gtk.Box):
         download_thread.start()
 
     def load_thumbnail(self):
-        set_result = self.__set_image("")
-        if not set_result:
-            tries = 10
-            performed_try = 0
-            while performed_try < tries:
-                if self.game.image_url and self.game.id:
-                    # Download the thumbnail
-                    image_url = "https:{}_196.jpg".format(self.game.image_url)
-                    thumbnail = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
+        thumbnail_path = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
+        if os.path.isfile(thumbnail_path):
+            GLib.idle_add(self.image.set_from_file, thumbnail_path)
+        else:
+            set_result = self.__set_image("")
+            if not set_result:
+                tries = 10
+                performed_try = 0
+                while performed_try < tries:
+                    if self.game.image_url and self.game.id:
+                        # Download the thumbnail
+                        image_url = "https:{}_196.jpg".format(self.game.image_url)
+                        thumbnail = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
 
-                    download = Download(image_url, thumbnail, finish_func=self.__set_image)
-                    DownloadManager.download_now(download)
-                    set_result = True
-                    break
-                performed_try += 1
-                time.sleep(1)
-        return set_result
+                        download = Download(image_url, thumbnail, finish_func=self.__set_image)
+                        DownloadManager.download_now(download)
+                        set_result = True
+                        break
+                    performed_try += 1
+                    time.sleep(1)
+            return set_result
 
     def __set_image(self, save_location):
         set_result = False

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -161,27 +161,23 @@ class GameTile(Gtk.Box):
         download_thread.start()
 
     def load_thumbnail(self):
-        thumbnail_path = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
-        if os.path.isfile(thumbnail_path):
-            GLib.idle_add(self.image.set_from_file, thumbnail_path)
-        else:
-            set_result = self.__set_image("")
-            if not set_result:
-                tries = 10
-                performed_try = 0
-                while performed_try < tries:
-                    if self.game.image_url and self.game.id:
-                        # Download the thumbnail
-                        image_url = "https:{}_196.jpg".format(self.game.image_url)
-                        thumbnail = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
+        set_result = self.__set_image("")
+        if not set_result:
+            tries = 10
+            performed_try = 0
+            while performed_try < tries:
+                if self.game.image_url and self.game.id:
+                    # Download the thumbnail
+                    image_url = "https:{}_196.jpg".format(self.game.image_url)
+                    thumbnail = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
 
-                        download = Download(image_url, thumbnail, finish_func=self.__set_image)
-                        DownloadManager.download_now(download)
-                        set_result = True
-                        break
-                    performed_try += 1
-                    time.sleep(1)
-            return set_result
+                    download = Download(image_url, thumbnail, finish_func=self.__set_image)
+                    DownloadManager.download_now(download)
+                    set_result = True
+                    break
+                performed_try += 1
+                time.sleep(1)
+        return set_result
 
     def __set_image(self, save_location):
         set_result = False
@@ -195,6 +191,10 @@ class GameTile(Gtk.Box):
             # Copy image to
             if os.path.isdir(os.path.dirname(thumbnail_install_dir)):
                 shutil.copy2(save_location, thumbnail_install_dir)
+            set_result = True
+        thumbnail_path = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
+        if os.path.isfile(thumbnail_path):
+            GLib.idle_add(self.image.set_from_file, thumbnail_path)
             set_result = True
         return set_result
 

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -164,23 +164,27 @@ class GameTileList(Gtk.Box):
         download_thread.start()
 
     def load_thumbnail(self):
-        set_result = self.__set_image("")
-        if not set_result:
-            tries = 10
-            performed_try = 0
-            while performed_try < tries:
-                if self.game.image_url and self.game.id:
-                    # Download the thumbnail
-                    image_url = "https:{}_196.jpg".format(self.game.image_url)
-                    thumbnail = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
+        thumbnail_path = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
+        if os.path.isfile(thumbnail_path):
+            GLib.idle_add(self.image.set_from_file, thumbnail_path)
+        else:
+            set_result = self.__set_image("")
+            if not set_result:
+                tries = 10
+                performed_try = 0
+                while performed_try < tries:
+                    if self.game.image_url and self.game.id:
+                        # Download the thumbnail
+                        image_url = "https:{}_196.jpg".format(self.game.image_url)
+                        thumbnail = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
 
-                    download = Download(image_url, thumbnail, finish_func=self.__set_image)
-                    DownloadManager.download_now(download)
-                    set_result = True
-                    break
-                performed_try += 1
-                time.sleep(1)
-        return set_result
+                        download = Download(image_url, thumbnail, finish_func=self.__set_image)
+                        DownloadManager.download_now(download)
+                        set_result = True
+                        break
+                    performed_try += 1
+                    time.sleep(1)
+            return set_result
 
     def __set_image(self, save_location):
         set_result = False

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -164,27 +164,23 @@ class GameTileList(Gtk.Box):
         download_thread.start()
 
     def load_thumbnail(self):
-        thumbnail_path = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
-        if os.path.isfile(thumbnail_path):
-            GLib.idle_add(self.image.set_from_file, thumbnail_path)
-        else:
-            set_result = self.__set_image("")
-            if not set_result:
-                tries = 10
-                performed_try = 0
-                while performed_try < tries:
-                    if self.game.image_url and self.game.id:
-                        # Download the thumbnail
-                        image_url = "https:{}_196.jpg".format(self.game.image_url)
-                        thumbnail = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
+        set_result = self.__set_image("")
+        if not set_result:
+            tries = 10
+            performed_try = 0
+            while performed_try < tries:
+                if self.game.image_url and self.game.id:
+                    # Download the thumbnail
+                    image_url = "https:{}_196.jpg".format(self.game.image_url)
+                    thumbnail = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
 
-                        download = Download(image_url, thumbnail, finish_func=self.__set_image)
-                        DownloadManager.download_now(download)
-                        set_result = True
-                        break
-                    performed_try += 1
-                    time.sleep(1)
-            return set_result
+                    download = Download(image_url, thumbnail, finish_func=self.__set_image)
+                    DownloadManager.download_now(download)
+                    set_result = True
+                    break
+                performed_try += 1
+                time.sleep(1)
+        return set_result
 
     def __set_image(self, save_location):
         set_result = False
@@ -198,6 +194,10 @@ class GameTileList(Gtk.Box):
             # Copy image to
             if os.path.isdir(os.path.dirname(thumbnail_install_dir)):
                 shutil.copy2(save_location, thumbnail_install_dir)
+            set_result = True
+        thumbnail_path = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
+        if os.path.isfile(thumbnail_path):
+            GLib.idle_add(self.image.set_from_file, thumbnail_path)
             set_result = True
         return set_result
 


### PR DESCRIPTION
After start, Minigalaxy downloads thumbnails from GOG even they are already there (it just rewrites them). This PR fixes that for saving some traffic and requests to GOG.