### PR TITLE
Fix creation of Desktop Entries (menu items)

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -218,7 +218,7 @@ def create_applications_file(game):
         exe_cmd = get_exec_line(game)
         # Create desktop file definition
         desktop_context = {
-            "game_bin_path": exe_cmd,
+            "game_bin_path": os.path.join('"{}"'.format(game.install_dir.replace('"', '\\"')), exe_cmd),
             "game_name": game.name,
             "game_install_dir": game.install_dir,
             "game_icon_path": os.path.join(game.install_dir, 'support/icon.png')


### PR DESCRIPTION
According to the [FreeDesktop Desktop Entry
Specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html),
if the value under the `Exec` key contains a space (among others), that
value must be quoted.
Moreover, on my Gnome desktop environment, the Desktop Entries generated
by minigalaxy prior to this commit do not appear to be valid (they don't
show up in the applications menu): apparently, one needs to put in an
absolute path, or a bare name. It looks like relative paths aren't
supported.