### PR TITLE
Add multiple downloads and document DownloadManager

### DIFF
--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -71,3 +71,5 @@ MINIMUM_RESUME_SIZE = 50 * 1024**2  # 50 MB
 
 SESSION = requests.Session()
 SESSION.headers.update({'User-Agent': 'Minigalaxy/{} (Linux {})'.format(VERSION, platform.machine())})
+
+NUMBER_DOWNLOAD_THREADS = 4

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -72,4 +72,7 @@ MINIMUM_RESUME_SIZE = 50 * 1024**2  # 50 MB
 SESSION = requests.Session()
 SESSION.headers.update({'User-Agent': 'Minigalaxy/{} (Linux {})'.format(VERSION, platform.machine())})
 
-NUMBER_DOWNLOAD_THREADS = 4
+# UI download threads are for UI assets like thumbnails or icons
+UI_DOWNLOAD_THREADS = 4
+# Game download threads are for long-running downloads like games, DLC or updates
+GAME_DOWNLOAD_THREADS = 4

--- a/minigalaxy/download.py
+++ b/minigalaxy/download.py
@@ -1,5 +1,13 @@
+from enum import Enum
 from zipfile import BadZipFile
 
+# Enums were added in Python 3.4
+class DownloadType(Enum):
+    ICON = 1
+    THUMBNAIL = 2
+    GAME = 3
+    GAME_UPDATE = 4
+    GAME_DLC = 5
 
 class Download:
     """
@@ -7,17 +15,16 @@ class Download:
 
     Usage:
     >>> import os
-    >>> from minigalaxy.download import Download
+    >>> from minigalaxy.download import Download, DownloadType
     >>> from minigalaxy.download_manager import DownloadManager
     >>> def your_function():
     >>>   image_url = "https://www.gog.com/bundles/gogwebsitestaticpages/images/icon_section1-header.png"
     >>>   thumbnail = os.path.join(".", "{}.jpg".format("test-icon"))
-    >>>   download = Download(image_url, thumbnail, finish_func=lambda x: print("Done downloading {}!".format(x)))
+    >>>   download = Download(image_url, thumbnail, DownloadType.THUMBNAIL, finish_func=lambda x: print("Done downloading {}!".format(x)))
     >>> your_function() # doctest: +SKIP
-
-
     """
-    def __init__(self, url, save_location, finish_func=None, progress_func=None, cancel_func=None, number=1,
+    def __init__(self, url, save_location, download_type=None, finish_func=None,
+                 progress_func=None, cancel_func=None, number=1,
                  out_of_amount=1, game=None):
         self.url = url
         self.save_location = save_location
@@ -27,6 +34,8 @@ class Download:
         self.number = number
         self.out_of_amount = out_of_amount
         self.game = game
+        # Type of object, e.g. icon, thumbnail, game, dlc,
+        self.download_type = download_type
 
     def set_progress(self, percentage: int) -> None:
         "Set the download progress of the Download"

--- a/minigalaxy/download.py
+++ b/minigalaxy/download.py
@@ -2,6 +2,21 @@ from zipfile import BadZipFile
 
 
 class Download:
+    """
+    A class to easily download from URLs and save the file.
+
+    Usage:
+    >>> import os
+    >>> from minigalaxy.download import Download
+    >>> from minigalaxy.download_manager import DownloadManager
+    >>> def your_function():
+    >>>   image_url = "https://www.gog.com/bundles/gogwebsitestaticpages/images/icon_section1-header.png"
+    >>>   thumbnail = os.path.join(".", "{}.jpg".format("test-icon"))
+    >>>   download = Download(image_url, thumbnail, finish_func=lambda x: print("Done downloading {}!".format(x)))
+    >>> your_function() # doctest: +SKIP
+
+
+    """
     def __init__(self, url, save_location, finish_func=None, progress_func=None, cancel_func=None, number=1,
                  out_of_amount=1, game=None):
         self.url = url
@@ -14,6 +29,7 @@ class Download:
         self.game = game
 
     def set_progress(self, percentage: int) -> None:
+        "Set the download progress of the Download"
         if self.__progress_func:
             if self.out_of_amount > 1:
                 # Change the percentage based on which number we are
@@ -23,6 +39,10 @@ class Download:
             self.__progress_func(percentage)
 
     def finish(self):
+        """
+        finish is called when the download has completed
+        If a finish_func was specified when the Download was created, call the function
+        """
         if self.__finish_func:
             try:
                 self.__finish_func(self.save_location)
@@ -30,5 +50,6 @@ class Download:
                 self.cancel()
 
     def cancel(self):
+        "Cancel the download, calling a cancel_func if one was specified"
         if self.__cancel_func:
             self.__cancel_func()

--- a/minigalaxy/download.py
+++ b/minigalaxy/download.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from zipfile import BadZipFile
 
+
 # Enums were added in Python 3.4
 class DownloadType(Enum):
     ICON = 1
@@ -8,6 +9,7 @@ class DownloadType(Enum):
     GAME = 3
     GAME_UPDATE = 4
     GAME_DLC = 5
+
 
 class Download:
     """
@@ -20,7 +22,7 @@ class Download:
     >>> def your_function():
     >>>   image_url = "https://www.gog.com/bundles/gogwebsitestaticpages/images/icon_section1-header.png"
     >>>   thumbnail = os.path.join(".", "{}.jpg".format("test-icon"))
-    >>>   download = Download(image_url, thumbnail, DownloadType.THUMBNAIL, finish_func=lambda x: print("Done downloading {}!".format(x)))
+    >>>   download = Download(image_url, thumbnail, DownloadType.THUMBNAIL, finish_func=lambda x: print("Done downloading {}!".format(x))) # noqa: E501
     >>> your_function() # doctest: +SKIP
     """
     def __init__(self, url, save_location, download_type=None, finish_func=None,

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -224,7 +224,6 @@ class __DownloadManger:
                 # Mark the task as done to keep counts correct so
                 # we can use join() or other functions later
                 download_queue.task_done()
-            time.sleep(0.2)
 
     def __download_file(self, download, download_queue):
         """

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -1,3 +1,21 @@
+"""
+A DownloadManager that provides an interface to manage and retry downloads.
+
+First, you need to create a Download object, then pass the Download object to the
+DownloadManager to download it.
+
+Example:
+>>> import os
+>>> from minigalaxy.download import Download
+>>> from minigalaxy.download_manager import DownloadManager
+>>> def your_function():
+>>>   image_url = "https://www.gog.com/bundles/gogwebsitestaticpages/images/icon_section1-header.png"
+>>>   thumbnail = os.path.join(".", "{}.jpg".format("test-icon"))
+>>>   download = Download(image_url, thumbnail, finish_func=lambda x: print("Done downloading {}!".format(x)))
+>>>   DownloadManager.download(download)
+>>> your_function() # doctest: +SKIP
+"""
+import logging
 import os
 import shutil
 import time
@@ -6,84 +24,198 @@ import queue
 
 from requests.exceptions import RequestException
 from minigalaxy.config import Config
-from minigalaxy.constants import DOWNLOAD_CHUNK_SIZE, MINIMUM_RESUME_SIZE, SESSION
+from minigalaxy.constants import DOWNLOAD_CHUNK_SIZE, MINIMUM_RESUME_SIZE, SESSION, NUMBER_DOWNLOAD_THREADS
 from minigalaxy.download import Download
+import minigalaxy.logger
 
+module_logger = logging.getLogger("minigalaxy.download_manager")
+
+class QueuedDownloadItem:
+    """
+    Wrap downloads in a simple class so we can manage when to download them
+    """
+    def __init__(self, download, priority=1):
+        """
+        Create a QueuedDownloadItem with a given download and priority level
+        """
+        self.priority = priority
+        self.item = download
+        self.queue_time = time.time_ns()
+
+    def __lt__(self, other):
+        """
+        Only compare QueuedDownloadItems on their priority level and
+        time added to the queue.
+        Later versions might use other factors (size, download type, etc.)
+        For example, UX needs might want to prioritize items and other UI assets.
+        """
+        if self.priority != other.priority:
+            return self.priority < other.priority
+        else:
+            return self.queue_time < other.queue_time
 
 class __DownloadManger:
-    def __init__(self):
-        self.__queue = queue.Queue()
-        self.__current_download = None
-        self.__cancel = False
-        self.__paused = False
+    """
+    A DownloadManager that provides an interface to manage and retry downloads.
 
-        download_thread = threading.Thread(target=self.__download_thread)
-        download_thread.daemon = True
-        download_thread.start()
+    First, you need to create a Download object, then pass the Download object to the
+    DownloadManager download or download_now method to download it.
+    """
+    def __init__(self):
+        """
+        Create a new DownloadManager Object
+
+        Args:
+            This initializer takes no arguments
+        """
+        # The Queue to store items for download
+        self.__queue = queue.PriorityQueue()
+        self.__cancel = {}
+        self.__paused = False
+        self.workers = []
+        # The list of currently active downloads
+        self.active_downloads = {}
+        self.active_downloads_lock = threading.Lock()
+
+        self.logger = logging.getLogger("minigalaxy.download_manager.DownloadManager")
+
+        for i in range(NUMBER_DOWNLOAD_THREADS):
+            download_thread = threading.Thread(target=lambda: self.__download_thread(i))
+            download_thread.id = i
+            download_thread.daemon = True
+            download_thread.start()
+            self.workers.append(download_thread)
 
     def download(self, download):
+        """
+        Add a download or list of downloads to the queue for downloading
+        You can download a single Download or a list of Downloads
+
+        Args:
+            A single Download or a list of Download objects
+        """
         if isinstance(download, Download):
-            self.__queue.put(download)
+            self.__queue.put(QueuedDownloadItem(download))
         else:
             # Assume we've received a list of downloads
             for d in download:
-                self.__queue.put(d)
+                self.__queue.put(QueuedDownloadItem(d))
 
     def download_now(self, download):
-        download_file_thread = threading.Thread(target=self.__download_file, args=(download,))
-        download_file_thread.daemon = True
-        download_file_thread.start()
+        """
+        Download an item with a higher priority
+        Any item with the download_now priority set will get downloaded
+        before other items.
+
+        This is useful for things like thumbnails and icons that are important
+        for UX responsiveness.
+
+        Args:
+            The Download to download
+        """
+        self.__queue.put(QueuedDownloadItem(download, 0))
 
     def cancel_download(self, downloads):
+        """
+        Cancel a download or a list of downloads
+
+        Args:
+            A single Download or a list of Download objects
+        """
+        self.logger.debug("Canceling download: {}".format(downloads))
         # Make sure we're always dealing with a list
         if isinstance(downloads, Download):
             downloads = [downloads]
 
         for download in downloads:
-            if download == self.__current_download:
-                self.cancel_current_download()
-            else:
-                self.__paused = True
-                new_queue = queue.Queue()
-                while not self.__queue.empty():
-                    queued_download = self.__queue.get()
-                    if download == queued_download:
-                        download.cancel()
-                    elif download.game == queued_download.game:
-                        download.cancel()
-                    else:
-                        new_queue.put(queued_download)
-                self.__queue = new_queue
-                self.__paused = False
+            with self.active_downloads_lock:
+                if download in self.active_downloads:
+                    self.logger.debug("Found download")
+                    self.__cancel[download] = True
+                else:
+                    self.__paused = True
+                    new_queue = queue.PriorityQueue()
+                    while not self.__queue.empty():
+                        queued_download = self.__queue.get()
+                        if download == queued_download.item:
+                            download.cancel()
+                        elif download.game == queued_download.item.game:
+                            download.cancel()
+                        else:
+                            new_queue.put(queued_download)
+                        # Mark the task as "done" to keep counts correct so
+                        # we can use join() or other functions later
+                        self.__queue.task_done()
+                    self.__queue = new_queue
+                    self.__paused = False
 
-    def cancel_current_download(self):
-        self.__cancel = True
+    def cancel_current_downloads(self):
+        """
+        Cancel the currentl downloads
+        """
+        self.logger.debug("Canceling current download")
+        with self.active_downloads_lock:
+            for download in self.active_downloads:
+                self.__cancel[download] = True
 
     def cancel_all_downloads(self):
+        """
+        Cancel all current downloads queued
+        """
+        self.logger.debug("Canceling all downloads")
+        self.logger.debug("queue length: {}".format(self.__queue.qsize()))
         while not self.__queue.empty():
-            self.__queue.get()
-        self.cancel_current_download()
+            download = self.__queue.get().item
+            self.logger.debug("canceling another download: {}".format(download.save_location))
+            # Mark the task as "done" to keep counts correct so
+            # we can use join() or other functions later
+            self.__queue.task_done()
+        self.cancel_current_downloads()
 
-        # wait for the download to be fully cancelled
-        while self.__current_download:
-            time.sleep(0.1)
+    def __remove_download_from_active_downloads(self, download):
+        "Remove a download from the list of active downloads"
+        with self.active_downloads_lock:
+            if download in self.active_downloads:
+                self.logger.debug("Removing download from active downloads list")
+                del self.active_downloads[download]
+            else:
+                self.logger.debug("Didn't find download in active downloads list")
 
-    def __download_thread(self):
+    def __download_thread(self, id=0):
+        """
+        The main DownloadManager thread calls this when it is created
+        It checks the queue, starting new downloads when they are available
+        Users of this library should not need to call this.
+        """
         while True:
             if not self.__queue.empty():
-                self.__current_download = self.__queue.get()
-                self.__download_file(self.__current_download)
+                # Update the active downloads
+                with self.active_downloads_lock:
+                    download = self.__queue.get().item
+                    self.active_downloads[download] = download
+                self.__download_file(download, id)
+                # Mark the task as done to keep counts correct so
+                # we can use join() or other functions later
+                self.__queue.task_done()
             time.sleep(0.1)
 
-    def __download_file(self, download):
-        self.prepare_location(download.save_location)
+    def __download_file(self, download, id=0):
+        """
+        This is called by __download_thread to download a file
+        It is also called directly by the thread created in download_now
+        Users of this library should not need to call this.
+
+        Args:
+            The Download to download
+        """
+        self.__prepare_location(download.save_location)
         download_max_attempts = 5
         download_attempt = 0
         result = False
         while download_attempt < download_max_attempts:
             try:
-                start_point, download_mode = self.get_start_point_and_download_mode(download)
-                result = self.download_operation(download, start_point, download_mode)
+                start_point, download_mode = self.__get_start_point_and_download_mode(download)
+                result = self.__download_operation(download, start_point, download_mode)
                 break
             except RequestException as e:
                 print(e)
@@ -91,18 +223,29 @@ class __DownloadManger:
         # Successful downloads
         if result:
             if download.number == download.out_of_amount:
+                self.logger.debug("Download finished, thread {}".format(id))
                 finish_thread = threading.Thread(target=download.finish)
                 finish_thread.start()
+            self.__remove_download_from_active_downloads(download)
             if self.__queue.empty():
-                Config.unset("current_download")
+                Config.unset("current_downloads")
         # Unsuccessful downloads and cancels
         else:
-            self.__cancel = False
+            if download in self.__cancel:
+                del self.__cancel[download]
             download.cancel()
-            self.__current_download = None
+            self.__remove_download_from_active_downloads(download)
             os.remove(download.save_location)
+            # We may want to unset current_downloads here
+            # For example, if a download was added that is impossible to complete
 
-    def prepare_location(self, save_location):
+    def __prepare_location(self, save_location):
+        """
+        Make sure the download directory exists and the file doesn't already exist
+
+        Args:
+            A filename string, where the download should be saved
+        """
         # Make sure the directory exists
         save_directory = os.path.dirname(save_location)
         if not os.path.isdir(save_directory):
@@ -111,23 +254,38 @@ class __DownloadManger:
         # Fail if the file already exists
         if os.path.isdir(save_location):
             shutil.rmtree(save_location)
-            print("{} is a directory. Will remove it, to make place for installer.".format(save_location))
+            self.logger.debug("{} is a directory. Will remove it, to make place for installer.".format(save_location))
 
-    def get_start_point_and_download_mode(self, download):
-        # Resume the previous download if possible
+    def __get_start_point_and_download_mode(self, download):
+        """
+        Resume the previous download if possible
+
+        Args:
+            The Download to download
+        """
         start_point = 0
         download_mode = 'wb'
         if os.path.isfile(download.save_location):
             if self.__is_same_download_as_before(download):
-                print("Resuming download {}".format(download.save_location))
+                self.logger.debug("Resuming download {}".format(download.save_location))
                 download_mode = 'ab'
                 start_point = os.stat(download.save_location).st_size
             else:
                 os.remove(download.save_location)
         return start_point, download_mode
 
-    def download_operation(self, download, start_point, download_mode):
-        # Download the file
+    def __download_operation(self, download, start_point, download_mode):
+        """
+        Download the file
+        This is called by __download_file to actually perform the download
+
+        Args:
+            The Download to download
+            The start point in the download, specified in bytes
+            The file mode to save the file as.
+              For example, "wb" to create a new file
+              or "ab" to append to a file for download resumes
+        """
         resume_header = {'Range': 'bytes={}-'.format(start_point)}
         download_request = SESSION.get(download.url, headers=resume_header, stream=True, timeout=30)
         downloaded_size = start_point
@@ -141,8 +299,10 @@ class __DownloadManger:
                         time.sleep(0.1)
                     save_file.write(chunk)
                     downloaded_size += len(chunk)
-                    if self.__cancel:
+                    if download in self.__cancel:
+                        self.logger.debug("Canceling download: {}".format(download.save_location))
                         result = False
+                        del self.__cancel[download]
                         break
                     if file_size > 0:
                         progress = int(downloaded_size / file_size * 100)
@@ -150,9 +310,17 @@ class __DownloadManger:
                 save_file.close()
         else:
             download.set_progress(100)
+        self.logger.debug("Returning result from _download_operation: {}".format(result))
         return result
 
     def __is_same_download_as_before(self, download):
+        """
+        Return true if the download is the same as an item with the same save_location
+        already downloaded.
+
+        Args:
+            The Download to check
+        """
         file_stats = os.stat(download.save_location)
         # Don't resume for very small files
         if file_stats.st_size < MINIMUM_RESUME_SIZE:
@@ -165,6 +333,5 @@ class __DownloadManger:
             with open(download.save_location, "rb") as file:
                 file_content = file.read(size_to_check)
                 return file_content == chunk
-
 
 DownloadManager = __DownloadManger()

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -11,7 +11,7 @@ Example:
 >>> def your_function():
 >>>   image_url = "https://www.gog.com/bundles/gogwebsitestaticpages/images/icon_section1-header.png"
 >>>   thumbnail = os.path.join(".", "{}.jpg".format("test-icon"))
->>>   download = Download(image_url, thumbnail, DownloadType.THUMBNAIL, finish_func=lambda x: print("Done downloading {}!".format(x)))
+>>>   download = Download(image_url, thumbnail, DownloadType.THUMBNAIL, finish_func=lambda x: print("Done downloading {}!".format(x))) # noqa: E501
 >>>   DownloadManager.download(download)
 >>> your_function() # doctest: +SKIP
 """
@@ -26,9 +26,10 @@ from requests.exceptions import RequestException
 from minigalaxy.config import Config
 from minigalaxy.constants import DOWNLOAD_CHUNK_SIZE, MINIMUM_RESUME_SIZE, SESSION, GAME_DOWNLOAD_THREADS, UI_DOWNLOAD_THREADS
 from minigalaxy.download import Download, DownloadType
-import minigalaxy.logger
+import minigalaxy.logger    # noqa: F401
 
 module_logger = logging.getLogger("minigalaxy.download_manager")
+
 
 class QueuedDownloadItem:
     """
@@ -53,6 +54,7 @@ class QueuedDownloadItem:
             return self.priority < other.priority
         else:
             return self.queue_time < other.queue_time
+
 
 class __DownloadManger:
     """
@@ -161,6 +163,7 @@ class __DownloadManger:
                     self.__paused = True
                     for download_queue, limit in self.queues:
                         # We may need to wrap this swap of the priority queue in a lock
+                        new_queue = queue.PriorityQueue()
                         while not download_queue.empty():
                             queued_download = download_queue.get()
                             if download == queued_download.item:
@@ -172,6 +175,7 @@ class __DownloadManger:
                             # Mark the task as "done" to keep counts correct so
                             # we can use join() or other functions later
                             download_queue.task_done()
+                        download_queue = new_queue
                     self.__paused = False
 
     def cancel_current_downloads(self):
@@ -359,5 +363,6 @@ class __DownloadManger:
             with open(download.save_location, "rb") as file:
                 file_content = file.read(size_to_check)
                 return file_content == chunk
+
 
 DownloadManager = __DownloadManger()

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -125,7 +125,7 @@ class __DownloadManger:
         else:
             # Add other items to the UI queue
             self.__ui_queue.put(QueuedDownloadItem(download, 0))
-            
+
     def download_now(self, download):
         """
         Download an item with a higher priority
@@ -143,8 +143,6 @@ class __DownloadManger:
     def cancel_download(self, downloads):
         """
         Cancel a download or a list of downloads
-        This only cancels items in the game download queue
-        Items in the UI queue are not deleted
 
         Args:
             A single Download or a list of Download objects

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -159,6 +159,20 @@ class __DownloadManger:
 
         # This follows the previous logic
         # First cancel all the active downloads
+        self.cancel_queued_downloads(download_dict)
+
+        # Next, loop through the downloads queued for download, comparing them to the
+        # cancel list
+        self.cancel_queued_downloads(download_dict)
+
+    def cancel_active_downloads(self, download_dict):
+        """
+        Cancel active downloads
+        This is called by cancel_download
+
+        Args:
+          download_dict is a dictionary of downloads to cancel with values True
+        """
         with self.active_downloads_lock:
             for download in self.active_downloads:
                 if download in download_dict:
@@ -168,8 +182,14 @@ class __DownloadManger:
                     # Remove it from the downloads to cancel
                     del download_dict[download]
 
-        # Next, loop through the downloads queued for download, comparing them to the
-        # cancel list
+    def cancel_queued_downloads(self, download_dict):
+        """
+        Cancel selected downloads in the queue
+        This is called by cancel_download
+
+        Args:
+          download_dict is a dictionary of downloads to cancel with values True
+        """
         for download in download_dict.keys():
             self.logger.debug("download: {}".format(download))
             for download_queue, limit in self.queues:

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -134,6 +134,7 @@ class __DownloadManger:
                     self.__cancel[download] = True
                 else:
                     self.__paused = True
+                    # We may need to wrap this swap of the priority queue in a lock
                     new_queue = queue.PriorityQueue()
                     while not self.__queue.empty():
                         queued_download = self.__queue.get()

--- a/minigalaxy/logger.py
+++ b/minigalaxy/logger.py
@@ -20,7 +20,8 @@ logger.setLevel(logging.DEBUG)
 
 # The console should log DEBUG messages and up
 ch = logging.StreamHandler()
-ch.setLevel(logging.ERROR)
+ch.setLevel(logging.DEBUG)
+#ch.setLevel(logging.ERROR)
 
 # create formatter and add it to the handlers
 # This doesn't use the MinigalaxyLogFormatter yet, it uses the default logging Formatter

--- a/minigalaxy/logger.py
+++ b/minigalaxy/logger.py
@@ -23,6 +23,7 @@ ch = logging.StreamHandler()
 ch.setLevel(logging.ERROR)
 
 # create formatter and add it to the handlers
+# This doesn't use the MinigalaxyLogFormatter yet, it uses the default logging Formatter
 formatter = logging.Formatter(fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 ch.setFormatter(formatter)
 

--- a/minigalaxy/logger.py
+++ b/minigalaxy/logger.py
@@ -1,0 +1,30 @@
+import logging
+import datetime
+
+class MinigalaxyLogFormatter(logging.Formatter):
+    converter = datetime.date.fromtimestamp
+
+    def formatTime(self, record, datefmt=None):
+        ct = self.converter(record.created)
+        if datefmt:
+            print("Have date format\n")
+            return ct.strftime(datefmt)
+        else:
+            time_string = ct.strftime("%Y-%m-%d %H:%M:%S")
+            time_string_with_ms = "%s,%03d" % (t, record.msecs)
+            return time_string_with_ms
+
+# create logger for the minigalaxy application
+logger = logging.getLogger('minigalaxy')
+logger.setLevel(logging.DEBUG)
+
+# The console should log DEBUG messages and up
+ch = logging.StreamHandler()
+ch.setLevel(logging.ERROR)
+
+# create formatter and add it to the handlers
+formatter = logging.Formatter(fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+ch.setFormatter(formatter)
+
+# add the handlers to the logger
+logger.addHandler(ch)

--- a/minigalaxy/logger.py
+++ b/minigalaxy/logger.py
@@ -1,5 +1,7 @@
 import logging
 import datetime
+import os
+
 
 class MinigalaxyLogFormatter(logging.Formatter):
     converter = datetime.date.fromtimestamp
@@ -11,8 +13,9 @@ class MinigalaxyLogFormatter(logging.Formatter):
             return ct.strftime(datefmt)
         else:
             time_string = ct.strftime("%Y-%m-%d %H:%M:%S")
-            time_string_with_ms = "%s,%03d" % (t, record.msecs)
+            time_string_with_ms = "%s,%03d" % (time_string, record.msecs)
             return time_string_with_ms
+
 
 # create logger for the minigalaxy application
 logger = logging.getLogger('minigalaxy')
@@ -20,8 +23,11 @@ logger.setLevel(logging.DEBUG)
 
 # The console should log DEBUG messages and up
 ch = logging.StreamHandler()
-ch.setLevel(logging.DEBUG)
-#ch.setLevel(logging.ERROR)
+debug = os.environ.get("MG_DEBUG")
+if debug:
+    ch.setLevel(logging.DEBUG)
+else:
+    ch.setLevel(logging.ERROR)
 
 # create formatter and add it to the handlers
 # This doesn't use the MinigalaxyLogFormatter yet, it uses the default logging Formatter

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -244,7 +244,7 @@ class GameTile(Gtk.Box):
         if not result:
             GLib.idle_add(self.update_to_state, cancel_to_state)
 
-    def __download(self, download_info, download_type, finish_func, cancel_to_state):
+    def __download(self, download_info, download_type, finish_func, cancel_to_state):  # noqa: C901
         download_success = True
         GLib.idle_add(self.update_to_state, self.state.QUEUED)
 

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -9,7 +9,7 @@ from enum import Enum
 from minigalaxy.translation import _
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, ICON_DIR, UI_DIR
 from minigalaxy.config import Config
-from minigalaxy.download import Download
+from minigalaxy.download import Download, DownloadType
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.launcher import start_game
 from minigalaxy.installer import uninstall_game, install_game, check_diskspace
@@ -101,7 +101,7 @@ class GameTile(Gtk.Box):
 
     # Do not restart the download if Minigalaxy is restarted
     def prevent_resume_on_startup(self):
-        download_ids = set(Config.get("current_downloads"))
+        download_ids = Config.get("current_downloads")
         if download_ids:
             new_download_ids = set()
             for download_id in download_ids:
@@ -177,8 +177,8 @@ class GameTile(Gtk.Box):
                     # Download the thumbnail
                     image_url = "https:{}_196.jpg".format(self.game.image_url)
                     thumbnail = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
-
-                    download = Download(image_url, thumbnail, finish_func=self.__set_image)
+                    download = Download(image_url, thumbnail, DownloadType.THUMBNAIL,
+                                        finish_func=self.__set_image)
                     DownloadManager.download_now(download)
                     set_result = True
                     break
@@ -221,7 +221,7 @@ class GameTile(Gtk.Box):
             result = True
         except NoDownloadLinkFound as e:
             print(e)
-            current_download_ids = set(Config.get("current_download"))
+            current_download_ids = Config.get("current_downloads")
             if current_download_ids:
                 new_current_download_ids = set()
                 for current_download_id in current_download_ids:
@@ -239,16 +239,21 @@ class GameTile(Gtk.Box):
         cancel_to_state = self.state.DOWNLOADABLE
         result, download_info = self.get_download_info()
         if result:
-            result = self.__download(download_info, finish_func, cancel_to_state)
+            result = self.__download(download_info, DownloadType.GAME, finish_func,
+                                     cancel_to_state)
         if not result:
             GLib.idle_add(self.update_to_state, cancel_to_state)
 
-    def __download(self, download_info, finish_func, cancel_to_state):
+    def __download(self, download_info, download_type, finish_func, cancel_to_state):
         download_success = True
         GLib.idle_add(self.update_to_state, self.state.QUEUED)
-        current_download_ids = set(Config.get("current_downloads"))
+
+        # Need to update the config with DownloadType metadata
+        current_download_ids = Config.get("current_downloads")
         if current_download_ids is None:
             current_download_ids = set()
+        else:
+            current_download_ids = set(current_download_ids)
         current_download_ids.add(self.game.id)
         Config.set("current_downloads", list(current_download_ids))
         # Start the download for all files
@@ -281,6 +286,7 @@ class GameTile(Gtk.Box):
             download = Download(
                 url=download_url,
                 save_location=download_path,
+                download_type=DownloadType.GAME,
                 finish_func=finish_func if download_path == executable_path else None,
                 progress_func=self.set_progress,
                 cancel_func=lambda: self.__cancel(to_state=cancel_to_state),
@@ -343,7 +349,8 @@ class GameTile(Gtk.Box):
         cancel_to_state = self.state.UPDATABLE
         result, download_info = self.get_download_info(self.game.platform)
         if result:
-            result = self.__download(download_info, finish_func, cancel_to_state)
+            result = self.__download(download_info, DownloadType.GAME_UPDATE, finish_func,
+                                     cancel_to_state)
         if not result:
             GLib.idle_add(self.update_to_state, cancel_to_state)
 
@@ -383,7 +390,8 @@ class GameTile(Gtk.Box):
             if dlc["downloads"]["installers"] == dlc_installers:
                 dlc_title = dlc["title"]
         cancel_to_state = self.state.INSTALLED
-        result = self.__download(download_info, finish_func, cancel_to_state)
+        result = self.__download(download_info, DownloadType.GAME_DLC, finish_func,
+                                 cancel_to_state)
         if not result:
             GLib.idle_add(self.update_to_state, cancel_to_state)
 

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -92,16 +92,23 @@ class GameTile(Gtk.Box):
 
     # Downloads if Minigalaxy was closed with this game downloading
     def resume_download_if_expected(self):
-        download_id = Config.get("current_download")
-        if download_id and download_id == self.game.id and self.current_state == self.state.DOWNLOADABLE:
-            download_thread = threading.Thread(target=self.__download_game)
-            download_thread.start()
+        download_ids = Config.get("current_downloads")
+        if download_ids:
+            for download_id in download_ids:
+                if download_id and download_id == self.game.id and self.current_state == self.state.DOWNLOADABLE:
+                    download_thread = threading.Thread(target=self.__download_game)
+                    download_thread.start()
 
     # Do not restart the download if Minigalaxy is restarted
     def prevent_resume_on_startup(self):
-        download_id = Config.get("current_download")
-        if download_id and download_id == self.game.id:
-            Config.unset("current_download")
+        download_ids = set(Config.get("current_downloads"))
+        if download_ids:
+            new_download_ids = set()
+            for download_id in download_ids:
+                if not (download_id and download_id == self.game.id):
+                    new_download_ids.add(download_id)
+
+            Config.set("current_downloads", list(new_download_ids))
 
     def __str__(self):
         return self.game.name
@@ -214,8 +221,13 @@ class GameTile(Gtk.Box):
             result = True
         except NoDownloadLinkFound as e:
             print(e)
-            if Config.get("current_download") == self.game.id:
-                Config.unset("current_download")
+            current_download_ids = set(Config.get("current_download"))
+            if current_download_ids:
+                new_current_download_ids = set()
+                for current_download_id in current_download_ids:
+                    if current_download_id != self.game.id:
+                        new_current_download_ids.add(current_download_id)
+                Config.set("current_downloads", list(new_current_download_ids))
             GLib.idle_add(self.parent.parent.show_error, _("Download error"),
                           _("There was an error when trying to fetch the download link!\n{}".format(e)))
             download_info = False
@@ -234,7 +246,11 @@ class GameTile(Gtk.Box):
     def __download(self, download_info, finish_func, cancel_to_state):
         download_success = True
         GLib.idle_add(self.update_to_state, self.state.QUEUED)
-        Config.set("current_download", self.game.id)
+        current_download_ids = set(Config.get("current_downloads"))
+        if current_download_ids is None:
+            current_download_ids = set()
+        current_download_ids.add(self.game.id)
+        Config.set("current_downloads", list(current_download_ids))
         # Start the download for all files
         self.download_list = []
         number_of_files = len(download_info['files'])

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -9,7 +9,7 @@ from enum import Enum
 from minigalaxy.translation import _
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, ICON_DIR, UI_DIR
 from minigalaxy.config import Config
-from minigalaxy.download import Download
+from minigalaxy.download import Download, DownloadType
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.launcher import start_game
 from minigalaxy.installer import uninstall_game, install_game, check_diskspace
@@ -104,7 +104,7 @@ class GameTileList(Gtk.Box):
 
     # Do not restart the download if Minigalaxy is restarted
     def prevent_resume_on_startup(self):
-        download_ids = set(Config.get("current_downloads"))
+        download_ids = Config.get("current_downloads")
         if download_ids:
             new_download_ids = set()
             for download_id in download_ids:
@@ -180,8 +180,8 @@ class GameTileList(Gtk.Box):
                     # Download the thumbnail
                     image_url = "https:{}_196.jpg".format(self.game.image_url)
                     thumbnail = os.path.join(THUMBNAIL_DIR, "{}.jpg".format(self.game.id))
-
-                    download = Download(image_url, thumbnail, finish_func=self.__set_image)
+                    download = Download(image_url, thumbnail, DownloadType.THUMBNAIL,
+                                        finish_func=self.__set_image)
                     DownloadManager.download_now(download)
                     set_result = True
                     break
@@ -224,7 +224,7 @@ class GameTileList(Gtk.Box):
             result = True
         except NoDownloadLinkFound as e:
             print(e)
-            current_download_ids = set(Config.get("current_download"))
+            current_download_ids = Config.get("current_downloads")
             if current_download_ids:
                 new_current_download_ids = set()
                 for current_download_id in current_download_ids:
@@ -242,19 +242,23 @@ class GameTileList(Gtk.Box):
         cancel_to_state = self.state.DOWNLOADABLE
         result, download_info = self.get_download_info()
         if result:
-            result = self.__download(download_info, finish_func, cancel_to_state)
+            result = self.__download(download_info, DownloadType.GAME, finish_func,
+                                     cancel_to_state)
         if not result:
             GLib.idle_add(self.update_to_state, cancel_to_state)
 
-    def __download(self, download_info, finish_func, cancel_to_state):
+    def __download(self, download_info, download_type, finish_func, cancel_to_state):
         download_success = True
         GLib.idle_add(self.update_to_state, self.state.QUEUED)
-        current_download_ids = set(Config.get("current_downloads"))
+
+        # Need to update the config with DownloadType metadata
+        current_download_ids = Config.get("current_downloads")
         if current_download_ids is None:
             current_download_ids = set()
+        else:
+            current_download_ids = set(current_download_ids)
         current_download_ids.add(self.game.id)
         Config.set("current_downloads", list(current_download_ids))
-
         # Start the download for all files
         self.download_list = []
         number_of_files = len(download_info['files'])
@@ -285,6 +289,7 @@ class GameTileList(Gtk.Box):
             download = Download(
                 url=download_url,
                 save_location=download_path,
+                download_type=DownloadType.GAME,
                 finish_func=finish_func if download_path == executable_path else None,
                 progress_func=self.set_progress,
                 cancel_func=lambda: self.__cancel(to_state=cancel_to_state),
@@ -347,7 +352,8 @@ class GameTileList(Gtk.Box):
         cancel_to_state = self.state.UPDATABLE
         result, download_info = self.get_download_info(self.game.platform)
         if result:
-            result = self.__download(download_info, finish_func, cancel_to_state)
+            result = self.__download(download_info, DownloadType.GAME_UPDATE, finish_func,
+                                     cancel_to_state)
         if not result:
             GLib.idle_add(self.update_to_state, cancel_to_state)
 
@@ -387,7 +393,8 @@ class GameTileList(Gtk.Box):
             if dlc["downloads"]["installers"] == dlc_installers:
                 dlc_title = dlc["title"]
         cancel_to_state = self.state.INSTALLED
-        result = self.__download(download_info, finish_func, cancel_to_state)
+        result = self.__download(download_info, DownloadType.GAME_DLC, finish_func,
+                                 cancel_to_state)
         if not result:
             GLib.idle_add(self.update_to_state, cancel_to_state)
 

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -247,7 +247,7 @@ class GameTileList(Gtk.Box):
         if not result:
             GLib.idle_add(self.update_to_state, cancel_to_state)
 
-    def __download(self, download_info, download_type, finish_func, cancel_to_state):
+    def __download(self, download_info, download_type, finish_func, cancel_to_state):  # noqa: C901
         download_success = True
         GLib.idle_add(self.update_to_state, self.state.QUEUED)
 


### PR DESCRIPTION
Thank you for this wonderful application.  The work that has been put into language translations and the application is inspiring.

I wanted to fix issue 270 or 367
https://github.com/sharkwouter/minigalaxy/issues/270
https://github.com/sharkwouter/minigalaxy/issues/367

But these require some caching work to do properly.  To start that work, I started documenting DownloadManager.  It has some great download resume code in it.  I cleaned up some small issues in it and added multiple game downloads.  Below are the changes:

Add ability to download multiple games.

Add documentation and examples to Download and DownloadManager.
Fix some concurrency bugs in DownloadManager.
Make prepare_location and get_start_point_and_download_mode private in
DownloadManager.
Switch to using a PriorityQueue in DownloadManager.
Add a logger to minigalaxy.

Thank you again and let me know if you want any changes in this PR.

Thanks,

Joshua Gerrish