### PR TITLE
Add gettext as a build dependency. (fixes #410)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Other Linux distributions may work as well. Minigalaxy requires the following de
 - PyGObject 3.29.1+
 - Webkit2gtk with API version 4.0 support
 - Python Requests
+- gettext
 
 ## Installation
 

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends: debhelper-compat (= 12),
                python3-all,
                python3-setuptools,
                help2man,
+               gettext,
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Vcs-Git: https://github.com/sharkwouter/minigalaxy.git


### PR DESCRIPTION
Trying to learn more about Debian packaging and this issue seemed appropriate.

There doesn't seem to be anything more to do than this to fix this issue. I've tested locally with `debuild`, which correctly failed when I didn't have `gettext` installed. After installing `gettext`, `debuild` produces a package that installs Minigalaxy (which I'm able to launch).

(`debuild` fails to sign changes but this, I presume, is expected since I'm not the author of those changes.)

Also, not sure if updating the README with _build_ dependencies specifically is relevant any more. The dependencies listed doesn't seem to be for building.