### PR TITLE
Don't fail installation if xml checksum data isn't available

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -177,7 +177,7 @@ class Api:
         checksum_data = self.__request(url)
         if 'checksum' in checksum_data.keys() and len(checksum_data['checksum']) > 0:
             xml_data = self.__get_xml_checksum(checksum_data['checksum'])
-            if xml_data and "md5" in xml_data.keys() and len(xml_data["md5"]) > 0:
+            if "md5" in xml_data.keys() and len(xml_data["md5"]) > 0:
                 result = xml_data["md5"]
 
         if not result:
@@ -196,7 +196,7 @@ class Api:
         checksum_data = self.__request(url)
         if 'checksum' in checksum_data.keys() and len(checksum_data['checksum']) > 0:
             xml_data = self.__get_xml_checksum(checksum_data['checksum'])
-            if xml_data and "total_size" in xml_data.keys() and int(xml_data["total_size"]) > 0:
+            if "total_size" in xml_data.keys() and int(xml_data["total_size"]) > 0:
                 result = int(xml_data["total_size"])
 
         if not result:
@@ -205,7 +205,7 @@ class Api:
         return result
 
     def __get_xml_checksum(self, url):
-        result = None
+        result = {}
         response = SESSION.get(url)
         if response.status_code == http.HTTPStatus.OK and len(response.text) > 0:
             response_object = ET.fromstring(response.text)

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -176,9 +176,9 @@ class Api:
         result = ""
         checksum_data = self.__request(url)
         if 'checksum' in checksum_data.keys() and len(checksum_data['checksum']) > 0:
-            root = self.__get_xml_checksum(checksum_data['checksum'])
-            if "md5" in root.keys() or len(root.attrib["md5"]) > 0:
-                result = root.attrib["md5"]
+            xml_data = self.__get_xml_checksum(checksum_data['checksum'])
+            if xml_data and "md5" in xml_data.keys() and len(xml_data["md5"]) > 0:
+                result = xml_data["md5"]
 
         if not result:
             print("Couldn't find md5 in xml checksum data")
@@ -195,9 +195,9 @@ class Api:
         result = 0
         checksum_data = self.__request(url)
         if 'checksum' in checksum_data.keys() and len(checksum_data['checksum']) > 0:
-            root = self.__get_xml_checksum(checksum_data['checksum'])
-            if "total_size" in root.keys() or int(root.attrib["total_size"]) > 0:
-                result = int(root.attrib["total_size"])
+            xml_data = self.__get_xml_checksum(checksum_data['checksum'])
+            if xml_data and "total_size" in xml_data.keys() and int(xml_data["total_size"]) > 0:
+                result = int(xml_data["total_size"])
 
         if not result:
             print("Couldn't find file size in xml checksum data")
@@ -205,10 +205,12 @@ class Api:
         return result
 
     def __get_xml_checksum(self, url):
-        result = {}
+        result = None
         response = SESSION.get(url)
         if response.status_code == http.HTTPStatus.OK and len(response.text) > 0:
-            result = ET.fromstring(response.text)
+            response_object = ET.fromstring(response.text)
+            if response_object and response_object.attrib:
+                result = response_object.attrib
         else:
             print("Couldn't read xml data. Response with code {} received with the following content: {}".format(
                 response.status_code, response.text

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -245,7 +245,7 @@ class GameTile(Gtk.Box):
                 GLib.idle_add(self.parent.parent.show_error, _("Download error"), _(str(e)))
                 download_success = False
                 break
-            total_file_size += int(self.api.get_file_size(file_info["downlink"]))
+            total_file_size += self.api.get_file_size(file_info["downlink"])
             try:
                 # Extract the filename from the download url (filename is between %2F and &token)
                 filename = urllib.parse.unquote(re.search('%2F(((?!%2F).)*)&t', download_url).group(1))
@@ -255,7 +255,9 @@ class GameTile(Gtk.Box):
             if key == 0:
                 # If key = 0, denote the file as the executable's path
                 executable_path = download_path
-            self.game.md5sum[os.path.basename(download_path)] = self.api.get_download_file_md5(file_info["downlink"])
+            md5sum = self.api.get_download_file_md5(file_info["downlink"])
+            if md5sum:
+                self.game.md5sum[os.path.basename(download_path)] = md5sum
             download = Download(
                 url=download_url,
                 save_location=download_path,

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -248,7 +248,7 @@ class GameTileList(Gtk.Box):
                 GLib.idle_add(self.parent.parent.show_error, _("Download error"), _(str(e)))
                 download_success = False
                 break
-            total_file_size += int(self.api.get_file_size(file_info["downlink"]))
+            total_file_size += self.api.get_file_size(file_info["downlink"])
             try:
                 # Extract the filename from the download url (filename is between %2F and &token)
                 filename = urllib.parse.unquote(re.search('%2F(((?!%2F).)*)&t', download_url).group(1))
@@ -258,7 +258,9 @@ class GameTileList(Gtk.Box):
             if key == 0:
                 # If key = 0, denote the file as the executable's path
                 executable_path = download_path
-            self.game.md5sum[os.path.basename(download_path)] = self.api.get_download_file_md5(file_info["downlink"])
+            md5sum = self.api.get_download_file_md5(file_info["downlink"])
+            if md5sum:
+                self.game.md5sum[os.path.basename(download_path)] = md5sum
             download = Download(
                 url=download_url,
                 save_location=download_path,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,6 +141,7 @@ class TestApi(TestCase):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get.side_effect = MagicMock()
         m_constants.SESSION.get().status_code = http.HTTPStatus.OK
         m_constants.SESSION.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="8acedf66c0d2986e7dee9af912b7df4f" chunks="4" timestamp="2015-07-30 17:11:12" total_size="36717998">
     <chunk id="0" from="0" to="10485759" method="md5">7e62ce101221ccdae2e9bff5c16ed9e0</chunk>
@@ -156,6 +157,7 @@ class TestApi(TestCase):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get.side_effect = MagicMock()
         m_constants.SESSION.get().status_code = http.HTTPStatus.OK
         m_constants.SESSION.get().text = ""
 
@@ -167,6 +169,7 @@ class TestApi(TestCase):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get.side_effect = MagicMock()
         m_constants.SESSION.get().status_code = http.HTTPStatus.NOT_FOUND
 
         exp = ""
@@ -177,6 +180,7 @@ class TestApi(TestCase):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get.side_effect = MagicMock()
         m_constants.SESSION.get().status_code = http.HTTPStatus.OK
         m_constants.SESSION.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="" chunks="4" timestamp="2015-07-30 17:11:12" total_size="36717998">
     <chunk id="0" from="0" to="10485759" method="md5">7e62ce101221ccdae2e9bff5c16ed9e0</chunk>
@@ -193,6 +197,7 @@ class TestApi(TestCase):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get.side_effect = MagicMock()
         m_constants.SESSION.get().status_code = http.HTTPStatus.OK
         m_constants.SESSION.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="8acedf66c0d2986e7dee9af912b7df4f" chunks="4" timestamp="2015-07-30 17:11:12" total_size="36717998">
     <chunk id="0" from="0" to="10485759" method="md5">7e62ce101221ccdae2e9bff5c16ed9e0</chunk>
@@ -208,6 +213,7 @@ class TestApi(TestCase):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get.side_effect = MagicMock()
         m_constants.SESSION.get().status_code = http.HTTPStatus.OK
         m_constants.SESSION.get().text = ""
 
@@ -219,6 +225,7 @@ class TestApi(TestCase):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get.side_effect = MagicMock()
         m_constants.SESSION.get().status_code = http.HTTPStatus.NOT_FOUND
 
         exp = 0
@@ -229,6 +236,7 @@ class TestApi(TestCase):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get.side_effect = MagicMock()
         m_constants.SESSION.get().status_code = http.HTTPStatus.OK
         m_constants.SESSION.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="8acedf66c0d2986e7dee9af912b7df4f" chunks="4" timestamp="2015-07-30 17:11:12">
     <chunk id="0" from="0" to="10485759" method="md5">7e62ce101221ccdae2e9bff5c16ed9e0</chunk>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -236,17 +236,6 @@ class TestApi(TestCase):
         obs = api.get_file_size("url")
         self.assertEqual(exp, obs)
 
-    def test_get_file_size_returns_zero_on_empty_response(self):
-        api = Api()
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
-        m_constants.SESSION.get().status_code = http.HTTPStatus.OK
-        m_constants.SESSION.get().text = ""
-
-        exp = 0
-        obs = api.get_file_size("url")
-        self.assertEqual(exp, obs)
-
     def test_get_file_size_returns_zero_on_missing_total_size(self):
         api = Api()
         api._Api__request = MagicMock()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import http
 from unittest import TestCase, mock
 from unittest.mock import MagicMock
 import copy
@@ -139,7 +140,8 @@ class TestApi(TestCase):
     def test_get_download_file_md5(self):
         api = Api()
         api._Api__request = MagicMock()
-        m_constants.SESSION.get.side_effect = MagicMock()
+        api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get().status_code = http.HTTPStatus.OK
         m_constants.SESSION.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="8acedf66c0d2986e7dee9af912b7df4f" chunks="4" timestamp="2015-07-30 17:11:12" total_size="36717998">
     <chunk id="0" from="0" to="10485759" method="md5">7e62ce101221ccdae2e9bff5c16ed9e0</chunk>
     <chunk id="1" from="10485760" to="20971519" method="md5">b80960a2546ce647bffea87f85385535</chunk>
@@ -148,6 +150,117 @@ class TestApi(TestCase):
 </file>'''
         exp = "8acedf66c0d2986e7dee9af912b7df4f"
         obs = api.get_download_file_md5("url")
+        self.assertEqual(exp, obs)
+
+    def test_get_download_file_md5_returns_empty_string_on_empty_response(self):
+        api = Api()
+        api._Api__request = MagicMock()
+        api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get().status_code = http.HTTPStatus.OK
+        m_constants.SESSION.get().text = ""
+
+        exp = ""
+        obs = api.get_download_file_md5("url")
+        self.assertEqual(exp, obs)
+
+    def test_get_download_file_md5_returns_empty_string_on_response_error(self):
+        api = Api()
+        api._Api__request = MagicMock()
+        api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get().status_code = http.HTTPStatus.NOT_FOUND
+
+        exp = ""
+        obs = api.get_download_file_md5("url")
+        self.assertEqual(exp, obs)
+
+    def test_get_download_file_md5_returns_empty_string_on_empty_response(self):
+        api = Api()
+        api._Api__request = MagicMock()
+        api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get().status_code = http.HTTPStatus.OK
+        m_constants.SESSION.get().text = ""
+
+        exp = ""
+        obs = api.get_download_file_md5("url")
+        self.assertEqual(exp, obs)
+
+    def test_get_download_file_md5_returns_empty_string_on_missing_md5(self):
+        api = Api()
+        api._Api__request = MagicMock()
+        api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get().status_code = http.HTTPStatus.OK
+        m_constants.SESSION.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="" chunks="4" timestamp="2015-07-30 17:11:12" total_size="36717998">
+    <chunk id="0" from="0" to="10485759" method="md5">7e62ce101221ccdae2e9bff5c16ed9e0</chunk>
+    <chunk id="1" from="10485760" to="20971519" method="md5">b80960a2546ce647bffea87f85385535</chunk>
+    <chunk id="2" from="20971520" to="31457279" method="md5">5464b4499cd4368bb83ea35f895d3560</chunk>
+    <chunk id="3" from="31457280" to="36717997" method="md5">0261b9225fc10c407df083f6d254c47b</chunk>
+</file>'''
+
+        exp = ""
+        obs = api.get_download_file_md5("url")
+        self.assertEqual(exp, obs)
+
+    def test_get_file_size(self):
+        api = Api()
+        api._Api__request = MagicMock()
+        api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get().status_code = http.HTTPStatus.OK
+        m_constants.SESSION.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="8acedf66c0d2986e7dee9af912b7df4f" chunks="4" timestamp="2015-07-30 17:11:12" total_size="36717998">
+    <chunk id="0" from="0" to="10485759" method="md5">7e62ce101221ccdae2e9bff5c16ed9e0</chunk>
+    <chunk id="1" from="10485760" to="20971519" method="md5">b80960a2546ce647bffea87f85385535</chunk>
+    <chunk id="2" from="20971520" to="31457279" method="md5">5464b4499cd4368bb83ea35f895d3560</chunk>
+    <chunk id="3" from="31457280" to="36717997" method="md5">0261b9225fc10c407df083f6d254c47b</chunk>
+</file>'''
+        exp = 36717998
+        obs = api.get_file_size("url")
+        self.assertEqual(exp, obs)
+
+    def test_get_file_size_returns_zero_on_empty_response(self):
+        api = Api()
+        api._Api__request = MagicMock()
+        api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get().status_code = http.HTTPStatus.OK
+        m_constants.SESSION.get().text = ""
+
+        exp = 0
+        obs = api.get_file_size("url")
+        self.assertEqual(exp, obs)
+
+    def test_get_file_size_returns_zero_on_response_error(self):
+        api = Api()
+        api._Api__request = MagicMock()
+        api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get().status_code = http.HTTPStatus.NOT_FOUND
+
+        exp = 0
+        obs = api.get_file_size("url")
+        self.assertEqual(exp, obs)
+
+    def test_get_file_size_returns_zero_on_empty_response(self):
+        api = Api()
+        api._Api__request = MagicMock()
+        api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get().status_code = http.HTTPStatus.OK
+        m_constants.SESSION.get().text = ""
+
+        exp = 0
+        obs = api.get_file_size("url")
+        self.assertEqual(exp, obs)
+
+    def test_get_file_size_returns_zero_on_missing_total_size(self):
+        api = Api()
+        api._Api__request = MagicMock()
+        api._Api__request.return_value = {"checksum": "url"}
+        m_constants.SESSION.get().status_code = http.HTTPStatus.OK
+        m_constants.SESSION.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="8acedf66c0d2986e7dee9af912b7df4f" chunks="4" timestamp="2015-07-30 17:11:12">
+    <chunk id="0" from="0" to="10485759" method="md5">7e62ce101221ccdae2e9bff5c16ed9e0</chunk>
+    <chunk id="1" from="10485760" to="20971519" method="md5">b80960a2546ce647bffea87f85385535</chunk>
+    <chunk id="2" from="20971520" to="31457279" method="md5">5464b4499cd4368bb83ea35f895d3560</chunk>
+    <chunk id="3" from="31457280" to="36717997" method="md5">0261b9225fc10c407df083f6d254c47b</chunk>
+</file>'''
+
+        exp = 0
+        obs = api.get_file_size("url")
         self.assertEqual(exp, obs)
 
     def test1_get_gamesdb_info(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -173,17 +173,6 @@ class TestApi(TestCase):
         obs = api.get_download_file_md5("url")
         self.assertEqual(exp, obs)
 
-    def test_get_download_file_md5_returns_empty_string_on_empty_response(self):
-        api = Api()
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
-        m_constants.SESSION.get().status_code = http.HTTPStatus.OK
-        m_constants.SESSION.get().text = ""
-
-        exp = ""
-        obs = api.get_download_file_md5("url")
-        self.assertEqual(exp, obs)
-
     def test_get_download_file_md5_returns_empty_string_on_missing_md5(self):
         api = Api()
         api._Api__request = MagicMock()


### PR DESCRIPTION
This still needs some work, but this should fix the issue already. Please test.