### PR TITLE
Allow to download/install Windows version for a Linux native game.

### DIFF
--- a/data/ui/properties.ui
+++ b/data/ui/properties.ui
@@ -1,264 +1,357 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <template class="Properties" parent="GtkDialog">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
+    <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="can_focus">False</property>
-        <property name="orientation">horizontal</property>
+        <property name="can-focus">False</property>
         <property name="spacing">18</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
+            <property name="margin-start">18</property>
             <property name="orientation">vertical</property>
             <property name="spacing">18</property>
-            <property name="margin_start">18</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="spacing">6</property>
                 <property name="homogeneous">True</property>
                 <child>
+                  <!-- n-columns=3 n-rows=10 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_top">18</property>
-                    <property name="row_spacing">6</property>
-                    <property name="column_spacing">12</property>
-                    <property name="row_homogeneous">True</property>
-                    <property name="column_homogeneous">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-top">18</property>
+                    <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
+                    <property name="column-homogeneous">True</property>
                     <child>
                       <object class="GtkButton" id="button_properties_regedit">
                         <property name="label" translatable="yes">Regedit</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <signal name="clicked" handler="on_button_properties_regedit_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_winecfg">
                         <property name="label" translatable="yes">Winecfg</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <signal name="clicked" handler="on_button_properties_winecfg_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_open_files">
                         <property name="label" translatable="yes">Open files</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <signal name="clicked" handler="on_button_properties_open_files_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_winetricks">
                         <property name="label" translatable="yes">Winetricks</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <signal name="clicked" handler="on_button_properties_winetricks_clicked" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Check for updates:</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">2</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">2</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkSwitch" id="switch_properties_check_for_updates">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">2</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">2</property>
                       </packing>
-                    </child>>
+                    </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Show FPS in game:</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">3</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">3</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkSwitch" id="switch_properties_show_fps">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">3</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">3</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Hide game:</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkSwitch" id="switch_properties_hide_game">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">4</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Use GameMode:</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">5</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">5</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkSwitch" id="switch_properties_use_gamemode">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">5</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">5</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Use MangoHud:</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">6</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">6</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkSwitch" id="switch_properties_use_mangohud">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">6</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">6</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Variable flags:</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">7</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">7</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkEntry" id="entry_properties_variable">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Added in front of the command used to launch the game</property>
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Added in front of the command used to launch the game</property>
                         <property name="halign">start</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">7</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">7</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Command flags:</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">8</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">8</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkEntry" id="entry_properties_command">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Added at the end of the command used to launch the game</property>
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Added at the end of the command used to launch the game</property>
                         <property name="halign">start</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">8</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">8</property>
                       </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Game platform:</property>
+                        <property name="justify">fill</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">9</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButtonBox" id="game_type">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="orientation">vertical</property>
+                        <property name="layout-style">center</property>
+                        <child>
+                          <object class="GtkRadioButton" id="radiobutton_linux_type">
+                            <property name="label" translatable="yes">Linux (native)</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="active">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="radiobutton_windows_type">
+                            <property name="label" translatable="yes">Windows (wine)</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="active">True</property>
+                            <property name="draw-indicator">True</property>
+                            <property name="group">radiobutton_linux_type</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">9</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                     <child>
                       <placeholder/>
@@ -280,16 +373,16 @@
             <child>
               <object class="GtkButtonBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_bottom">18</property>
+                <property name="can-focus">False</property>
+                <property name="margin-bottom">18</property>
                 <property name="spacing">12</property>
-                <property name="layout_style">end</property>
+                <property name="layout-style">end</property>
                 <child>
                   <object class="GtkButton" id="button_properties_cancel">
                     <property name="label" translatable="yes">Cancel</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
                     <signal name="clicked" handler="on_button_properties_cancel_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -302,8 +395,8 @@
                   <object class="GtkButton" id="button_properties_ok">
                     <property name="label" translatable="yes">OK</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
                     <signal name="clicked" handler="on_button_properties_ok_clicked" swapped="no"/>
                   </object>
                   <packing>

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -90,14 +90,17 @@ class Api:
                         # Only support Linux unless the show_windows_games setting is enabled
                         if product["worksOn"]["Linux"]:
                             platform = "linux"
+                            supported_platforms = [platform, "windows"]
                         elif Config.get("show_windows_games"):
                             platform = "windows"
+                            supported_platforms = [platform]
                         else:
                             continue
                         if not product["url"]:
                             print("{} ({}) has no store page url".format(product["title"], product['id']))
                         game = Game(name=product["title"], url=product["url"], game_id=product["id"],
-                                    image_url=product["image"], platform=platform)
+                                    image_url=product["image"], platform=platform,
+                                    supported_platforms=supported_platforms)
                         games.append(game)
                 if current_page == total_pages:
                     all_pages_processed = True
@@ -134,7 +137,7 @@ class Api:
         return response
 
     # This returns a unique download url and a link to the checksum of the download
-    def get_download_info(self, game: Game, operating_system="linux", dlc_installers="") -> dict:
+    def get_download_info(self, game: Game, operating_system="", dlc_installers="") -> dict:
         if dlc_installers:
             installers = dlc_installers
         else:
@@ -186,6 +189,13 @@ class Api:
             Config.set("username", username)
         return username
 
+    def get_download_version(self, game: Game):
+        if not game.get_info("platform"):
+            platform_version = game.platform
+        else:
+            platform_version = game.get_info("platform")
+        return platform_version
+        
     def get_version(self, game: Game, gameinfo=None, dlc_name="") -> str:
         if gameinfo is None:
             gameinfo = self.get_info(game)

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -195,7 +195,7 @@ class Api:
         else:
             platform_version = game.get_info("platform")
         return platform_version
-        
+
     def get_version(self, game: Game, gameinfo=None, dlc_name="") -> str:
         if gameinfo is None:
             gameinfo = self.get_info(game)

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -8,17 +8,18 @@ from minigalaxy.paths import CONFIG_GAMES_DIR
 
 class Game:
     def __init__(self, name: str, url: str = "", md5sum=None, game_id: int = 0, install_dir: str = "",
-                 image_url="", platform="linux", dlcs=None):
+                 image_url="", platform="linux", supported_platforms: list = None, dlcs=None):
         self.name = name
         self.url = url
         self.md5sum = {} if md5sum is None else md5sum
         self.id = game_id
         self.install_dir = install_dir
         self.image_url = image_url
-        self.platform = platform
         self.dlcs = [] if dlcs is None else dlcs
         self.status_file_path = self.get_status_file_path()
-
+        self.platform = self.get_info("platform") if self.get_info("platform") else platform
+        self.supported_platforms = [platform] if supported_platforms is None else supported_platforms
+        
     def get_stripped_name(self):
         return self.__strip_string(self.name)
 
@@ -140,6 +141,10 @@ class Game:
         if not self.install_dir:
             self.install_dir = os.path.join(Config.get("install_dir"), self.get_install_directory_name())
 
+    def set_platform(self, platform):
+        self.platform = platform
+        self.set_info("platform", platform)
+        
     def __str__(self):
         return self.name
 

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -19,7 +19,7 @@ class Game:
         self.status_file_path = self.get_status_file_path()
         self.platform = self.get_info("platform") if self.get_info("platform") else platform
         self.supported_platforms = [platform] if supported_platforms is None else supported_platforms
-        
+
     def get_stripped_name(self):
         return self.__strip_string(self.name)
 
@@ -144,7 +144,7 @@ class Game:
     def set_platform(self, platform):
         self.platform = platform
         self.set_info("platform", platform)
-        
+
     def __str__(self):
         return self.name
 

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -112,7 +112,7 @@ def make_tmp_dir(game):
 
 def extract_installer(game, installer, temp_dir):
     # Extract the installer
-    if game.platform in ["linux"]:
+    if game.platform in ["linux"] and not game.get_info("platform") or game.get_info("platform") == "linux":
         err_msg = extract_linux(installer, temp_dir)
     else:
         err_msg = extract_windows(game, installer, temp_dir)

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -204,9 +204,9 @@ class GameTile(Gtk.Box):
                     break
         return keep_path
 
-    def get_download_info(self, platform="linux"):
+    def get_download_info(self):
         try:
-            download_info = self.api.get_download_info(self.game, platform)
+            download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game))
             result = True
         except NoDownloadLinkFound as e:
             print(e)
@@ -319,7 +319,7 @@ class GameTile(Gtk.Box):
     def __download_update(self) -> None:
         finish_func = self.__update
         cancel_to_state = self.state.UPDATABLE
-        result, download_info = self.get_download_info(self.game.platform)
+        result, download_info = self.get_download_info(self.api.get_download_version(self.game))
         if result:
             result = self.__download(download_info, finish_func, cancel_to_state)
         if not result:
@@ -347,7 +347,7 @@ class GameTile(Gtk.Box):
             else:
                 self.image.set_tooltip_text(self.game.name)
         for dlc in self.game.dlcs:
-            download_info = self.api.get_download_info(self.game, dlc_installers=dlc["downloads"]["installers"])
+            download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game), dlc_installers=dlc["downloads"]["installers"])
             if self.game.is_update_available(version_from_api=download_info["version"], dlc_title=dlc["title"]):
                 self.__download_dlc(dlc["downloads"]["installers"])
 
@@ -355,7 +355,7 @@ class GameTile(Gtk.Box):
         def finish_func(save_location):
             self.__install_dlc(save_location, dlc_title=dlc_title)
 
-        download_info = self.api.get_download_info(self.game, dlc_installers=dlc_installers)
+        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game), dlc_installers=dlc_installers)
         dlc_title = self.game.name
         for dlc in self.game.dlcs:
             if dlc["downloads"]["installers"] == dlc_installers:
@@ -400,7 +400,7 @@ class GameTile(Gtk.Box):
             self.dlc_horizontal_box.pack_start(dlc_box, False, True, 0)
             dlc_box.show_all()
             self.get_async_image_dlc_icon(icon, title)
-        download_info = self.api.get_download_info(self.game, dlc_installers=installer)
+        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game), dlc_installers=installer)
         if self.game.is_update_available(version_from_api=download_info["version"], dlc_title=title):
             icon_name = "emblem-synchronizing"
             self.dlc_dict[title][0].set_sensitive(True)

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -348,7 +348,7 @@ class GameTile(Gtk.Box):
                 self.image.set_tooltip_text(self.game.name)
         for dlc in self.game.dlcs:
             download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game),
-                            dlc_installers=dlc["downloads"]["installers"])
+                                                       dlc_installers=dlc["downloads"]["installers"])
             if self.game.is_update_available(version_from_api=download_info["version"], dlc_title=dlc["title"]):
                 self.__download_dlc(dlc["downloads"]["installers"])
 
@@ -357,7 +357,7 @@ class GameTile(Gtk.Box):
             self.__install_dlc(save_location, dlc_title=dlc_title)
 
         download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game),
-                        dlc_installers=dlc_installers)
+                                                   dlc_installers=dlc_installers)
         dlc_title = self.game.name
         for dlc in self.game.dlcs:
             if dlc["downloads"]["installers"] == dlc_installers:
@@ -403,7 +403,7 @@ class GameTile(Gtk.Box):
             dlc_box.show_all()
             self.get_async_image_dlc_icon(icon, title)
         download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game),
-                        dlc_installers=installer)
+                                                   dlc_installers=installer)
         if self.game.is_update_available(version_from_api=download_info["version"], dlc_title=title):
             icon_name = "emblem-synchronizing"
             self.dlc_dict[title][0].set_sensitive(True)

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -347,7 +347,8 @@ class GameTile(Gtk.Box):
             else:
                 self.image.set_tooltip_text(self.game.name)
         for dlc in self.game.dlcs:
-            download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game), dlc_installers=dlc["downloads"]["installers"])
+            download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game),
+                            dlc_installers=dlc["downloads"]["installers"])
             if self.game.is_update_available(version_from_api=download_info["version"], dlc_title=dlc["title"]):
                 self.__download_dlc(dlc["downloads"]["installers"])
 
@@ -355,7 +356,8 @@ class GameTile(Gtk.Box):
         def finish_func(save_location):
             self.__install_dlc(save_location, dlc_title=dlc_title)
 
-        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game), dlc_installers=dlc_installers)
+        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game),
+                        dlc_installers=dlc_installers)
         dlc_title = self.game.name
         for dlc in self.game.dlcs:
             if dlc["downloads"]["installers"] == dlc_installers:
@@ -400,7 +402,8 @@ class GameTile(Gtk.Box):
             self.dlc_horizontal_box.pack_start(dlc_box, False, True, 0)
             dlc_box.show_all()
             self.get_async_image_dlc_icon(icon, title)
-        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game), dlc_installers=installer)
+        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game),
+                        dlc_installers=installer)
         if self.game.is_update_available(version_from_api=download_info["version"], dlc_title=title):
             icon_name = "emblem-synchronizing"
             self.dlc_dict[title][0].set_sensitive(True)

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -359,7 +359,7 @@ class GameTileList(Gtk.Box):
         def finish_func(save_location):
             self.__install_dlc(save_location, dlc_title=dlc_title)
 
-        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game), 
+        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game),
                                                    dlc_installers=dlc_installers)
         dlc_title = self.game.name
         for dlc in self.game.dlcs:
@@ -405,7 +405,7 @@ class GameTileList(Gtk.Box):
             self.dlc_horizontal_box.pack_start(dlc_box, False, True, 0)
             dlc_box.show_all()
             self.get_async_image_dlc_icon(icon, title)
-        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game), 
+        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game),
                                                    dlc_installers=installer)
         if self.game.is_update_available(version_from_api=download_info["version"], dlc_title=title):
             icon_name = "emblem-synchronizing"

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -207,9 +207,9 @@ class GameTileList(Gtk.Box):
                     break
         return keep_path
 
-    def get_download_info(self, platform="linux"):
+    def get_download_info(self):
         try:
-            download_info = self.api.get_download_info(self.game, platform)
+            download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game))
             result = True
         except NoDownloadLinkFound as e:
             print(e)
@@ -350,7 +350,8 @@ class GameTileList(Gtk.Box):
             else:
                 self.image.set_tooltip_text(self.game.name)
         for dlc in self.game.dlcs:
-            download_info = self.api.get_download_info(self.game, dlc_installers=dlc["downloads"]["installers"])
+            download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game),
+                                                       dlc_installers=dlc["downloads"]["installers"])
             if self.game.is_update_available(version_from_api=download_info["version"], dlc_title=dlc["title"]):
                 self.__download_dlc(dlc["downloads"]["installers"])
 
@@ -358,7 +359,8 @@ class GameTileList(Gtk.Box):
         def finish_func(save_location):
             self.__install_dlc(save_location, dlc_title=dlc_title)
 
-        download_info = self.api.get_download_info(self.game, dlc_installers=dlc_installers)
+        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game), 
+                                                   dlc_installers=dlc_installers)
         dlc_title = self.game.name
         for dlc in self.game.dlcs:
             if dlc["downloads"]["installers"] == dlc_installers:
@@ -403,7 +405,8 @@ class GameTileList(Gtk.Box):
             self.dlc_horizontal_box.pack_start(dlc_box, False, True, 0)
             dlc_box.show_all()
             self.get_async_image_dlc_icon(icon, title)
-        download_info = self.api.get_download_info(self.game, dlc_installers=installer)
+        download_info = self.api.get_download_info(self.game, self.api.get_download_version(self.game), 
+                                                   dlc_installers=installer)
         if self.game.is_update_available(version_from_api=download_info["version"], dlc_title=title):
             icon_name = "emblem-synchronizing"
             self.dlc_dict[title][0].set_sensitive(True)

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -26,7 +26,9 @@ class Properties(Gtk.Dialog):
     entry_properties_command = Gtk.Template.Child()
     button_properties_cancel = Gtk.Template.Child()
     button_properties_ok = Gtk.Template.Child()
-
+    radiobutton_linux_type = Gtk.Template.Child()
+    radiobutton_windows_type = Gtk.Template.Child()
+    
     def __init__(self, parent, game, api):
         Gtk.Dialog.__init__(self, title=_("Properties of {}").format(game.name), parent=parent.parent.parent,
                             modal=True)
@@ -83,6 +85,10 @@ class Properties(Gtk.Dialog):
             self.game.set_info("command", str(self.entry_properties_command.get_text()))
         self.game.set_info("hide_game", self.switch_properties_hide_game.get_active())
         self.parent.parent.filter_library()
+        if self.radiobutton_linux_type.get_active():
+            self.game.set_platform("linux")
+        elif self.radiobutton_windows_type.get_active():
+            self.game.set_platform("windows")
         self.destroy()
 
     @Gtk.Template.Callback("on_button_properties_regedit_clicked")
@@ -118,7 +124,15 @@ class Properties(Gtk.Dialog):
             self.entry_properties_variable.set_sensitive(False)
             self.entry_properties_command.set_sensitive(False)
 
-        if game.platform == 'linux':
+        if game.platform in ["linux"]:
             self.button_properties_regedit.hide()
             self.button_properties_winecfg.hide()
             self.button_properties_winetricks.hide()
+            self.radiobutton_linux_type.set_active(True)
+        elif game.platform in ["windows"]:
+            self.radiobutton_windows_type.set_active(True)
+
+        if "linux" not in self.game.supported_platforms:
+            self.radiobutton_linux_type.set_sensitive(False)
+        if "windows" not in self.game.supported_platforms or not shutil.which("wine"):
+            self.radiobutton_windows_type.set_sensitive(False)

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -28,7 +28,7 @@ class Properties(Gtk.Dialog):
     button_properties_ok = Gtk.Template.Child()
     radiobutton_linux_type = Gtk.Template.Child()
     radiobutton_windows_type = Gtk.Template.Child()
-    
+
     def __init__(self, parent, game, api):
         Gtk.Dialog.__init__(self, title=_("Properties of {}").format(game.name), parent=parent.parent.parent,
                             modal=True)


### PR DESCRIPTION
I don't know if you're gonna like this pull request :D 
My PR is based on the Makson's PR #317 

Why i did this ?
- Some native games works better with Windows version and Wine.
- Native games can have an oldest version than Windows like [Ruiner](https://www.gogdb.org/product/1637928515#downloads) or [Pathfinder Kingmaker](https://www.gogdb.org/product/1982293831#downloads)
- And maybe others thing.

I tried and use it since a long time and it works (Download/Installation and DLC download/installation)