### PR TITLE
Fix freeze for games generating a lot of output

### DIFF
--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -4,6 +4,7 @@ import shutil
 import re
 import json
 import glob
+import threading
 from minigalaxy.translation import _
 
 
@@ -37,6 +38,8 @@ def start_game(game):
         error_message, process = run_game_subprocess(game)
     if not error_message:
         error_message = check_if_game_started_correctly(process, game)
+    if not error_message:
+        send_game_output_to_stdout(process)
     if error_message:
         print(_("Failed to start {}:").format(game.name))
         print(error_message)
@@ -180,18 +183,19 @@ def set_fps_display(game):
 
 
 def run_game_subprocess(game):
-    # Change the directory to the install dir
-    working_dir = os.getcwd()
-    os.chdir(game.install_dir)
     try:
-        process = subprocess.Popen(get_execute_command(game), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.Popen(
+            get_execute_command(game),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=0,
+            cwd=game.install_dir
+        )
         error_message = ""
     except FileNotFoundError:
         process = None
         error_message = _("No executable was found in {}").format(game.install_dir)
 
-    # restore the working directory
-    os.chdir(working_dir)
     return error_message, process
 
 
@@ -207,13 +211,10 @@ def check_if_game_started_correctly(process, game):
     if error_message in ["Game start process has finished prematurely"]:
         error_message = check_if_game_start_process_spawned_final_process(error_message, game)
 
-    # Set the error message to what's been received in std error if not yet set
+    # Set the error message to what's been received in stdout if not yet set
     if error_message:
-        stdout, stderror = process.communicate()
-        if stderror:
-            error_message = stderror.decode("utf-8")
-        elif stdout:
-            error_message = stdout.decode("utf-8")
+        stdout, _ = process.communicate()
+        error_message = stdout.decode("utf-8")
     return error_message
 
 
@@ -230,3 +231,13 @@ def check_if_game_start_process_spawned_final_process(error_message, game):
             error_message = ""
             break
     return error_message
+
+
+def send_game_output_to_stdout(process):
+    def _internal_call(process):
+        for line in iter(process.stdout.readline, b''):
+            print(line.decode('utf-8'), end='')
+        process.stdout.close()
+        process.wait()
+    t = threading.Thread(target=_internal_call, args=(process,))
+    t.start()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -162,9 +162,9 @@ class Test(TestCase):
     @mock.patch('minigalaxy.launcher.check_if_game_start_process_spawned_final_process')
     def test2_check_if_game_started_correctly(self, mock_check_game):
         mock_process = MagicMock()
-        mock_process.communicate.return_value = (b"Output message", b"Error message")
+        mock_process.communicate.return_value = (b"Output message", None)
         game = Game("Test Game", install_dir="/test/install/dir")
-        exp = "Error message"
+        exp = "Output message"
         obs = launcher.check_if_game_started_correctly(mock_process, game)
         self.assertEqual(exp, obs)
 


### PR DESCRIPTION
When using minigalaxy, some games tend to freeze after a few minutes.
When running them manually, from a terminal, I can't reproduce the
freeze. This is the case, at least, for "Darkest Dungeon" and "Slay the
Spire".
This issue seems to be related to how the `subprocess.Popen` call is
done when launching the game. `stdout` and `stderr` are set to
`subprocess.PIPE`, but `subprocess.PIPE.communicate` is called only once
if the game is not running after a 3s delay. The subprocess output is
filling an internal buffer and the game hangs when this buffer is full.

Now, stderr is merged in stdout, and a new thread is started to consume
the subprocess stdout and send it to the parent process stdout. A thread
is created in order to avoid blocking the main UI thread.