### PR TITLE
Delete all offline installer files.

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -272,7 +272,6 @@ def compare_directories(dir1, dir2):
 def remove_installer(game, installer):
     error_message = ""
     installer_directory = os.path.dirname(installer)
-
     if not os.path.isdir(installer_directory):
         error_message = "No installer directory is present: {}".format(installer_directory)
         return error_message
@@ -291,7 +290,8 @@ def remove_installer(game, installer):
             except Exception as e:
                 error_message = str(e)
     else:
-        os.remove(installer)
+        for file in os.listdir(installer_directory):
+            os.remove(os.path.join(installer_directory, file))
 
     return error_message
 


### PR DESCRIPTION
Hi,

There is an issue with MG when the users decide to don't keep the installer.
With the actual code and for all game which have more than 1 file (Windows games), only the .exe file is deleted :
![Screenshot from 2022-04-10 22-31-06](https://user-images.githubusercontent.com/3606036/162640736-6a3fdb4e-afe0-48f3-af8f-9d273d469a61.png)

I think this piece of code was implemented before the possibility to download Windows games because Linux games have only one file. 

My PR fix this issue. All Windows offline setup and Linux offline setup are correctly deleted.