### PR TITLE
Fix error in Properties window when wine is not installed

### DIFF
--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -47,7 +47,7 @@ class Properties(Gtk.Dialog):
         # Retrieve custom wine path each time Properties is open
         if self.game.get_info("custom_wine"):
             self.button_properties_wine.set_filename(self.game.get_info("custom_wine"))
-        else:
+        elif shutil.which("wine"):
             self.button_properties_wine.set_filename(shutil.which("wine"))
 
         # Keep switch FPS disabled/enabled


### PR DESCRIPTION
When wine is not installed `shutil.which()` returns `None` and this exception is raised:
```
Traceback (most recent call last):
  File "/home/laurent/Projects/src/github.com/lmeunier/minigalaxy/minigalaxy/ui/gametile.py", line 134, in show_properties
    properties_window = Properties(self, self.game, self.api)
  File "/home/laurent/Projects/src/github.com/lmeunier/minigalaxy/minigalaxy/ui/properties.py", line 51, in __init__
    self.button_properties_wine.set_filename(shutil.which("wine"))
TypeError: Argument 1 does not allow None as a value
```

This error prevents the Properties window to be shown.