### PR TITLE
Fixed localized DLC names

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -129,8 +129,8 @@ class Api:
 
     # Get Extrainfo about a game
     def get_info(self, game: Game) -> dict:
-        request_url = "https://api.gog.com/products/{}?locale=en-US&expand=downloads,expanded_dlcs,description,screenshots,videos," \
-                      "related_products,changelog".format(str(game.id))
+        request_url = "https://api.gog.com/products/{}?locale=en-US&expand=downloads,expanded_dlcs,description,screenshots," \
+                      "videos,related_products,changelog".format(str(game.id))
         response = self.__request(request_url)
         return response
 

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -129,8 +129,8 @@ class Api:
 
     # Get Extrainfo about a game
     def get_info(self, game: Game) -> dict:
-        request_url = "https://api.gog.com/products/{}?expand=downloads,expanded_dlcs,description,screenshots,videos," \
-                      "related_products,changelog ".format(str(game.id))
+        request_url = "https://api.gog.com/products/{}?locale=en-US&expand=downloads,expanded_dlcs,description,screenshots,videos," \
+                      "related_products,changelog".format(str(game.id))
         response = self.__request(request_url)
         return response
 


### PR DESCRIPTION
GOG has localized names for some games and DLCs (e.g. [Frostpunk: The Rifts](https://www.gog.com/game/frostpunk_the_rifts)), but it provides them based on user's IP. It looks heterogeneous when you want to use English everywhere. This PR fixes it.
Before:
![0](https://user-images.githubusercontent.com/14265316/151784757-fa0dfea1-a1c2-4006-bd38-0bbf7e4765b3.png)
After:
![1](https://user-images.githubusercontent.com/14265316/164973494-ce3dd96f-6e18-461c-940e-d941b79f8e47.png)
I thought about making a switcher for that behavior, but I have a doubt that it'll be in demand. @sharkwouter what do you think?