### PR TITLE
Make sure the links to the xml based checksum are only used once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Add gettext to build dependencies (thanks to larslindq)
 - Improve error handling upon API errors
 - Fix several issues with launching Windows games from Minigalaxy
+- Fix some games getting stuck on in queue
 
 - Add Greek translation (thanks to Pyrofanis)
 - Add Spanish (Spain) translation (thanks to mbarrio)

--- a/minigalaxy/file_info.py
+++ b/minigalaxy/file_info.py
@@ -1,0 +1,7 @@
+class FileInfo:
+    """
+    Just a container for the md5 checksum and file size of a downloadable file
+    """
+    def __init__(self, md5, size):
+        self.md5 = md5
+        self.size = size

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -249,7 +249,8 @@ class GameTile(Gtk.Box):
                 GLib.idle_add(self.parent.parent.show_error, _("Download error"), _(str(e)))
                 download_success = False
                 break
-            total_file_size += self.api.get_file_size(file_info["downlink"])
+            info = self.api.get_download_file_info(file_info["downlink"])
+            total_file_size += info.size
             try:
                 # Extract the filename from the download url (filename is between %2F and &token)
                 filename = urllib.parse.unquote(re.search('%2F(((?!%2F).)*)&t', download_url).group(1))
@@ -259,9 +260,8 @@ class GameTile(Gtk.Box):
             if key == 0:
                 # If key = 0, denote the file as the executable's path
                 executable_path = download_path
-            md5sum = self.api.get_download_file_md5(file_info["downlink"])
-            if md5sum:
-                self.game.md5sum[os.path.basename(download_path)] = md5sum
+            if info.md5:
+                self.game.md5sum[os.path.basename(download_path)] = info.md5
             download = Download(
                 url=download_url,
                 save_location=download_path,

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -252,7 +252,8 @@ class GameTileList(Gtk.Box):
                 GLib.idle_add(self.parent.parent.show_error, _("Download error"), _(str(e)))
                 download_success = False
                 break
-            total_file_size += self.api.get_file_size(file_info["downlink"])
+            info = self.api.get_download_file_info(file_info["downlink"])
+            total_file_size += info.size
             try:
                 # Extract the filename from the download url (filename is between %2F and &token)
                 filename = urllib.parse.unquote(re.search('%2F(((?!%2F).)*)&t', download_url).group(1))
@@ -262,9 +263,8 @@ class GameTileList(Gtk.Box):
             if key == 0:
                 # If key = 0, denote the file as the executable's path
                 executable_path = download_path
-            md5sum = self.api.get_download_file_md5(file_info["downlink"])
-            if md5sum:
-                self.game.md5sum[os.path.basename(download_path)] = md5sum
+            if info.md5:
+                self.game.md5sum[os.path.basename(download_path)] = info.md5
             download = Download(
                 url=download_url,
                 save_location=download_path,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,7 +138,7 @@ class TestApi(TestCase):
         obs = api.get_version(test_game, gameinfo=API_GET_INFO_TOONSTRUCK, dlc_name=dlc_name)
         self.assertEqual(exp, obs)
 
-    def test_get_download_file_md5(self):
+    def test_get_download_file__info_md5(self):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
@@ -151,10 +151,10 @@ class TestApi(TestCase):
     <chunk id="3" from="31457280" to="36717997" method="md5">0261b9225fc10c407df083f6d254c47b</chunk>
 </file>'''
         exp = "8acedf66c0d2986e7dee9af912b7df4f"
-        obs = api.get_download_file_md5("url")
+        obs = api.get_download_file_info("url").md5
         self.assertEqual(exp, obs)
 
-    def test_get_download_file_md5_returns_empty_string_on_empty_response(self):
+    def test_get_download_file_info_md5_returns_empty_string_on_empty_response(self):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
@@ -163,10 +163,10 @@ class TestApi(TestCase):
         m_constants.SESSION.get().text = ""
 
         exp = ""
-        obs = api.get_download_file_md5("url")
+        obs = api.get_download_file_info("url").md5
         self.assertEqual(exp, obs)
 
-    def test_get_download_file_md5_returns_empty_string_on_response_error(self):
+    def test_get_download_file_info_md5_returns_empty_string_on_response_error(self):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
@@ -174,10 +174,10 @@ class TestApi(TestCase):
         m_constants.SESSION.get().status_code = http.HTTPStatus.NOT_FOUND
 
         exp = ""
-        obs = api.get_download_file_md5("url")
+        obs = api.get_download_file_info("url").md5
         self.assertEqual(exp, obs)
 
-    def test_get_download_file_md5_returns_empty_string_on_missing_md5(self):
+    def test_get_download_file_info_md5_returns_empty_string_on_missing_md5(self):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
@@ -191,10 +191,10 @@ class TestApi(TestCase):
 </file>'''
 
         exp = ""
-        obs = api.get_download_file_md5("url")
+        obs = api.get_download_file_info("url").md5
         self.assertEqual(exp, obs)
 
-    def test_get_file_size(self):
+    def test_get_file_info_size(self):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
@@ -207,10 +207,10 @@ class TestApi(TestCase):
     <chunk id="3" from="31457280" to="36717997" method="md5">0261b9225fc10c407df083f6d254c47b</chunk>
 </file>'''
         exp = 36717998
-        obs = api.get_file_size("url")
+        obs = api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
-    def test_get_file_size_returns_zero_on_empty_response(self):
+    def test_get_file_info_size_returns_zero_on_empty_response(self):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
@@ -219,10 +219,10 @@ class TestApi(TestCase):
         m_constants.SESSION.get().text = ""
 
         exp = 0
-        obs = api.get_file_size("url")
+        obs = api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
-    def test_get_file_size_returns_zero_on_response_error(self):
+    def test_get_file_info_size_returns_zero_on_response_error(self):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
@@ -230,30 +230,30 @@ class TestApi(TestCase):
         m_constants.SESSION.get().status_code = http.HTTPStatus.NOT_FOUND
 
         exp = 0
-        obs = api.get_file_size("url")
+        obs = api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
-    def test_get_file_size_returns_zero_on_request_exception(self):
+    def test_get_file_info_size_returns_zero_on_request_exception(self):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = requests.exceptions.RequestException("test")
 
         exp = 0
-        obs = api.get_file_size("url")
+        obs = api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
-    def test_get_file_size_returns_zero_on_request_timeout_exception(self):
+    def test_get_file_info_size_returns_zero_on_request_timeout_exception(self):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = requests.exceptions.ReadTimeout("test")
 
         exp = 0
-        obs = api.get_file_size("url")
+        obs = api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
-    def test_get_file_size_returns_zero_on_missing_total_size(self):
+    def test_get_file_info_size_returns_zero_on_missing_total_size(self):
         api = Api()
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
@@ -267,7 +267,7 @@ class TestApi(TestCase):
 </file>'''
 
         exp = 0
-        obs = api.get_file_size("url")
+        obs = api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
     def test1_get_gamesdb_info(self):


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

It turns out the what was causing games to get stuck in queue was that a link used for determining the md5sum and file size for a download was used twice, even though these links only allow a single use. I've updated the code and added a fileinfo class. This should solve #484

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
