### PR TITLE
Fix exception when no content length is received by server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**2.0.0**
+- Fix downloads failing when content length is not returned by the server
+
 **1.2.0**
 - Split game information and properties into different windows (thanks to TotalCaesar659)
 - Add list view (thanks to TotalCaesar659)

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -131,9 +131,13 @@ class __DownloadManger:
         resume_header = {'Range': 'bytes={}-'.format(start_point)}
         download_request = SESSION.get(download.url, headers=resume_header, stream=True, timeout=30)
         downloaded_size = start_point
-        file_size = int(download_request.headers.get('content-length'))
+        file_size = None
+        try:
+            file_size = int(download_request.headers.get('content-length'))
+        except ValueError:
+            print(f"Couldn't get file size for {download.save_location}. No progress will be shown.")
         result = True
-        if downloaded_size < file_size:
+        if not file_size or downloaded_size < file_size:
             with open(download.save_location, download_mode) as save_file:
                 for chunk in download_request.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
                     # Pause if needed
@@ -144,7 +148,7 @@ class __DownloadManger:
                     if self.__cancel:
                         result = False
                         break
-                    if file_size > 0:
+                    if file_size:
                         progress = int(downloaded_size / file_size * 100)
                         download.set_progress(progress)
                 save_file.close()


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

<!-- Describe what was changed -->

When the content length is not returned by the server you currently see an ugly exception. It doesn't seem to break anything, oddly enough, though. But this should fix the exception. I'll add a test later.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
