### PR TITLE
Redo the Config class

### DIFF
--- a/bin/minigalaxy
+++ b/bin/minigalaxy
@@ -16,9 +16,11 @@ if os.path.isdir(os.path.join(LAUNCH_PATH, "../minigalaxy")):
 from minigalaxy.version import VERSION
 from minigalaxy.paths import CONFIG_DIR, CACHE_DIR
 
+
 def conf_reset():
     shutil.rmtree(CONFIG_DIR, ignore_errors=True)
     shutil.rmtree(CACHE_DIR, ignore_errors=True)
+
 
 def cli_params():
     parser = argparse.ArgumentParser(description="A simple GOG Linux client")
@@ -31,6 +33,7 @@ def cli_params():
 
     return parser.parse_args()
 
+
 def main():
     cli_args = cli_params()
 
@@ -39,9 +42,13 @@ def main():
     # Import the gi module after parsing arguments
     from minigalaxy.ui.gtk import Gtk
     from minigalaxy.ui import Window
+    from minigalaxy.config import Config
+    from minigalaxy.api import Api
 
     # Start the application
-    window = Window(APPLICATION_NAME)
+    config = Config()
+    api = Api(config)
+    window = Window(config, api, APPLICATION_NAME)
     window.connect("destroy", Gtk.main_quit)
     Gtk.main()
 

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -8,6 +8,7 @@ import xml.etree.ElementTree as ET
 from minigalaxy.file_info import FileInfo
 from minigalaxy.game import Game
 from minigalaxy.constants import IGNORE_GAME_IDS, SESSION
+from minigalaxy.config import Config
 
 
 class NoDownloadLinkFound(BaseException):
@@ -15,7 +16,7 @@ class NoDownloadLinkFound(BaseException):
 
 
 class Api:
-    def __init__(self, config: 'Config'):
+    def __init__(self, config: Config):
         self.config = config
         self.login_success_url = "https://embed.gog.com/on_login_success"
         self.redirect_uri = "https://embed.gog.com/on_login_success?origin=client"

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -155,5 +155,5 @@ class Config:
         return self.get("current_downloads", [])
 
     @current_downloads.setter
-    def create_applications_file(self, new_value: list[int]) -> None:
+    def current_downloads(self, new_value: list[int]) -> None:
         self.set("current_downloads", new_value)

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -114,7 +114,7 @@ class Config:
 
     @property
     def show_hidden_games(self) -> bool:
-        return self.get("keep_installers", False)
+        return self.get("show_hidden_games", False)
 
     @show_hidden_games.setter
     def show_hidden_games(self, new_value: bool) -> None:

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -1,113 +1,146 @@
 import os
-import threading
 import json
-import time
-from minigalaxy.paths import CONFIG_DIR, CONFIG_FILE_PATH, DEFAULT_INSTALL_DIR
-
-# The default values for new configuration files
-DEFAULT_CONFIGURATION = {
-    "locale": "",
-    "lang": "en",
-    "view": "grid",
-    "install_dir": DEFAULT_INSTALL_DIR,
-    "keep_installers": False,
-    "stay_logged_in": True,
-    "use_dark_theme": False,
-    "show_hidden_games": False,
-    "show_windows_games": False,
-    "keep_window_maximized": False,
-    "installed_filter": False,
-    "create_applications_file": False
-}
+from minigalaxy.paths import CONFIG_FILE_PATH, DEFAULT_INSTALL_DIR
 
 
-# Make sure you never spawn two instances of this class
-# If multiple instances go out of sync, they will overwrite each others changes
-# The config file is only read once upon starting up
-class __Config:
-    def __init__(self):
-        self.first_run = False
+class Config:
+
+    __config_file: str
+    __config: dict
+
+    def __init__(self, config_file: str = CONFIG_FILE_PATH):
+        self.__config_file = config_file
         self.__config = {}
-        self.__config_file = CONFIG_FILE_PATH
-        self.__update_required = False
+        self.__load()
 
-    def first_run_init(self):
-        if not self.first_run:
-            self.first_run = True
-            self.__config = self.__load_config_file()
-            self.__add_missing_config_entries()
-            # Update the config file regularly to reflect the self.__config dictionary
-            keep_config_synced_thread = threading.Thread(target=self.__keep_config_synced)
-            keep_config_synced_thread.daemon = True
-            keep_config_synced_thread.start()
-
-    def __keep_config_synced(self):
-        while True:
-            if self.__update_required:
-                self.__update_config_file()
-                self.__update_required = False
-            time.sleep(0.1)
-
-    def __load_config_file(self) -> dict:
-        if os.path.exists(self.__config_file):
+    def __load(self) -> None:
+        if os.path.isfile(self.__config_file):
             with open(self.__config_file, "r") as file:
                 try:
-                    return json.loads(file.read())
+                    self.__config = json.loads(file.read())
                 except json.decoder.JSONDecodeError:
                     print("Reading config.json failed, creating new config file.")
-                    return self.__create_config_file()
-        else:
-            return self.__create_config_file()
+                    os.remove(self.__config_file)
 
-    def __create_config_file(self) -> dict:
-        # Make sure the configuration directory exists before creating the configuration file
-        if not os.path.exists(CONFIG_DIR):
-            os.makedirs(CONFIG_DIR, mode=0o755)
+    def __write(self) -> None:
+        if not os.path.isfile(self.__config_file):
+            config_dir = os.path.dirname(self.__config_file)
+            os.makedirs(config_dir, mode=0o700, exist_ok=True)
+        temp_file = f"{self.__config_file}.tmp"
         with open(self.__config_file, "w") as file:
-            file.write(json.dumps(DEFAULT_CONFIGURATION))
-            file.close()
+            file.write(json.dumps(self.__config, ensure_ascii=False))
+        os.rename(temp_file, self.__config_file)
 
-        # Make sure the default installation path exists
-        if not os.path.isdir(DEFAULT_CONFIGURATION['install_dir']):
-            os.makedirs(DEFAULT_CONFIGURATION['install_dir'], mode=0o755)
+    def get(self, key: str, default: any = None) -> any:
+        return self.__config[key] if key in self.__config else default
 
-        return DEFAULT_CONFIGURATION
-
-    def __update_config_file(self):
-        with open(self.__config_file, "w") as file:
-            file.write(json.dumps(self.__config))
-            file.close()
-
-    def __add_missing_config_entries(self):
-        # Make sure all config values in the default configuration are available
-        added_value = False
-        for key in DEFAULT_CONFIGURATION:
-            if self.get(key) is None:
-                self.set(key, DEFAULT_CONFIGURATION[key])
-                added_value = True
-        if added_value:
-            self.__update_config_file()
-            self.__config = self.__load_config_file()
-
-    def set(self, key, value):
-        self.first_run_init()
+    def set(self, key: str, value: any) -> None:
         self.__config[key] = value
-        self.__update_required = True
+        self.__write()
 
-    def get(self, key):
-        self.first_run_init()
-        try:
-            return self.__config[key]
-        except KeyError:
-            return None
+    @property
+    def locale(self) -> str:
+        return self.get("locale", "")
 
-    def unset(self, key):
-        self.first_run_init()
-        try:
-            del self.__config[key]
-            self.__update_required = True
-        except KeyError:
-            pass
+    @locale.setter
+    def locale(self, new_value: str) -> None:
+        self.set("locale", new_value)
+
+    @property
+    def lang(self) -> str:
+        return self.get("lang", "en")
+
+    @lang.setter
+    def lang(self, new_value: str) -> None:
+        self.set("lang", new_value)
+
+    @property
+    def view(self) -> str:
+        return self.get("view", "grid")
+
+    @view.setter
+    def view(self, new_value: str) -> None:
+        self.set("view", new_value)
+
+    @property
+    def install_dir(self) -> str:
+        return self.get("install_dir", DEFAULT_INSTALL_DIR)
+
+    @install_dir.setter
+    def install_dir(self, new_value: str) -> None:
+        self.set("install_dir", new_value)
+
+    @property
+    def username(self) -> str:
+        return self.get("username", "")
+
+    @username.setter
+    def username(self, new_value: str) -> None:
+        self.set("username", new_value)
+
+    @property
+    def keep_installers(self) -> bool:
+        return self.get("keep_installers", False)
+
+    @keep_installers.setter
+    def keep_installers(self, new_value: bool) -> None:
+        self.set("keep_installers", new_value)
+
+    @property
+    def stay_logged_in(self) -> bool:
+        return self.get("stay_logged_in", True)
+
+    @stay_logged_in.setter
+    def stay_logged_in(self, new_value: bool) -> None:
+        self.set("stay_logged_in", new_value)
+
+    @property
+    def use_dark_theme(self) -> bool:
+        return self.get("use_dark_theme", False)
+
+    @use_dark_theme.setter
+    def use_dark_theme(self, new_value: bool) -> None:
+        self.set("use_dark_theme", new_value)
+
+    @property
+    def show_hidden_games(self) -> bool:
+        return self.get("keep_installers", False)
+
+    @show_hidden_games.setter
+    def show_hidden_games(self, new_value: bool) -> None:
+        self.set("show_hidden_games", new_value)
+
+    @property
+    def show_windows_games(self) -> bool:
+        return self.get("show_windows_games", False)
+
+    @show_windows_games.setter
+    def show_windows_games(self, new_value: bool) -> None:
+        self.set("show_windows_games", new_value)
+
+    @property
+    def keep_window_maximized(self) -> bool:
+        return self.get("keep_window_maximized", False)
+
+    @keep_window_maximized.setter
+    def keep_window_maximized(self, new_value: bool) -> None:
+        self.set("keep_window_maximized", new_value)
+
+    @property
+    def installed_filter(self) -> bool:
+        return self.get("installed_filter", False)
+
+    @installed_filter.setter
+    def installed_filter(self, new_value: bool) -> None:
+        self.set("installed_filter", new_value)
+
+    @property
+    def create_applications_file(self) -> bool:
+        return self.get("create_applications_file", False)
+
+    @create_applications_file.setter
+    def create_applications_file(self, new_value: bool) -> None:
+        self.set("create_applications_file", new_value)
 
 
-Config = __Config()
+

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -27,7 +27,7 @@ class Config:
             config_dir = os.path.dirname(self.__config_file)
             os.makedirs(config_dir, mode=0o700, exist_ok=True)
         temp_file = f"{self.__config_file}.tmp"
-        with open(self.__config_file, "w") as file:
+        with open(temp_file, "w") as file:
             file.write(json.dumps(self.__config, ensure_ascii=False))
         os.rename(temp_file, self.__config_file)
 
@@ -77,6 +77,14 @@ class Config:
     @username.setter
     def username(self, new_value: str) -> None:
         self.set("username", new_value)
+
+    @property
+    def refresh_token(self) -> str:
+        return self.get("refresh_token", "")
+
+    @refresh_token.setter
+    def refresh_token(self, new_value: str) -> None:
+        self.set("refresh_token", new_value)
 
     @property
     def keep_installers(self) -> bool:
@@ -142,5 +150,10 @@ class Config:
     def create_applications_file(self, new_value: bool) -> None:
         self.set("create_applications_file", new_value)
 
+    @property
+    def current_downloads(self) -> list[int]:
+        return self.get("current_downloads", [])
 
-
+    @current_downloads.setter
+    def create_applications_file(self, new_value: list[int]) -> None:
+        self.set("current_downloads", new_value)

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -33,129 +33,129 @@ class Config:
             file.write(json.dumps(self.__config, ensure_ascii=False))
         os.rename(temp_file, self.__config_file)
 
-    def get(self, key: str, default: any = None) -> any:
+    def __get(self, key: str, default: any = None) -> any:
         return self.__config[key] if key in self.__config else default
 
-    def set(self, key: str, value: any) -> None:
+    def __set(self, key: str, value: any) -> None:
         self.__config[key] = value
         self.__write()
 
     @property
     def locale(self) -> str:
-        return self.get("locale", "")
+        return self.__get("locale", "")
 
     @locale.setter
     def locale(self, new_value: str) -> None:
-        self.set("locale", new_value)
+        self.__set("locale", new_value)
 
     @property
     def lang(self) -> str:
-        return self.get("lang", "en")
+        return self.__get("lang", "en")
 
     @lang.setter
     def lang(self, new_value: str) -> None:
-        self.set("lang", new_value)
+        self.__set("lang", new_value)
 
     @property
     def view(self) -> str:
-        return self.get("view", "grid")
+        return self.__get("view", "grid")
 
     @view.setter
     def view(self, new_value: str) -> None:
-        self.set("view", new_value)
+        self.__set("view", new_value)
 
     @property
     def install_dir(self) -> str:
-        return self.get("install_dir", DEFAULT_INSTALL_DIR)
+        return self.__get("install_dir", DEFAULT_INSTALL_DIR)
 
     @install_dir.setter
     def install_dir(self, new_value: str) -> None:
-        self.set("install_dir", new_value)
+        self.__set("install_dir", new_value)
 
     @property
     def username(self) -> str:
-        return self.get("username", "")
+        return self.__get("username", "")
 
     @username.setter
     def username(self, new_value: str) -> None:
-        self.set("username", new_value)
+        self.__set("username", new_value)
 
     @property
     def refresh_token(self) -> str:
-        return self.get("refresh_token", "")
+        return self.__get("refresh_token", "")
 
     @refresh_token.setter
     def refresh_token(self, new_value: str) -> None:
-        self.set("refresh_token", new_value)
+        self.__set("refresh_token", new_value)
 
     @property
     def keep_installers(self) -> bool:
-        return self.get("keep_installers", False)
+        return self.__get("keep_installers", False)
 
     @keep_installers.setter
     def keep_installers(self, new_value: bool) -> None:
-        self.set("keep_installers", new_value)
+        self.__set("keep_installers", new_value)
 
     @property
     def stay_logged_in(self) -> bool:
-        return self.get("stay_logged_in", True)
+        return self.__get("stay_logged_in", True)
 
     @stay_logged_in.setter
     def stay_logged_in(self, new_value: bool) -> None:
-        self.set("stay_logged_in", new_value)
+        self.__set("stay_logged_in", new_value)
 
     @property
     def use_dark_theme(self) -> bool:
-        return self.get("use_dark_theme", False)
+        return self.__get("use_dark_theme", False)
 
     @use_dark_theme.setter
     def use_dark_theme(self, new_value: bool) -> None:
-        self.set("use_dark_theme", new_value)
+        self.__set("use_dark_theme", new_value)
 
     @property
     def show_hidden_games(self) -> bool:
-        return self.get("show_hidden_games", False)
+        return self.__get("show_hidden_games", False)
 
     @show_hidden_games.setter
     def show_hidden_games(self, new_value: bool) -> None:
-        self.set("show_hidden_games", new_value)
+        self.__set("show_hidden_games", new_value)
 
     @property
     def show_windows_games(self) -> bool:
-        return self.get("show_windows_games", False)
+        return self.__get("show_windows_games", False)
 
     @show_windows_games.setter
     def show_windows_games(self, new_value: bool) -> None:
-        self.set("show_windows_games", new_value)
+        self.__set("show_windows_games", new_value)
 
     @property
     def keep_window_maximized(self) -> bool:
-        return self.get("keep_window_maximized", False)
+        return self.__get("keep_window_maximized", False)
 
     @keep_window_maximized.setter
     def keep_window_maximized(self, new_value: bool) -> None:
-        self.set("keep_window_maximized", new_value)
+        self.__set("keep_window_maximized", new_value)
 
     @property
     def installed_filter(self) -> bool:
-        return self.get("installed_filter", False)
+        return self.__get("installed_filter", False)
 
     @installed_filter.setter
     def installed_filter(self, new_value: bool) -> None:
-        self.set("installed_filter", new_value)
+        self.__set("installed_filter", new_value)
 
     @property
     def create_applications_file(self) -> bool:
-        return self.get("create_applications_file", False)
+        return self.__get("create_applications_file", False)
 
     @create_applications_file.setter
     def create_applications_file(self, new_value: bool) -> None:
-        self.set("create_applications_file", new_value)
+        self.__set("create_applications_file", new_value)
 
     @property
     def current_downloads(self) -> List[int]:
-        return self.get("current_downloads", [])
+        return self.__get("current_downloads", [])
 
     @current_downloads.setter
     def current_downloads(self, new_value: List[int]) -> None:
-        self.set("current_downloads", new_value)
+        self.__set("current_downloads", new_value)

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -1,5 +1,7 @@
 import os
 import json
+from typing import List
+
 from minigalaxy.paths import CONFIG_FILE_PATH, DEFAULT_INSTALL_DIR
 
 
@@ -151,9 +153,9 @@ class Config:
         self.set("create_applications_file", new_value)
 
     @property
-    def current_downloads(self) -> list[int]:
+    def current_downloads(self) -> List[int]:
         return self.get("current_downloads", [])
 
     @current_downloads.setter
-    def current_downloads(self, new_value: list[int]) -> None:
+    def current_downloads(self, new_value: List[int]) -> None:
         self.set("current_downloads", new_value)

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -23,7 +23,6 @@ import threading
 import queue
 
 from requests.exceptions import RequestException
-from minigalaxy.config import Config
 from minigalaxy.constants import DOWNLOAD_CHUNK_SIZE, MINIMUM_RESUME_SIZE, SESSION, GAME_DOWNLOAD_THREADS, UI_DOWNLOAD_THREADS
 from minigalaxy.download import Download, DownloadType
 import minigalaxy.logger    # noqa: F401
@@ -297,8 +296,6 @@ class __DownloadManger:
                 finish_thread = threading.Thread(target=download.finish)
                 finish_thread.start()
             self.__remove_download_from_active_downloads(download)
-            if download_queue.empty():
-                Config.unset("current_downloads")
         # Unsuccessful downloads and cancels
         else:
             if download in self.__cancel:

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -2,13 +2,12 @@ import os
 import re
 import json
 
-from minigalaxy.config import Config
 from minigalaxy.paths import CONFIG_GAMES_DIR
 
 
 class Game:
     def __init__(self, name: str, url: str = "", md5sum=None, game_id: int = 0, install_dir: str = "",
-                 image_url="", platform="linux", dlcs=None, config=None):
+                 image_url="", platform="linux", dlcs=None):
         self.name = name
         self.url = url
         self.md5sum = {} if md5sum is None else md5sum
@@ -18,10 +17,6 @@ class Game:
         self.platform = platform
         self.dlcs = [] if dlcs is None else dlcs
         self.status_file_path = self.get_status_file_path()
-
-        self.config = config
-        if not self.config:
-            self.config = Config()
 
     def get_stripped_name(self):
         return self.__strip_string(self.name)
@@ -140,9 +135,13 @@ class Game:
         # End: Code for compatibility with minigalaxy 1.0.1 and 1.0.2
         return value
 
-    def set_install_dir(self):
+    def set_install_dir(self, install_dir) -> None:
+        """
+        Set the install directory based on the given install dir and the game name
+        :param install_dir: the global install directory from the config
+        """
         if not self.install_dir:
-            self.install_dir = os.path.join(self.config.install_dir, self.get_install_directory_name())
+            self.install_dir = os.path.join(install_dir, self.get_install_directory_name())
 
     def __str__(self):
         return self.name

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -8,7 +8,7 @@ from minigalaxy.paths import CONFIG_GAMES_DIR
 
 class Game:
     def __init__(self, name: str, url: str = "", md5sum=None, game_id: int = 0, install_dir: str = "",
-                 image_url="", platform="linux", dlcs=None):
+                 image_url="", platform="linux", dlcs=None, config=None):
         self.name = name
         self.url = url
         self.md5sum = {} if md5sum is None else md5sum
@@ -18,6 +18,10 @@ class Game:
         self.platform = platform
         self.dlcs = [] if dlcs is None else dlcs
         self.status_file_path = self.get_status_file_path()
+
+        self.config = config
+        if not self.config:
+            self.config = Config()
 
     def get_stripped_name(self):
         return self.__strip_string(self.name)
@@ -138,7 +142,7 @@ class Game:
 
     def set_install_dir(self):
         if not self.install_dir:
-            self.install_dir = os.path.join(Config.get("install_dir"), self.get_install_directory_name())
+            self.install_dir = os.path.join(self.config.install_dir, self.get_install_directory_name())
 
     def __str__(self):
         return self.name

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -40,7 +40,14 @@ def check_diskspace(required_size, location):
     return diskspace_available >= installed_game_size
 
 
-def install_game(game: Game, installer: str, language: str, install_dir: str, keep_installers: bool, create_desktop_file: bool):  # noqa: C901
+def install_game(  # noqa: C901
+        game: Game,
+        installer: str,
+        language: str,
+        install_dir: str,
+        keep_installers: bool,
+        create_desktop_file: bool
+):
     error_message = ""
     tmp_dir = ""
     print("Installing {}".format(game.name))

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -3,10 +3,11 @@ import shutil
 import subprocess
 import hashlib
 import textwrap
+
+from minigalaxy.game import Game
 from minigalaxy.translation import _
 from minigalaxy.launcher import get_execute_command
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, APPLICATIONS_DIR
-from minigalaxy.config import Config
 
 
 def get_available_disk_space(location):
@@ -39,7 +40,7 @@ def check_diskspace(required_size, location):
     return diskspace_available >= installed_game_size
 
 
-def install_game(game, installer):  # noqa: C901
+def install_game(game: Game, installer: str, language: str, install_dir: str, keep_installers: bool, create_desktop_file: bool):  # noqa: C901
     error_message = ""
     tmp_dir = ""
     print("Installing {}".format(game.name))
@@ -50,17 +51,17 @@ def install_game(game, installer):  # noqa: C901
     if not error_message:
         error_message, tmp_dir = make_tmp_dir(game)
     if not error_message:
-        error_message = extract_installer(game, installer, tmp_dir)
+        error_message = extract_installer(game, installer, tmp_dir, language)
     if not error_message:
         error_message = move_and_overwrite(game, tmp_dir)
     if not error_message:
         error_message = copy_thumbnail(game)
-    if not error_message:
+    if not error_message and create_desktop_file:
         error_message = create_applications_file(game)
     if not error_message:
-        error_message = remove_installer(game, installer)
+        error_message = remove_installer(game, installer, install_dir, keep_installers)
     else:
-        remove_installer(game, installer)
+        remove_installer(game, installer, install_dir, keep_installers)
     if not error_message:
         error_message = postinstaller(game)
     if error_message:
@@ -111,12 +112,12 @@ def make_tmp_dir(game):
     return error_message, temp_dir
 
 
-def extract_installer(game, installer, temp_dir):
+def extract_installer(game: Game, installer: str, temp_dir: str, language: str):
     # Extract the installer
     if game.platform in ["linux"]:
         err_msg = extract_linux(installer, temp_dir)
     else:
-        err_msg = extract_windows(game, installer, temp_dir)
+        err_msg = extract_windows(game, installer, temp_dir, language)
     return err_msg
 
 
@@ -132,17 +133,17 @@ def extract_linux(installer, temp_dir):
     return err_msg
 
 
-def extract_windows(game, installer, temp_dir):
-    err_msg = extract_by_innoextract(installer, temp_dir)
+def extract_windows(game: Game, installer: str, temp_dir: str, language: str):
+    err_msg = extract_by_innoextract(installer, temp_dir, language)
     if err_msg:
         err_msg = extract_by_wine(game, installer, temp_dir)
     return err_msg
 
 
-def extract_by_innoextract(installer, temp_dir):
+def extract_by_innoextract(installer: str, temp_dir: str, language: str):
     err_msg = ""
     if shutil.which("innoextract"):
-        lang = lang_install(installer)
+        lang = lang_install(installer, language)
         cmd = ["innoextract", installer, "-d", temp_dir, "--gog", lang]
         stdout, stderr, exitcode = _exe_cmd(cmd)
         if exitcode not in [0]:
@@ -221,32 +222,31 @@ def get_exec_line(game):
 
 def create_applications_file(game):
     error_message = ""
-    if Config.get("create_applications_file"):
-        path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
-        exe_cmd = get_exec_line(game)
-        # Create desktop file definition
-        desktop_context = {
-            "game_bin_path": os.path.join('"{}"'.format(game.install_dir.replace('"', '\\"')), exe_cmd),
-            "game_name": game.name,
-            "game_install_dir": game.install_dir,
-            "game_icon_path": os.path.join(game.install_dir, 'support/icon.png')
-            }
-        desktop_definition = """\
-            [Desktop Entry]
-            Type=Application
-            Terminal=false
-            StartupNotify=true
-            Exec={game_bin_path}
-            Path={game_install_dir}
-            Name={game_name}
-            Icon={game_icon_path}""".format(**desktop_context)
-        if not os.path.isfile(path_to_shortcut):
-            try:
-                with open(path_to_shortcut, 'w+') as desktop_file:
-                    desktop_file.writelines(textwrap.dedent(desktop_definition))
-            except Exception as e:
-                os.remove(path_to_shortcut)
-                error_message = e
+    path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
+    exe_cmd = get_exec_line(game)
+    # Create desktop file definition
+    desktop_context = {
+        "game_bin_path": os.path.join('"{}"'.format(game.install_dir.replace('"', '\\"')), exe_cmd),
+        "game_name": game.name,
+        "game_install_dir": game.install_dir,
+        "game_icon_path": os.path.join(game.install_dir, 'support/icon.png')
+        }
+    desktop_definition = """\
+        [Desktop Entry]
+        Type=Application
+        Terminal=false
+        StartupNotify=true
+        Exec={game_bin_path}
+        Path={game_install_dir}
+        Name={game_name}
+        Icon={game_icon_path}""".format(**desktop_context)
+    if not os.path.isfile(path_to_shortcut):
+        try:
+            with open(path_to_shortcut, 'w+') as desktop_file:
+                desktop_file.writelines(textwrap.dedent(desktop_definition))
+        except Exception as e:
+            os.remove(path_to_shortcut)
+            error_message = e
     return error_message
 
 
@@ -271,15 +271,15 @@ def compare_directories(dir1, dir2):
     return result
 
 
-def remove_installer(game, installer):
+def remove_installer(game: Game, installer: str, install_dir: str, keep_installers: bool):
     error_message = ""
     installer_directory = os.path.dirname(installer)
     if not os.path.isdir(installer_directory):
         error_message = "No installer directory is present: {}".format(installer_directory)
         return error_message
 
-    if Config.get("keep_installers"):
-        keep_dir = os.path.join(Config.get("install_dir"), "installer")
+    if keep_installers:
+        keep_dir = os.path.join(install_dir, "installer")
         keep_dir2 = os.path.join(keep_dir, game.get_install_directory_name())
         if keep_dir2 == installer_directory:
             # We are using the keep installer already
@@ -341,7 +341,7 @@ def _mv(source_dir, target_dir):
 # Some installers allow to choose game's language before installation (Divinity Original Sin or XCom EE / XCom 2)
 # "--list-languages" option returns "en-US", "fr-FR" etc... for these games.
 # Others installers return "French : Français" but disallow to choose game's language before installation
-def lang_install(installer):
+def lang_install(installer: str, language: str):
     languages = []
     arg = ""
     process = subprocess.Popen(["innoextract", installer, "--list-languages"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -354,7 +354,7 @@ def lang_install(installer):
         languages.append(line[3:])
     for lang in languages:
         if "-" in lang:  # lang must be like "en-US" only.
-            if Config.get("lang") == lang[0:2]:
+            if language == lang[0:2]:
                 arg = "--language={}".format(lang)
                 break
             else:

--- a/minigalaxy/translation.py
+++ b/minigalaxy/translation.py
@@ -27,7 +27,7 @@ gettext.textdomain(TRANSLATION_DOMAIN)
 os.unsetenv("LANGUAGE")
 os.unsetenv("LANG")
 
-current_locale = Config.get("locale")
+current_locale = Config().locale
 default_locale = locale.getdefaultlocale()[0]
 if current_locale == '':
     if default_locale is None:

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -190,7 +190,7 @@ class GameTile(Gtk.Box):
 
     def __set_image(self, save_location):
         set_result = False
-        self.game.set_install_dir()
+        self.game.set_install_dir(self.config.install_dir)
         thumbnail_install_dir = os.path.join(self.game.install_dir, "thumbnail.jpg")
         if os.path.isfile(thumbnail_install_dir):
             GLib.idle_add(self.image.set_from_file, thumbnail_install_dir)
@@ -315,7 +315,7 @@ class GameTile(Gtk.Box):
         if self.game.id in self.config.current_downloads:
             self.config.current_downloads.remove(self.game.id)
         self.download_list = []
-        self.game.set_install_dir()
+        self.game.set_install_dir(self.config.install_dir)
         install_success = self.__install(save_location)
         if install_success:
             self.__check_for_dlc(self.api.get_info(self.game))
@@ -496,7 +496,7 @@ class GameTile(Gtk.Box):
         self.progress_bar.set_fraction(0.0)
 
     def reload_state(self):
-        self.game.set_install_dir()
+        self.game.set_install_dir(self.config.install_dir)
         dont_act_in_states = [self.state.QUEUED, self.state.DOWNLOADING, self.state.INSTALLING, self.state.UNINSTALLING,
                               self.state.UPDATING, self.state.DOWNLOADING]
         if self.current_state in dont_act_in_states:
@@ -569,7 +569,7 @@ class GameTile(Gtk.Box):
         self.menu_button_update.hide()
         self.button_cancel.hide()
 
-        self.game.set_install_dir()
+        self.game.set_install_dir(self.config.install_dir)
 
         if self.progress_bar:
             self.progress_bar.destroy()
@@ -584,7 +584,7 @@ class GameTile(Gtk.Box):
         self.menu_button.show()
         self.menu_button_uninstall.show()
         self.button_cancel.hide()
-        self.game.set_install_dir()
+        self.game.set_install_dir(self.config.install_dir)
 
         if self.progress_bar:
             self.progress_bar.destroy()

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -6,6 +6,8 @@ import re
 import time
 import urllib.parse
 from enum import Enum
+
+from minigalaxy.config import Config
 from minigalaxy.translation import _
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, ICON_DIR, UI_DIR
 from minigalaxy.download import Download, DownloadType
@@ -42,7 +44,7 @@ class GameTile(Gtk.Box):
                  ' UPDATING UPDATE_INSTALLABLE')
 
     def __init__(self, parent, game):
-        self.config = parent.config
+        self.config: Config = parent.config
         current_locale = self.config.locale
         default_locale = locale.getdefaultlocale()[0]
         if current_locale == '':
@@ -132,7 +134,7 @@ class GameTile(Gtk.Box):
 
     @Gtk.Template.Callback("on_menu_button_information_clicked")
     def show_information(self, button):
-        information_window = Information(self, self.game, self.api)
+        information_window = Information(self, self.game, self.config, self.api)
         information_window.run()
         information_window.destroy()
 
@@ -310,6 +312,8 @@ class GameTile(Gtk.Box):
         return download_success
 
     def __install_game(self, save_location):
+        if self.game.id in self.config.current_downloads:
+            self.config.current_downloads.remove(self.game.id)
         self.download_list = []
         self.game.set_install_dir()
         install_success = self.__install(save_location)

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -329,7 +329,13 @@ class GameTile(Gtk.Box):
             failed_state = self.state.DOWNLOADABLE
         success_state = self.state.INSTALLED
         GLib.idle_add(self.update_to_state, processing_state)
-        err_msg = install_game(self.game, save_location, self.config.lang, self.config.install_dir, self.config.keep_installers, self.config.create_applications_file)
+        err_msg = install_game(
+            self.game, save_location,
+            self.config.lang,
+            self.config.install_dir,
+            self.config.keep_installers,
+            self.config.create_applications_file
+        )
         if not err_msg:
             GLib.idle_add(self.update_to_state, success_state)
             install_success = True

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -329,7 +329,7 @@ class GameTile(Gtk.Box):
             failed_state = self.state.DOWNLOADABLE
         success_state = self.state.INSTALLED
         GLib.idle_add(self.update_to_state, processing_state)
-        err_msg = install_game(self.game, save_location)
+        err_msg = install_game(self.game, save_location, self.config.lang, self.config.install_dir, self.config.keep_installers, self.config.create_applications_file)
         if not err_msg:
             GLib.idle_add(self.update_to_state, success_state)
             install_success = True

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -330,7 +330,7 @@ class GameTileList(Gtk.Box):
             failed_state = self.state.DOWNLOADABLE
         success_state = self.state.INSTALLED
         GLib.idle_add(self.update_to_state, processing_state)
-        err_msg = install_game(self.game, save_location)
+        err_msg = install_game(self.game, save_location, self.config.lang, self.config.install_dir, self.config.keep_installers, self.config.create_applications_file)
         if not err_msg:
             GLib.idle_add(self.update_to_state, success_state)
             install_success = True

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -135,7 +135,7 @@ class GameTileList(Gtk.Box):
 
     @Gtk.Template.Callback("on_menu_button_information_clicked")
     def show_information(self, button):
-        information_window = Information(self, self.game, self.api)
+        information_window = Information(self, self.game, self.config, self.api)
         information_window.run()
         information_window.destroy()
 
@@ -313,6 +313,8 @@ class GameTileList(Gtk.Box):
         return download_success
 
     def __install_game(self, save_location):
+        if self.game.id in self.config.current_downloads:
+            self.config.current_downloads.remove(self.game.id)
         self.download_list = []
         self.game.set_install_dir()
         install_success = self.__install(save_location)

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -191,7 +191,7 @@ class GameTileList(Gtk.Box):
 
     def __set_image(self, save_location):
         set_result = False
-        self.game.set_install_dir()
+        self.game.set_install_dir(self.config.install_dir)
         thumbnail_install_dir = os.path.join(self.game.install_dir, "thumbnail.jpg")
         if os.path.isfile(thumbnail_install_dir):
             GLib.idle_add(self.image.set_from_file, thumbnail_install_dir)
@@ -316,7 +316,7 @@ class GameTileList(Gtk.Box):
         if self.game.id in self.config.current_downloads:
             self.config.current_downloads.remove(self.game.id)
         self.download_list = []
-        self.game.set_install_dir()
+        self.game.set_install_dir(self.config.install_dir)
         install_success = self.__install(save_location)
         if install_success:
             self.__check_for_dlc(self.api.get_info(self.game))
@@ -498,7 +498,7 @@ class GameTileList(Gtk.Box):
         self.progress_bar.set_fraction(0.0)
 
     def reload_state(self):
-        self.game.set_install_dir()
+        self.game.set_install_dir(self.config.install_dir)
         dont_act_in_states = [self.state.QUEUED, self.state.DOWNLOADING, self.state.INSTALLING, self.state.UNINSTALLING,
                               self.state.UPDATING, self.state.DOWNLOADING]
         if self.current_state in dont_act_in_states:
@@ -571,7 +571,7 @@ class GameTileList(Gtk.Box):
         self.menu_button_update.hide()
         self.button_cancel.hide()
 
-        self.game.set_install_dir()
+        self.game.set_install_dir(self.config.install_dir)
 
         if self.progress_bar:
             self.progress_bar.destroy()
@@ -586,7 +586,7 @@ class GameTileList(Gtk.Box):
         self.menu_button.show()
         self.menu_button_uninstall.show()
         self.button_cancel.hide()
-        self.game.set_install_dir()
+        self.game.set_install_dir(self.config.install_dir)
 
         if self.progress_bar:
             self.progress_bar.destroy()

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -8,7 +8,6 @@ import urllib.parse
 from enum import Enum
 from minigalaxy.translation import _
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, ICON_DIR, UI_DIR
-from minigalaxy.config import Config
 from minigalaxy.download import Download, DownloadType
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.launcher import start_game
@@ -44,7 +43,8 @@ class GameTileList(Gtk.Box):
                  ' UPDATING UPDATE_INSTALLABLE')
 
     def __init__(self, parent, game):
-        current_locale = Config.get("locale")
+        self.config = parent.config
+        current_locale = self.config.locale
         default_locale = locale.getdefaultlocale()[0]
         if current_locale == '':
             locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
@@ -75,7 +75,7 @@ class GameTileList(Gtk.Box):
         self.download_dir = os.path.join(CACHE_DIR, "download", self.game.get_install_directory_name())
 
         # Set folder if user wants to keep installer (disabled by default)
-        self.keep_dir = os.path.join(Config.get("install_dir"), "installer")
+        self.keep_dir = os.path.join(self.config.install_dir, "installer")
         self.keep_path = os.path.join(self.keep_dir, self.game.get_install_directory_name())
         if not os.path.exists(CACHE_DIR):
             os.makedirs(CACHE_DIR, mode=0o755)
@@ -95,7 +95,7 @@ class GameTileList(Gtk.Box):
 
     # Downloads if Minigalaxy was closed with this game downloading
     def resume_download_if_expected(self):
-        download_ids = Config.get("current_downloads")
+        download_ids = self.config.current_downloads
         if download_ids:
             for download_id in download_ids:
                 if download_id and download_id == self.game.id and self.current_state == self.state.DOWNLOADABLE:
@@ -104,14 +104,14 @@ class GameTileList(Gtk.Box):
 
     # Do not restart the download if Minigalaxy is restarted
     def prevent_resume_on_startup(self):
-        download_ids = Config.get("current_downloads")
+        download_ids = self.config.current_downloads
         if download_ids:
             new_download_ids = set()
             for download_id in download_ids:
                 if not (download_id and download_id == self.game.id):
                     new_download_ids.add(download_id)
 
-            Config.set("current_downloads", list(new_download_ids))
+            self.config.current_downloads = list(new_download_ids)
 
     def __str__(self):
         return self.game.name
@@ -224,13 +224,13 @@ class GameTileList(Gtk.Box):
             result = True
         except NoDownloadLinkFound as e:
             print(e)
-            current_download_ids = Config.get("current_downloads")
+            current_download_ids = self.config.current_downloads
             if current_download_ids:
                 new_current_download_ids = set()
                 for current_download_id in current_download_ids:
                     if current_download_id != self.game.id:
                         new_current_download_ids.add(current_download_id)
-                Config.set("current_downloads", list(new_current_download_ids))
+                self.config.current_downloads = list(new_current_download_ids)
             GLib.idle_add(self.parent.parent.show_error, _("Download error"),
                           _("There was an error when trying to fetch the download link!\n{}".format(e)))
             download_info = False
@@ -252,13 +252,13 @@ class GameTileList(Gtk.Box):
         GLib.idle_add(self.update_to_state, self.state.QUEUED)
 
         # Need to update the config with DownloadType metadata
-        current_download_ids = Config.get("current_downloads")
+        current_download_ids = self.config.current_downloads
         if current_download_ids is None:
             current_download_ids = set()
         else:
             current_download_ids = set(current_download_ids)
         current_download_ids.add(self.game.id)
-        Config.set("current_downloads", list(current_download_ids))
+        self.config.current_downloads = list(current_download_ids)
         # Start the download for all files
         self.download_list = []
         number_of_files = len(download_info['files'])
@@ -300,7 +300,7 @@ class GameTileList(Gtk.Box):
             download_files.insert(0, download)
         self.download_list.extend(download_files)
 
-        if check_diskspace(total_file_size, Config.get("install_dir")):
+        if check_diskspace(total_file_size, self.config.install_dir):
             DownloadManager.download(download_files)
             ds_msg_title = ""
             ds_msg_text = ""

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -330,7 +330,14 @@ class GameTileList(Gtk.Box):
             failed_state = self.state.DOWNLOADABLE
         success_state = self.state.INSTALLED
         GLib.idle_add(self.update_to_state, processing_state)
-        err_msg = install_game(self.game, save_location, self.config.lang, self.config.install_dir, self.config.keep_installers, self.config.create_applications_file)
+        err_msg = install_game(
+            self.game,
+            save_location,
+            self.config.lang,
+            self.config.install_dir,
+            self.config.keep_installers,
+            self.config.create_applications_file
+        )
         if not err_msg:
             GLib.idle_add(self.update_to_state, success_state)
             install_success = True

--- a/minigalaxy/ui/information.py
+++ b/minigalaxy/ui/information.py
@@ -24,11 +24,12 @@ class Information(Gtk.Dialog):
     button_information_pcgamingwiki = Gtk.Template.Child()
     label_game_description = Gtk.Template.Child()
 
-    def __init__(self, parent, game, api):
+    def __init__(self, parent, game, config: Config, api):
         Gtk.Dialog.__init__(self, title=_("Information about {}").format(game.name), parent=parent.parent.parent,
                             modal=True)
         self.parent = parent
         self.game = game
+        self.config = config
         self.api = api
         self.gamesdb_info = self.api.get_gamesdb_info(self.game)
 
@@ -117,7 +118,7 @@ class Information(Gtk.Dialog):
 
     def load_description(self):
         description = ""
-        lang = Config.get("lang")
+        lang = self.config.lang
         if self.gamesdb_info["summary"]:
             desc_lang = "*"
             for summary_key in self.gamesdb_info["summary"].keys():

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -9,6 +9,7 @@ from minigalaxy.game import Game
 from minigalaxy.ui.gametile import GameTile
 from minigalaxy.ui.gametilelist import GameTileList
 from minigalaxy.ui.gtk import Gtk, GLib
+from minigalaxy.config import Config
 from minigalaxy.translation import _
 
 
@@ -18,7 +19,7 @@ class Library(Gtk.Viewport):
 
     flowbox = Gtk.Template.Child()
 
-    def __init__(self, parent, config: 'Config', api: Api):
+    def __init__(self, parent, config: Config, api: Api):
         Gtk.Viewport.__init__(self)
         self.parent = parent
         self.config = config

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -5,7 +5,6 @@ import threading
 from typing import List
 from minigalaxy.paths import UI_DIR
 from minigalaxy.api import Api
-from minigalaxy.config import Config
 from minigalaxy.game import Game
 from minigalaxy.ui.gametile import GameTile
 from minigalaxy.ui.gametilelist import GameTileList
@@ -19,11 +18,12 @@ class Library(Gtk.Viewport):
 
     flowbox = Gtk.Template.Child()
 
-    def __init__(self, parent, api: Api):
+    def __init__(self, parent, config: 'Config', api: Api):
         Gtk.Viewport.__init__(self)
         self.parent = parent
+        self.config = config
         self.api = api
-        self.show_installed_only = Config.get("installed_filter")
+        self.show_installed_only = self.config.installed_filter
         self.search_string = ""
         self.offline = False
         self.games = []
@@ -74,7 +74,7 @@ class Library(Gtk.Viewport):
             if tile.current_state in [tile.state.DOWNLOADABLE, tile.state.INSTALLABLE]:
                 return False
 
-        if not Config.get("show_hidden_games") and tile.game.get_info("hide_game"):
+        if not self.config.show_hidden_games and tile.game.get_info("hide_game"):
             return False
 
         return True
@@ -99,7 +99,7 @@ class Library(Gtk.Viewport):
                 self.__add_gametile(game)
 
     def __add_gametile(self, game):
-        view = Config.get("view")
+        view = self.config.view
         if view == "grid":
             self.flowbox.add(GameTile(self, game))
         elif view == "list":
@@ -109,13 +109,13 @@ class Library(Gtk.Viewport):
 
     def __get_installed_games(self) -> List[Game]:
         # Make sure the install directory exists
-        library_dir = Config.get("install_dir")
+        library_dir = self.config.install_dir
         if not os.path.exists(library_dir):
             os.makedirs(library_dir, mode=0o755)
         directories = os.listdir(library_dir)
         games = []
         for directory in directories:
-            full_path = os.path.join(Config.get("install_dir"), directory)
+            full_path = os.path.join(self.config.install_dir, directory)
             # Only scan directories
             if not os.path.isdir(full_path):
                 continue

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -6,6 +6,7 @@ from minigalaxy.paths import UI_DIR
 from minigalaxy.constants import SUPPORTED_DOWNLOAD_LANGUAGES, SUPPORTED_LOCALES, VIEWS
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.ui.gtk import Gtk
+from minigalaxy.config import Config
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "preferences.ui"))
@@ -26,7 +27,7 @@ class Preferences(Gtk.Dialog):
     button_cancel = Gtk.Template.Child()
     button_save = Gtk.Template.Child()
 
-    def __init__(self, parent, config: 'Config'):
+    def __init__(self, parent, config: Config):
         Gtk.Dialog.__init__(self, title=_("Preferences"), parent=parent, modal=True)
         self.parent = parent
         self.config = config

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -4,7 +4,6 @@ import shutil
 from minigalaxy.translation import _
 from minigalaxy.paths import UI_DIR
 from minigalaxy.constants import SUPPORTED_DOWNLOAD_LANGUAGES, SUPPORTED_LOCALES, VIEWS
-from minigalaxy.config import Config
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.ui.gtk import Gtk
 
@@ -27,20 +26,21 @@ class Preferences(Gtk.Dialog):
     button_cancel = Gtk.Template.Child()
     button_save = Gtk.Template.Child()
 
-    def __init__(self, parent):
+    def __init__(self, parent, config: 'Config'):
         Gtk.Dialog.__init__(self, title=_("Preferences"), parent=parent, modal=True)
         self.parent = parent
+        self.config = config
 
         self.__set_locale_list()
         self.__set_language_list()
         self.__set_view_list()
-        self.button_file_chooser.set_filename(Config.get("install_dir"))
-        self.switch_keep_installers.set_active(Config.get("keep_installers"))
-        self.switch_stay_logged_in.set_active(Config.get("stay_logged_in"))
-        self.switch_use_dark_theme.set_active(Config.get("use_dark_theme"))
-        self.switch_show_hidden_games.set_active(Config.get("show_hidden_games"))
-        self.switch_show_windows_games.set_active(Config.get("show_windows_games"))
-        self.switch_create_applications_file.set_active(Config.get("create_applications_file"))
+        self.button_file_chooser.set_filename(self.config.install_dir)
+        self.switch_keep_installers.set_active(self.config.keep_installers)
+        self.switch_stay_logged_in.set_active(self.config.stay_logged_in)
+        self.switch_use_dark_theme.set_active(self.config.use_dark_theme)
+        self.switch_show_hidden_games.set_active(self.config.show_hidden_games)
+        self.switch_show_windows_games.set_active(self.config.show_windows_games)
+        self.switch_create_applications_file.set_active(self.config.create_applications_file)
 
         # Set tooltip for keep installers label
         installer_dir = os.path.join(self.button_file_chooser.get_filename(), "installer")
@@ -60,7 +60,7 @@ class Preferences(Gtk.Dialog):
         self.combobox_program_language.add_attribute(self.renderer_text, "text", 1)
 
         # Set the active option
-        current_locale = Config.get("locale")
+        current_locale = self.config.locale
         default_locale = locale.getdefaultlocale()
         if current_locale is None:
             locale.setlocale(locale.LC_ALL, default_locale)
@@ -81,7 +81,7 @@ class Preferences(Gtk.Dialog):
         self.combobox_language.add_attribute(self.renderer_text, "text", 1)
 
         # Set the active option
-        current_lang = Config.get("lang")
+        current_lang = self.config.lang
         for key in range(len(languages)):
             if languages[key][:1][0] == current_lang:
                 self.combobox_language.set_active(key)
@@ -99,7 +99,7 @@ class Preferences(Gtk.Dialog):
         self.combobox_view.add_attribute(self.renderer_text, "text", 1)
 
         # Set the active option
-        current_view = Config.get("view")
+        current_view = self.config.view
         for key in range(len(views)):
             if views[key][:1][0] == current_view:
                 self.combobox_view.set_active(key)
@@ -113,11 +113,11 @@ class Preferences(Gtk.Dialog):
             if locale_choice == '':
                 default_locale = locale.getdefaultlocale()[0]
                 locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
-                Config.set("locale", locale_choice)
+                self.config.locale = locale_choice
             else:
                 try:
                     locale.setlocale(locale.LC_ALL, (locale_choice, 'UTF-8'))
-                    Config.set("locale", locale_choice)
+                    self.config.locale = locale_choice
                 except locale.Error:
                     self.parent.show_error(_("Failed to change program language. Make sure locale is generated on "
                                              "your system."))
@@ -127,28 +127,28 @@ class Preferences(Gtk.Dialog):
         if lang_choice is not None:
             model = self.combobox_language.get_model()
             lang, _ = model[lang_choice][:2]
-            Config.set("lang", lang)
+            self.config.lang = lang
 
     def __save_view_choice(self) -> None:
         view_choice = self.combobox_view.get_active_iter()
         if view_choice is not None:
             model = self.combobox_view.get_model()
             view, _ = model[view_choice][:2]
-            if view != Config.get("view"):
+            if view != self.config.view:
                 self.parent.reset_library()
-            Config.set("view", view)
+            self.config.view = view
 
     def __save_theme_choice(self) -> None:
         settings = Gtk.Settings.get_default()
-        Config.set("use_dark_theme", self.switch_use_dark_theme.get_active())
-        if Config.get("use_dark_theme") is True:
+        self.config.use_dark_theme = self.switch_use_dark_theme.get_active()
+        if self.config.use_dark_theme is True:
             settings.set_property("gtk-application-prefer-dark-theme", True)
         else:
             settings.set_property("gtk-application-prefer-dark-theme", False)
 
     def __save_install_dir_choice(self) -> bool:
         choice = self.button_file_chooser.get_filename()
-        old_dir = Config.get("install_dir")
+        old_dir = self.config.install_dir
         if choice == old_dir:
             return True
 
@@ -172,7 +172,7 @@ class Preferences(Gtk.Dialog):
         except OSError:
             pass
 
-        Config.set("install_dir", choice)
+        self.config.install_dir = choice
         return True
 
     @Gtk.Template.Callback("on_button_save_clicked")
@@ -181,22 +181,22 @@ class Preferences(Gtk.Dialog):
         self.__save_language_choice()
         self.__save_view_choice()
         self.__save_theme_choice()
-        Config.set("keep_installers", self.switch_keep_installers.get_active())
-        Config.set("stay_logged_in", self.switch_stay_logged_in.get_active())
-        Config.set("show_hidden_games", self.switch_show_hidden_games.get_active())
-        Config.set("create_applications_file", self.switch_create_applications_file.get_active())
+        self.config.keep_installers = self.switch_keep_installers.get_active()
+        self.config.stay_logged_in = self.switch_stay_logged_in.get_active()
+        self.config.show_hidden_games = self.switch_show_hidden_games.get_active()
+        self.config.create_applications_file = self.switch_create_applications_file.get_active()
         self.parent.library.filter_library()
 
-        if self.switch_show_windows_games.get_active() != Config.get("show_windows_games"):
+        if self.switch_show_windows_games.get_active() != self.config.show_windows_games:
             if self.switch_show_windows_games.get_active() and not shutil.which("wine"):
                 self.parent.show_error(_("Wine wasn't found. Showing Windows games cannot be enabled."))
-                Config.set("show_windows_games", False)
+                self.config.show_windows_games = False
             else:
-                Config.set("show_windows_games", self.switch_show_windows_games.get_active())
+                self.config.show_windows_games = self.switch_show_windows_games.get_active()
                 self.parent.reset_library()
 
         # Only change the install_dir is it was actually changed
-        if self.button_file_chooser.get_filename() != Config.get("install_dir"):
+        if self.button_file_chooser.get_filename() != self.config.install_dir:
             if self.__save_install_dir_choice():
                 DownloadManager.cancel_all_downloads()
                 self.parent.reset_library()

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -116,7 +116,6 @@ class Properties(Gtk.Dialog):
 
     @Gtk.Template.Callback("on_button_properties_open_files_clicked")
     def on_menu_button_open_files(self, widget):
-        self.game.set_install_dir()
         subprocess.call(["xdg-open", self.game.install_dir])
 
     def button_sensitive(self, game):

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -9,6 +9,7 @@ from minigalaxy.paths import UI_DIR, LOGO_IMAGE_PATH, THUMBNAIL_DIR, COVER_DIR, 
 from minigalaxy.translation import _
 from minigalaxy.ui.library import Library
 from minigalaxy.ui.gtk import Gtk, Gdk, GdkPixbuf
+from minigalaxy.config import Config
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "application.ui"))
@@ -24,7 +25,7 @@ class Window(Gtk.ApplicationWindow):
     menu_logout = Gtk.Template.Child()
     window_library = Gtk.Template.Child()
 
-    def __init__(self, config: 'config', api: 'Api', name="Minigalaxy"):
+    def __init__(self, config: Config, api: 'Api', name="Minigalaxy"):
         current_locale = config.locale
         default_locale = locale.getdefaultlocale()[0]
         if current_locale == '':

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -83,7 +83,7 @@ class Window(Gtk.ApplicationWindow):
 
     @Gtk.Template.Callback("on_menu_preferences_clicked")
     def show_preferences(self, button):
-        preferences_window = Preferences(self)
+        preferences_window = Preferences(self, self.config)
         preferences_window.run()
         preferences_window.destroy()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,9 +6,7 @@ import sys
 import requests
 import time
 m_constants = MagicMock()
-m_config = MagicMock()
 sys.modules['minigalaxy.constants'] = m_constants
-sys.modules['minigalaxy.config'] = m_config
 from minigalaxy.api import Api    # noqa: E402
 from minigalaxy.game import Game  # noqa: E402
 
@@ -27,53 +25,60 @@ GAMESDB_INFO_STELLARIS = {'cover': 'https://images.gog.com/8d822a05746670fb2540e
 
 class TestApi(TestCase):
     def test_get_login_url(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         exp = "https://auth.gog.com/auth?client_id=46899977096215655&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient&response_type=code&layout=client2"
         obs = api.get_login_url()
         self.assertEqual(exp, obs)
 
     def test_get_redirect_url(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         exp = "https://embed.gog.com/on_login_success?origin=client"
         obs = api.get_redirect_url()
         self.assertEqual(exp, obs)
 
     def test1_can_connect(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         m_constants.return_value = True
         exp = True
         obs = api.can_connect()
         self.assertEqual(exp, obs)
 
     def test2_can_connect(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         m_constants.SESSION.get.side_effect = requests.exceptions.ConnectionError(mock.Mock(status="Connection Error"))
         exp = False
         obs = api.can_connect()
         self.assertEqual(exp, obs)
 
     def test1_get_download_info(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api.get_info = MagicMock()
         api.get_info.return_value = API_GET_INFO_TOONSTRUCK
-        m_config.Config.get.return_value = "pl"
+        config.lang = "pl"
         test_game = Game("Test Game")
         exp = {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]}
         obs = api.get_download_info(test_game)
         self.assertEqual(exp, obs)
 
     def test2_get_download_info(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api.get_info = MagicMock()
         api.get_info.return_value = API_GET_INFO_TOONSTRUCK
-        m_config.Config.get.return_value = "fr"
+        config.lang = "fr"
         test_game = Game("Test Game")
         exp = {'id': 'installer_linux_fr', 'name': 'Toonstruck', 'os': 'linux', 'language': 'fr', 'language_full': 'français', 'version': 'gog-2', 'total_size': 1011875840, 'files': [{'id': 'fr3installer0', 'size': 1011875840, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr3installer0'}]}
         obs = api.get_download_info(test_game)
         self.assertEqual(exp, obs)
 
     def test3_get_download_info(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api.get_info = MagicMock()
         api.get_info.return_value = {'downloads': {'installers': [
             {'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]},
@@ -81,23 +86,25 @@ class TestApi(TestCase):
             {'id': 'installer_windows_fr', 'name': 'Toonstruck', 'os': 'windows', 'language': 'fr', 'language_full': 'français', 'version': '1.0', 'total_size': 985661440, 'files': [{'id': 'fr1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer0'}, {'id': 'fr1installer1', 'size': 984612864, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer1'}]},
             {'id': 'installer_mac_fr', 'name': 'Toonstruck', 'os': 'mac', 'language': 'fr', 'language_full': 'français', 'version': 'gog-3', 'total_size': 1023410176, 'files': [{'id': 'fr2installer0', 'size': 1023410176, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr2installer0'}]}
         ]}}
-        m_config.Config.get.return_value = "en"
+        config.lang = "en"
         test_game = Game("Test Game")
         exp = {'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]}
         obs = api.get_download_info(test_game)
         self.assertEqual(exp, obs)
 
     def test4_get_download_info(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         dlc_test_installer = API_GET_INFO_TOONSTRUCK["downloads"]["installers"]
-        m_config.Config.get.return_value = "en"
+        config.lang = "en"
         test_game = Game("Test Game")
         exp = {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]}
         obs = api.get_download_info(test_game, dlc_installers=dlc_test_installer)
         self.assertEqual(exp, obs)
 
     def test1_get_library(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api.active_token = True
         response_dict = {'totalPages': 1, 'products': [{'id': 1097893768, 'title': 'Neverwinter Nights: Enhanced Edition', 'image': '//images-2.gog-statics.com/8706f7fb87a4a41bc34254f3b49f59f96cf13d067b2c8bbfd8d41c327392052a', 'url': '/game/neverwinter_nights_enhanced_edition_pack', 'worksOn': {'Windows': True, 'Mac': True, 'Linux': True}}]}
         api.active_token_expiration_time = time.time() + 10.0
@@ -111,7 +118,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test2_get_library(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api.active_token = False
         api.active_token_expiration_time = time.time() + 10.0
         response_mock = MagicMock()
@@ -122,14 +130,16 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test1_get_version(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         test_game = Game("Test Game", platform="linux")
         exp = "gog-2"
         obs = api.get_version(test_game, gameinfo=API_GET_INFO_TOONSTRUCK)
         self.assertEqual(exp, obs)
 
     def test2_get_version(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         test_game = Game("Test Game", platform="linux")
         dlc_name = "Test DLC"
         game_info = API_GET_INFO_TOONSTRUCK
@@ -139,7 +149,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test_get_download_file__info_md5(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = MagicMock()
@@ -155,7 +166,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test_get_download_file_info_md5_returns_empty_string_on_empty_response(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = MagicMock()
@@ -167,7 +179,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test_get_download_file_info_md5_returns_empty_string_on_response_error(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = MagicMock()
@@ -178,7 +191,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test_get_download_file_info_md5_returns_empty_string_on_missing_md5(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = MagicMock()
@@ -195,7 +209,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = MagicMock()
@@ -211,7 +226,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size_returns_zero_on_empty_response(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = MagicMock()
@@ -223,7 +239,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size_returns_zero_on_response_error(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = MagicMock()
@@ -234,7 +251,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size_returns_zero_on_request_exception(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = requests.exceptions.RequestException("test")
@@ -244,7 +262,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size_returns_zero_on_request_timeout_exception(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = requests.exceptions.ReadTimeout("test")
@@ -254,7 +273,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size_returns_zero_on_missing_total_size(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"checksum": "url"}
         m_constants.SESSION.get.side_effect = MagicMock()
@@ -271,7 +291,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test1_get_gamesdb_info(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request_gamesdb = MagicMock()
         api._Api__request_gamesdb.side_effect = [{}]
         test_game = Game("Test Game")
@@ -280,7 +301,8 @@ class TestApi(TestCase):
         self.assertEqual(exp, obs)
 
     def test2_get_gamesdb_info(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request_gamesdb = MagicMock()
         api._Api__request_gamesdb.side_effect = API_GET_INFO_STELLARIS
         test_game = Game("Stellaris")
@@ -292,7 +314,8 @@ class TestApi(TestCase):
         api_info = copy.deepcopy(API_GET_INFO_STELLARIS)
         api_info[0]["game"]["genres"] = []
         api_info[0]["game"]["genres_ids"] = []
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request_gamesdb = MagicMock()
         api._Api__request_gamesdb.side_effect = api_info
 
@@ -304,10 +327,11 @@ class TestApi(TestCase):
 
     def test_get_user_info_from_api(self):
         username = "test"
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"username": username}
-        m_config.Config.get.return_value = ""
+        config.username = ""
         m_constants.SESSION.get.side_effect = MagicMock()
         m_constants.SESSION.get().status_code = http.HTTPStatus.OK
 
@@ -316,19 +340,21 @@ class TestApi(TestCase):
 
     def test_get_user_info_from_config(self):
         username = "test"
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {"username": "wrong"}
-        m_config.Config.get.return_value = username
+        config.username = username
 
         obs = api.get_user_info()
         self.assertEqual(username, obs)
 
     def test_get_user_info_return_empty_string_when_nothing_is_returned(self):
-        api = Api()
+        config = MagicMock()
+        api = Api(config)
         api._Api__request = MagicMock()
         api._Api__request.return_value = {}
-        m_config.Config.get.return_value = ""
+        config.username = ""
 
         exp = ""
         obs = api.get_user_info()
@@ -336,5 +362,4 @@ class TestApi(TestCase):
 
 
 del sys.modules['minigalaxy.constants']
-del sys.modules['minigalaxy.config']
 del sys.modules["minigalaxy.game"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ class TestConfig(TestCase):
                 "view": "view",
                 "install_dir": "install_dir",
                 "username": "username",
+                "refresh_token": "refresh_token",
                 "keep_installers": true,
                 "stay_logged_in": false,
                 "use_dark_theme": true,
@@ -25,7 +26,8 @@ class TestConfig(TestCase):
                 "show_windows_games": true,
                 "keep_window_maximized": true,
                 "installed_filter": true,
-                "create_applications_file": true
+                "create_applications_file": true,
+                "current_downloads": [1, 2, 3]
             }
             """
         with patch("builtins.open", mock_open(read_data=config_data)):
@@ -36,6 +38,7 @@ class TestConfig(TestCase):
         self.assertEqual("lang", config.lang)
         self.assertEqual("view", config.view)
         self.assertEqual("install_dir", config.install_dir)
+        self.assertEqual("refresh_token", config.refresh_token)
         self.assertEqual(True, config.keep_installers)
         self.assertEqual(False, config.stay_logged_in)
         self.assertEqual(True, config.use_dark_theme)
@@ -44,6 +47,7 @@ class TestConfig(TestCase):
         self.assertEqual(True, config.keep_window_maximized)
         self.assertEqual(True, config.installed_filter)
         self.assertEqual(True, config.create_applications_file)
+        self.assertEqual([1, 2, 3], config.current_downloads)
 
     @patch('os.path.isfile')
     def test_defaults_if_file_does_not_exist(self, mock_isfile: MagicMock):
@@ -56,6 +60,7 @@ class TestConfig(TestCase):
         self.assertEqual("grid", config.view)
         self.assertEqual("", config.username)
         self.assertEqual(DEFAULT_INSTALL_DIR, config.install_dir)
+        self.assertEqual("", config.refresh_token)
         self.assertEqual("", config.username)
         self.assertEqual(False, config.keep_installers)
         self.assertEqual(True, config.stay_logged_in)
@@ -65,6 +70,7 @@ class TestConfig(TestCase):
         self.assertEqual(False, config.keep_window_maximized)
         self.assertEqual(False, config.installed_filter)
         self.assertEqual(False, config.create_applications_file)
+        self.assertEqual([], config.current_downloads)
 
     @patch('os.path.isfile')
     def test_get(self, mock_isfile: MagicMock):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,6 +72,38 @@ class TestConfig(TestCase):
         self.assertEqual(False, config.create_applications_file)
         self.assertEqual([], config.current_downloads)
 
+    @patch("os.remove")
+    @patch("os.path.isfile")
+    def test_invalid_config_file_is_deleted(self, mock_isfile: MagicMock, mock_remove: MagicMock):
+        mock_isfile.return_value = True
+        filename = "/this/is/a/test"
+        config_data = \
+            """
+            {
+                "locale": "locale",
+            """
+        with patch("builtins.open", mock_open(read_data=config_data)):
+            config = Config(filename)
+
+        mock_remove.assert_called_once_with(filename)
+
+        self.assertEqual("", config.locale)
+        self.assertEqual("en", config.lang)
+        self.assertEqual("grid", config.view)
+        self.assertEqual("", config.username)
+        self.assertEqual(DEFAULT_INSTALL_DIR, config.install_dir)
+        self.assertEqual("", config.refresh_token)
+        self.assertEqual("", config.username)
+        self.assertEqual(False, config.keep_installers)
+        self.assertEqual(True, config.stay_logged_in)
+        self.assertEqual(False, config.use_dark_theme)
+        self.assertEqual(False, config.show_hidden_games)
+        self.assertEqual(False, config.show_windows_games)
+        self.assertEqual(False, config.keep_window_maximized)
+        self.assertEqual(False, config.installed_filter)
+        self.assertEqual(False, config.create_applications_file)
+        self.assertEqual([], config.current_downloads)
+
     @patch('os.path.isfile')
     def test_get(self, mock_isfile: MagicMock):
         mock_isfile.return_value = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,7 +185,7 @@ class TestConfig(TestCase):
             """
         with patch("builtins.open", mock_open(read_data=config_data)):
             config = Config()
-        lang = config.get("lang")
+        lang = config._Config__get("lang")
         self.assertEqual("lang", lang)
 
     @patch("os.rename")
@@ -213,7 +213,7 @@ class TestConfig(TestCase):
             """
         with patch("builtins.open", mock_open(read_data=config_data)):
             config = Config("/path/config.json")
-            config.set("lang", "lang2")
+            config._Config__set("lang", "lang2")
 
         self.assertEqual("lang2", config.lang)
         mock_rename.assert_called_once_with("/path/config.json.tmp", "/path/config.json")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-import sys
 from unittest import TestCase
 from unittest.mock import MagicMock, patch, mock_open
 
@@ -57,6 +56,7 @@ class TestConfig(TestCase):
         self.assertEqual("grid", config.view)
         self.assertEqual("", config.username)
         self.assertEqual(DEFAULT_INSTALL_DIR, config.install_dir)
+        self.assertEqual("", config.username)
         self.assertEqual(False, config.keep_installers)
         self.assertEqual(True, config.stay_logged_in)
         self.assertEqual(False, config.use_dark_theme)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,71 +1,111 @@
 import sys
-from unittest import TestCase, mock
+from unittest import TestCase
 from unittest.mock import MagicMock, patch, mock_open
-from minigalaxy.config import DEFAULT_CONFIGURATION
-JSON_DEFAULT_CONFIGURATION = str(DEFAULT_CONFIGURATION).replace("'", "\"").replace("False", "false").replace("True", "true")
 
-m_thread = MagicMock()
-sys.modules['threading'] = m_thread
+from minigalaxy.config import Config
+from minigalaxy.paths import DEFAULT_INSTALL_DIR
 
 
 class TestConfig(TestCase):
-    @mock.patch('os.path.exists')
-    def test_get(self, mock_isfile):
+
+    @patch('os.path.isfile')
+    def test_read_config_file(self, mock_isfile: MagicMock):
         mock_isfile.return_value = True
-        config = JSON_DEFAULT_CONFIGURATION
-        with patch("builtins.open", mock_open(read_data=config)):
-            from minigalaxy.config import Config
-            Config.first_run = True
-            Config._Config__config = DEFAULT_CONFIGURATION
-            lang = Config.get("lang")
-        exp = "en"
-        obs = lang
-        self.assertEqual(exp, obs)
+        config_data = \
+            """
+            {
+                "locale": "locale",
+                "lang": "lang",
+                "view": "view",
+                "install_dir": "install_dir",
+                "username": "username",
+                "keep_installers": true,
+                "stay_logged_in": false,
+                "use_dark_theme": true,
+                "show_hidden_games": true,
+                "show_windows_games": true,
+                "keep_window_maximized": true,
+                "installed_filter": true,
+                "create_applications_file": true
+            }
+            """
+        with patch("builtins.open", mock_open(read_data=config_data)):
+            config = Config()
 
-    @mock.patch('os.path.isdir')
-    @mock.patch('os.path.exists')
-    def test_create_config(self, mock_exists, mock_isdir):
-        mock_exists.side_effect = [False, True]
-        mock_isdir.return_value = True
-        with patch("builtins.open", mock_open()) as mock_config:
-            from minigalaxy.config import Config
-            Config.first_run = False
-            Config.get("")
-        mock_c = mock_config.mock_calls
-        write_string = ""
-        for kall in mock_c:
-            name, args, kwargs = kall
-            if name == "().write":
-                write_string = "{}{}".format(write_string, args[0])
-        exp = JSON_DEFAULT_CONFIGURATION
-        obs = write_string
-        self.assertEqual(exp, obs)
+        self.assertIsNotNone(config)
+        self.assertEqual("locale", config.locale)
+        self.assertEqual("lang", config.lang)
+        self.assertEqual("view", config.view)
+        self.assertEqual("install_dir", config.install_dir)
+        self.assertEqual(True, config.keep_installers)
+        self.assertEqual(False, config.stay_logged_in)
+        self.assertEqual(True, config.use_dark_theme)
+        self.assertEqual(True, config.show_hidden_games)
+        self.assertEqual(True, config.show_windows_games)
+        self.assertEqual(True, config.keep_window_maximized)
+        self.assertEqual(True, config.installed_filter)
+        self.assertEqual(True, config.create_applications_file)
 
-    @mock.patch('os.path.exists')
-    def test_set(self, mock_isfile):
+    @patch('os.path.isfile')
+    def test_defaults_if_file_does_not_exist(self, mock_isfile: MagicMock):
+        mock_isfile.return_value = False
+        config = Config()
+        self.assertEqual({}, config._Config__config)
+
+        self.assertEqual("", config.locale)
+        self.assertEqual("en", config.lang)
+        self.assertEqual("grid", config.view)
+        self.assertEqual("", config.username)
+        self.assertEqual(DEFAULT_INSTALL_DIR, config.install_dir)
+        self.assertEqual(False, config.keep_installers)
+        self.assertEqual(True, config.stay_logged_in)
+        self.assertEqual(False, config.use_dark_theme)
+        self.assertEqual(False, config.show_hidden_games)
+        self.assertEqual(False, config.show_windows_games)
+        self.assertEqual(False, config.keep_window_maximized)
+        self.assertEqual(False, config.installed_filter)
+        self.assertEqual(False, config.create_applications_file)
+
+    @patch('os.path.isfile')
+    def test_get(self, mock_isfile: MagicMock):
         mock_isfile.return_value = True
-        config = JSON_DEFAULT_CONFIGURATION
-        with patch("builtins.open", mock_open(read_data=config)):
-            from minigalaxy.config import Config
-            Config.first_run = True
-            Config.set("lang", "pl")
-            lang = Config.get("lang")
-        exp = "pl"
-        obs = lang
-        self.assertEqual(exp, obs)
+        config_data = \
+            """
+            {
+                "lang": "lang"
+            }
+            """
+        with patch("builtins.open", mock_open(read_data=config_data)):
+            config = Config()
+        lang = config.get("lang")
+        self.assertEqual("lang", lang)
 
-    @mock.patch('os.path.exists')
-    def test_unset(self, mock_isfile):
+    @patch("os.rename")
+    @patch('os.path.isfile')
+    @patch('os.makedirs')
+    def test_create_config(self, mock_makedirs: MagicMock, mock_isfile: MagicMock, mock_rename: MagicMock):
+        mock_isfile.return_value = False
+        config = Config("/path/config.json")
+        with patch("builtins.open", mock_open()):
+            config.lang = "lang"
+        self.assertEqual("lang", config.lang)
+        mock_makedirs.assert_called_once_with("/path", mode=0o700, exist_ok=True)
+        mock_rename.assert_called_once_with("/path/config.json.tmp", "/path/config.json")
+
+    @patch("os.rename")
+    @patch('os.path.isfile')
+    @patch('os.makedirs')
+    def test_set(self, mock_makedirs: MagicMock, mock_isfile: MagicMock, mock_rename: MagicMock):
         mock_isfile.return_value = True
-        config = JSON_DEFAULT_CONFIGURATION
-        with patch("builtins.open", mock_open(read_data=config)):
-            from minigalaxy.config import Config
-            Config.first_run = True
-            Config.unset("lang")
-            lang = Config.get("lang")
-        exp = None
-        obs = lang
-        self.assertEqual(exp, obs)
+        config_data = \
+            """
+            {
+                "lang": "lang"
+            }
+            """
+        with patch("builtins.open", mock_open(read_data=config_data)):
+            config = Config("/path/config.json")
+            config.set("lang", "lang2")
 
-
-del sys.modules['threading']
+        self.assertEqual("lang2", config.lang)
+        mock_rename.assert_called_once_with("/path/config.json.tmp", "/path/config.json")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,6 +38,7 @@ class TestConfig(TestCase):
         self.assertEqual("lang", config.lang)
         self.assertEqual("view", config.view)
         self.assertEqual("install_dir", config.install_dir)
+        self.assertEqual("username", config.username)
         self.assertEqual("refresh_token", config.refresh_token)
         self.assertEqual(True, config.keep_installers)
         self.assertEqual(False, config.stay_logged_in)
@@ -61,7 +62,6 @@ class TestConfig(TestCase):
         self.assertEqual("", config.username)
         self.assertEqual(DEFAULT_INSTALL_DIR, config.install_dir)
         self.assertEqual("", config.refresh_token)
-        self.assertEqual("", config.username)
         self.assertEqual(False, config.keep_installers)
         self.assertEqual(True, config.stay_logged_in)
         self.assertEqual(False, config.use_dark_theme)
@@ -93,7 +93,6 @@ class TestConfig(TestCase):
         self.assertEqual("", config.username)
         self.assertEqual(DEFAULT_INSTALL_DIR, config.install_dir)
         self.assertEqual("", config.refresh_token)
-        self.assertEqual("", config.username)
         self.assertEqual(False, config.keep_installers)
         self.assertEqual(True, config.stay_logged_in)
         self.assertEqual(False, config.use_dark_theme)
@@ -103,6 +102,77 @@ class TestConfig(TestCase):
         self.assertEqual(False, config.installed_filter)
         self.assertEqual(False, config.create_applications_file)
         self.assertEqual([], config.current_downloads)
+
+    @patch("os.path.isfile")
+    def test_config_property_setters(self, mock_isfile: MagicMock):
+        mock_isfile.return_value = True
+        filename = "/this/is/a/test"
+        config_data = "{}"
+        with patch("builtins.open", mock_open(read_data=config_data)):
+            config = Config(filename)
+            config._Config__write = MagicMock()
+
+        self.assertEqual("", config.locale)
+        config.locale = "en_US.UTF-8"
+        self.assertEqual("en_US.UTF-8", config.locale)
+
+        config._Config__write.assert_called_once()
+
+        self.assertEqual("en", config.lang)
+        config.lang = "pl"
+        self.assertEqual("pl", config.lang)
+
+        self.assertEqual("grid", config.view)
+        config.view = "list"
+        self.assertEqual("list", config.view)
+
+        self.assertEqual("", config.username)
+        config.username = "username"
+        self.assertEqual("username", config.username)
+
+        self.assertEqual(DEFAULT_INSTALL_DIR, config.install_dir)
+        config.install_dir = "/install/dir"
+        self.assertEqual("/install/dir", config.install_dir)
+
+        self.assertEqual("", config.refresh_token)
+        config.refresh_token = "refresh_token"
+        self.assertEqual("refresh_token", config.refresh_token)
+
+        self.assertEqual(False, config.keep_installers)
+        config.keep_installers = True
+        self.assertEqual(True, config.keep_installers)
+
+        self.assertEqual(True, config.stay_logged_in)
+        config.stay_logged_in = False
+        self.assertEqual(False, config.stay_logged_in)
+
+        self.assertEqual(False, config.use_dark_theme)
+        config.use_dark_theme = True
+        self.assertEqual(True, config.use_dark_theme)
+
+        self.assertEqual(False, config.show_hidden_games)
+        config.show_hidden_games = True
+        self.assertEqual(True, config.show_hidden_games)
+
+        self.assertEqual(False, config.show_windows_games)
+        config.show_windows_games = True
+        self.assertEqual(True, config.show_windows_games)
+
+        self.assertEqual(False, config.keep_window_maximized)
+        config.keep_window_maximized = True
+        self.assertEqual(True, config.keep_window_maximized)
+
+        self.assertEqual(False, config.installed_filter)
+        config.installed_filter = True
+        self.assertEqual(True, config.installed_filter)
+
+        self.assertEqual(False, config.create_applications_file)
+        config.create_applications_file = True
+        self.assertEqual(True, config.create_applications_file)
+
+        self.assertEqual([], config.current_downloads)
+        config.current_downloads = [1, 2, 3]
+        self.assertEqual([1, 2, 3], config.current_downloads)
 
     @patch('os.path.isfile')
     def test_get(self, mock_isfile: MagicMock):

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -270,7 +270,6 @@ en-US
     def test_set_install_dir(self):
         install_directory = "/home/user/GOG Games"
         install_game_name = "Neverwinter Nights"
-        config = MagicMock()
         game = Game(install_game_name)
         game.set_install_dir(install_directory)
         exp = os.path.join(install_directory, install_game_name)

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -270,8 +270,9 @@ en-US
     def test_set_install_dir(self):
         install_directory = "/home/user/GOG Games"
         install_game_name = "Neverwinter Nights"
-        m_config.Config.get.return_value = install_directory
-        game = Game(install_game_name)
+        config = MagicMock()
+        config.install_dir = install_directory
+        game = Game(install_game_name, config=config)
         game.set_install_dir()
         exp = os.path.join(install_directory, install_game_name)
         obs = game.install_dir

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -271,9 +271,8 @@ en-US
         install_directory = "/home/user/GOG Games"
         install_game_name = "Neverwinter Nights"
         config = MagicMock()
-        config.install_dir = install_directory
-        game = Game(install_game_name, config=config)
-        game.set_install_dir()
+        game = Game(install_game_name)
+        game.set_install_dir(install_directory)
         exp = os.path.join(install_directory, install_game_name)
         obs = game.install_dir
         self.assertEqual(exp, obs)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -57,7 +57,7 @@ class Test(TestCase):
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1207658695"
         exp = ""
-        obs = installer.extract_installer(game, installer_path, temp_dir)
+        obs = installer.extract_installer(game, installer_path, temp_dir, "en")
         self.assertEqual(exp, obs)
 
     @mock.patch('os.path.exists')
@@ -72,7 +72,7 @@ class Test(TestCase):
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1207658695"
         exp = "The installation of /home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh failed. Please try again."
-        obs = installer.extract_installer(game, installer_path, temp_dir)
+        obs = installer.extract_installer(game, installer_path, temp_dir, "en")
         self.assertEqual(exp, obs)
 
     @mock.patch('subprocess.Popen')
@@ -85,7 +85,7 @@ class Test(TestCase):
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
-        obs = installer.extract_installer(game, installer_path, temp_dir)
+        obs = installer.extract_installer(game, installer_path, temp_dir, "en")
         self.assertEqual(exp, obs)
 
     @mock.patch('os.path.exists')
@@ -112,7 +112,7 @@ class Test(TestCase):
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
-        obs = installer.extract_windows(game, installer_path, temp_dir)
+        obs = installer.extract_windows(game, installer_path, temp_dir, "en")
         self.assertEqual(exp, obs)
 
     @mock.patch('subprocess.Popen')
@@ -124,7 +124,7 @@ class Test(TestCase):
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
-        obs = installer.extract_by_innoextract(installer_path, temp_dir)
+        obs = installer.extract_by_innoextract(installer_path, temp_dir, "en")
         self.assertEqual(exp, obs)
 
     @mock.patch('shutil.which')
@@ -133,7 +133,7 @@ class Test(TestCase):
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = "Innoextract not installed."
-        obs = installer.extract_by_innoextract(installer_path, temp_dir)
+        obs = installer.extract_by_innoextract(installer_path, temp_dir, "en")
         self.assertEqual(exp, obs)
 
     @mock.patch('subprocess.Popen')
@@ -145,7 +145,7 @@ class Test(TestCase):
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = "Innoextract extraction failed."
-        obs = installer.extract_by_innoextract(installer_path, temp_dir)
+        obs = installer.extract_by_innoextract(installer_path, temp_dir, "en")
         self.assertEqual(exp, obs)
 
     @mock.patch('subprocess.Popen')
@@ -329,48 +329,44 @@ class Test(TestCase):
         """
         game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
         installer_path = "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
-        obs = installer.remove_installer(game1, installer_path)
+        obs = installer.remove_installer(game1, installer_path, "/this/is/a/fake/directory", False)
         exp = "No installer directory is present: /home/i/.cache/minigalaxy/download/Beneath a Steel Sky"
         self.assertEqual(obs, exp)
 
     @mock.patch('os.path.isdir')
     @mock.patch('minigalaxy.installer.compare_directories')
-    @mock.patch('minigalaxy.config.Config.get')
     @mock.patch('shutil.rmtree')
     @mock.patch('os.remove')
     @mock.patch('os.listdir')
-    def test_remove_installer_no_keep(self, mock_list_dir, mock_os_remove, mock_shutil_rmtree, mock_config, mock_compare_directories, mock_os_path_isdir):
+    def test_remove_installer_no_keep(self, mock_list_dir, mock_os_remove, mock_shutil_rmtree, mock_compare_directories, mock_os_path_isdir):
         """
         Disabled keep_installer
         """
         mock_os_path_isdir.return_value = True
         mock_compare_directories.return_value = False
-        mock_config.return_value = False
         mock_list_dir.return_value = ["beneath_a_steel_sky_en_gog_2_20150.sh"]
 
         game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
         installer_path = "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
-        obs = installer.remove_installer(game1, installer_path)
+        obs = installer.remove_installer(game1, installer_path, "/some/directory/test", False)
         assert mock_os_remove.called
         assert not mock_shutil_rmtree.called
         self.assertEqual(obs, "")
 
     @mock.patch('os.remove')
     @mock.patch('shutil.rmtree')
-    @mock.patch('minigalaxy.config.Config.get')
     @mock.patch('minigalaxy.installer.compare_directories')
     @mock.patch('os.path.isdir')
-    def test_remove_installer_same_content(self, mock_os_path_isdir, mock_compare_directories, mock_config, mock_shutil_rmtree, mock_os_remove):
+    def test_remove_installer_same_content(self, mock_os_path_isdir, mock_compare_directories, mock_shutil_rmtree, mock_os_remove):
         """
         Same content of installer and keep dir
         """
         mock_os_path_isdir.return_value = True
         mock_compare_directories.return_value = True
-        mock_config.side_effect = [True, "/home/i/GOG Games/installer"]
 
         game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
         installer_path = "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
-        obs = installer.remove_installer(game1, installer_path)
+        obs = installer.remove_installer(game1, installer_path, "/home/i/GOG Games/installer", True)
         assert not mock_shutil_rmtree.called
         assert not mock_os_remove.called
         self.assertEqual(obs, "")
@@ -378,42 +374,40 @@ class Test(TestCase):
     @mock.patch('os.remove')
     @mock.patch('shutil.move')
     @mock.patch('shutil.rmtree')
-    @mock.patch('minigalaxy.config.Config.get')
     @mock.patch('minigalaxy.installer.compare_directories')
     @mock.patch('os.path.isdir')
-    def test_remove_installer_keep(self, mock_os_path_isdir, mock_compare_directories, mock_config, mock_shutil_rmtree, mock_shutil_move, mock_os_remove):
+    def test_remove_installer_keep(self, mock_os_path_isdir, mock_compare_directories, mock_shutil_rmtree, mock_shutil_move, mock_os_remove):
         """
         Keep installer dir
         """
         mock_os_path_isdir.return_value = True
         mock_compare_directories.return_value = False
-        mock_config.side_effect = [True, "/home/i/GOG Games/installer"]
 
         game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
         installer_path = "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
-        obs = installer.remove_installer(game1, installer_path)
+        obs = installer.remove_installer(game1, installer_path, "/home/i/GOG Games/installer", True)
         assert mock_shutil_rmtree.called
         assert mock_shutil_move.called
         assert not mock_os_remove.called
         self.assertEqual(obs, "")
 
+    @patch("os.listdir")
     @mock.patch('os.remove')
     @mock.patch('shutil.move')
     @mock.patch('shutil.rmtree')
-    @mock.patch('minigalaxy.config.Config.get')
     @mock.patch('minigalaxy.installer.compare_directories')
     @mock.patch('os.path.isdir')
-    def test_remove_installer_from_keep(self, mock_os_path_isdir, mock_compare_directories, mock_config, mock_shutil_rmtree, mock_shutil_move, mock_os_remove):
+    def test_remove_installer_from_keep(self, mock_os_path_isdir, mock_compare_directories, mock_shutil_rmtree, mock_shutil_move, mock_os_remove, mock_os_listdir):
         """
         Called from keep dir
         """
         mock_os_path_isdir.return_value = True
         mock_compare_directories.return_value = False
-        mock_config.side_effect = [True, "/home/i/GOG Games"]
+        mock_os_listdir.return_value = []
 
         game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath A Steel Sky", platform="linux")
         installer_path = "/home/i/GOG Games/installer/Beneath A Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
-        obs = installer.remove_installer(game1, installer_path)
+        obs = installer.remove_installer(game1, installer_path, "/home/i/GOG Games/installer", False)
         assert not mock_shutil_rmtree.called
         assert not mock_shutil_move.called
         assert not mock_os_remove.called

--- a/tests/test_ui_library.py
+++ b/tests/test_ui_library.py
@@ -17,8 +17,8 @@ class UnitTestGtkTemplate:
 
     def from_file(self, lib_file):
         def passthrough(func):
-            def passthrough2(parent, api):
-                return func(parent, api)
+            def passthrough2(*args, **kwargs):
+                return func(*args, **kwargs)
             return passthrough2
         return passthrough
 
@@ -77,9 +77,10 @@ class TestLibrary(TestCase):
         for game in API_GAMES:
             api_games.append(Game(name=game, game_id=int(API_GAMES[game]),))
         err_msg = ""
+        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), api_mock)
+        test_library = Library(MagicMock(), config, api_mock)
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = len(API_GAMES)
@@ -94,9 +95,10 @@ class TestLibrary(TestCase):
         for game in API_GAMES:
             api_games.append(Game(name=game, game_id=int(API_GAMES[game]),))
         err_msg = ""
+        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), api_mock)
+        test_library = Library(MagicMock(), config, api_mock)
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = True
@@ -114,9 +116,10 @@ class TestLibrary(TestCase):
         api_gmae_with_id = Game(name="Game without ID", game_id=1234567890)
         api_games.append(api_gmae_with_id)
         err_msg = ""
+        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), api_mock)
+        test_library = Library(MagicMock(), config, api_mock)
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = True
@@ -136,9 +139,10 @@ class TestLibrary(TestCase):
             api_games.append(Game(name=game, game_id=int(API_GAMES[game]), url="http://test_url{}".format(str(url_nr))))
             url_nr += 1
         err_msg = ""
+        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), api_mock)
+        test_library = Library(MagicMock(), config, api_mock)
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = "http://test_url1"
@@ -153,9 +157,10 @@ class TestLibrary(TestCase):
         for game in API_GAMES:
             api_games.append(Game(name=game, game_id=int(API_GAMES[game])))
         err_msg = ""
+        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), api_mock)
+        test_library = Library(MagicMock(), config, api_mock)
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = "Neverwinter Nights: Enhanced Edition"
@@ -166,9 +171,10 @@ class TestLibrary(TestCase):
         self_games = [Game(name="Torchlight 2", game_id=0, install_dir="/home/user/GoG Games/Torchlight II")]
         api_games = [Game(name="Torchlight II", game_id=1958228073)]
         err_msg = ""
+        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), api_mock)
+        test_library = Library(MagicMock(), config, api_mock)
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = 1

--- a/tests/test_ui_window.py
+++ b/tests/test_ui_window.py
@@ -18,8 +18,8 @@ class UnitTestGtkTemplate:
 
     def from_file(self, lib_file):
         def passthrough(func):
-            def passthrough2():
-                return func()
+            def passthrough2(*args, **kwargs):
+                return func(*args, **kwargs)
             return passthrough2
         return passthrough
 
@@ -61,26 +61,38 @@ from minigalaxy.ui.window import Window  # noqa: E402
 class TestWindow(TestCase):
     def test1_init(self):
         with patch('minigalaxy.ui.window.Api.can_connect', return_value=False):
-            test_window = Window()
+            config = MagicMock()
+            config.locale = "en_US.UTF-8"
+            config.keep_window_maximized = False
+            api = MagicMock()
+            api.can_connect.return_value = False
+            test_window = Window(api=api, config=config)
             exp = True
             obs = test_window.offline
             self.assertEqual(exp, obs)
 
     def test2_init(self):
-        with patch('minigalaxy.ui.window.Api.can_connect', return_value=True):
-            with patch('minigalaxy.ui.window.Api.authenticate', return_value=True):
-                test_window = Window()
-                exp = False
-                obs = test_window.offline
-                self.assertEqual(exp, obs)
-                self.assertEqual(test_window.api.authenticate.called, True)
+        config = MagicMock()
+        config.locale = "en_US.UTF-8"
+        config.keep_window_maximized = False
+        api = MagicMock()
+        api.authenticate.return_value = True
+        test_window = Window(api=api, config=config)
+        exp = False
+        obs = test_window.offline
+        self.assertEqual(exp, obs)
+        api.authenticate.assert_called_once()
 
     def test3_init(self):
-        with patch('minigalaxy.ui.window.Api.authenticate', side_effect=JSONDecodeError(msg='mock', doc='mock', pos=0)):
-            test_window = Window()
-            exp = True
-            obs = test_window.offline
-            self.assertEqual(exp, obs)
+        config = MagicMock()
+        config.locale = "en_US.UTF-8"
+        config.keep_window_maximized = False
+        api = MagicMock()
+        api.authenticate.side_effect = JSONDecodeError(msg='mock', doc='mock', pos=0)
+        test_window = Window(api=api, config=config)
+        exp = True
+        obs = test_window.offline
+        self.assertEqual(exp, obs)
 
 
 del sys.modules['gi']


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

<!-- Describe what was changed -->

As part of a major refactor I'm trying to do for version 2.0.0 I'm getting rid of global object and will instead be using constructors to pass along these shared objects along. This will make testing much easier and it will clean up the code. Config is one of these global objects. Since I'm addressing this anyway, I decided to also refactor and simplify the Config class in general.

This should simplify the following: 
- It should be easier to use the config class. You can just use `config.variable = "value"` to save and `config.variable` to retrieve. What's saved will be persistent.
- There is no longer a thread which updates the config on disk. This was not safeguarding the file well and it had very little performance benefit, since the config file is quite small. We now use a temporary file and then copy instead, which should be safe.
- Testing is way easier. It's no longer required to prevent the import and it's super easy to mock in tests.

It is very important that only 1 Config object is used, though, otherwise they will go out of sync. The config is only read once when a config object is initialized, after that it's only written to. 

## Work remaining

This PR was not quite done yet at the moment of submitting. The following still need to be fixed:
- [x] Game objects all have their own Config object. This has to be addressed before merging.
- [x] A lot of tests still expect the old config. These need to be updated.
- [x] I've added the refresh_token and current_downloads properties to Config last and they still need to be included in `test_config.py`.
- [x] Make the Get and Set methods in the Config class private.
- [x] Make installer.py work like expected again

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
