### PR TITLE
debian: add python3-requests to build deps for help2man

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Build-Depends: debhelper-compat (= 12),
                dh-sequence-python3,
                python3-all,
                python3-setuptools,
+               python3-requests,
                help2man,
                gettext,
 Standards-Version: 4.5.0


### PR DESCRIPTION
This fixes a build error with Minigalaxy: since bin/minigalaxy now imports requests, this package is now a build dependency as help2man needs to run bin/minigalaxy for the man page.