### PR TITLE
Hide A Plague Tale Digital Goodies Pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 **1.2.3**
 - Fix game information not showing in list view (thanks to TotalCaesar659)
+- Hide A Plague Tale Digital Goodies Pack (thanks to TotalCaesar659)
 
 **1.2.2**
 - Fix progress bar not showing up for downloads

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -59,6 +59,7 @@ IGNORE_GAME_IDS = [
     1980301910,  # The Witcher Goodies Collection
     2005648906,  # Spring Sale Goodies Collection #1
     1486144755,  # Cyberpunk 2077 Goodies Collection
+    1581684020,  # A Plague Tale Digital Goodies Pack
 ]
 
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

Hide A Plague Tale Digital Goodies Pack from library cause it shows error "A Plague Tale Digital Goodies Pack with id 1581684020 couldn't be installed" when trying to download.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
