### PR TITLE
Remove radius from top corners of the "play" button

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -3,3 +3,7 @@
   color: red;
   background-color: purple;
 }
+button {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}


### PR DESCRIPTION
Small UI change. The left and right top corners of the "play" button have now a radius of 0. IMO, this gives a better look as the thumbnail and the button have now the same width.

Before:
![before](https://user-images.githubusercontent.com/1508181/219927722-569f59a3-12b5-4ef9-b86d-aa20c6466e08.png)

After:
![after](https://user-images.githubusercontent.com/1508181/219927762-05dc42ad-d038-4c03-850c-0de71409bab5.png)


