### PR TITLE
Move the Gametile menu button alongside the Play button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix game information not showing in list view (thanks to TotalCaesar659)
 - Hide A Plague Tale Digital Goodies Pack (thanks to TotalCaesar659)
 - Remove round corners from top of the "play" button (thanks to lmeunier)
+- Move the Gametile menu button alongside the Play button (thanks to lmeunier)
 
 **1.2.2**
 - Fix progress bar not showing up for downloads

--- a/data/po/cs_CZ.po
+++ b/data/po/cs_CZ.po
@@ -238,7 +238,7 @@ msgstr "Balík Innoextract není nainstalován."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Nainstalované"
+msgstr "nainstalovat"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -337,7 +337,7 @@ msgstr "Otevřít soubory"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "hrát"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/cs_CZ.po
+++ b/data/po/cs_CZ.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-24 10:09+0200\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2022-09-24 10:17+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -42,20 +42,20 @@ msgstr "Přidáno na konec příkazu pro spuštění hry"
 msgid "Added in front of the command used to launch the game"
 msgstr "Přidáno před příkaz pro spuštění hry"
 
-#: minigalaxy/ui/gametilelist.py:150 minigalaxy/ui/gametile.py:147
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Opravdu chcete zrušit stahování {}?"
 
-#: minigalaxy/ui/window.py:98
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Opravdu se chcete odhlásit z GOG?"
 
-#: minigalaxy/ui/gametilelist.py:163 minigalaxy/ui/gametile.py:160
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Opravdu chcete odinstalovat %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:31
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Brazilská portugalština"
 
@@ -72,7 +72,7 @@ msgstr "Zrušit"
 msgid "Check for updates:"
 msgstr "Kontrolovat aktualizace:"
 
-#: minigalaxy/constants.py:8
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Čínština"
 
@@ -80,16 +80,25 @@ msgstr "Čínština"
 msgid "Command flags:"
 msgstr "Příznaky příkazu:"
 
-#: minigalaxy/ui/information.py:72 minigalaxy/ui/information.py:82
-#: minigalaxy/ui/information.py:92
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Stránku obchodu se nepodařilo otevřít"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Stránku fóra se nepodařilo otevřít"
+
+#: minigalaxy/ui/information.py:75
 msgid "Couldn't open forum page"
 msgstr "Stránku fóra se nepodařilo otevřít"
 
-#: minigalaxy/ui/information.py:62
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Stránku obchodu se nepodařilo otevřít"
 
-#: minigalaxy/ui/information.py:52
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Stránku podpory se nepodařilo otevřít"
 
@@ -99,28 +108,38 @@ msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Vytvořit zástupce: "
 
-#: minigalaxy/constants.py:32
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr "Čeština"
 
-#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:193
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "Stažitelný obsah (DLC)"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Dánština"
 
-#: minigalaxy/ui/gametilelist.py:234 minigalaxy/ui/gametilelist.py:273
-#: minigalaxy/ui/gametile.py:231 minigalaxy/ui/gametile.py:270
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "stáhnout"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Chyba stahování"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "stahování…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Nizozemština"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Angličtina"
 
@@ -128,7 +147,7 @@ msgstr "Angličtina"
 msgid "Facebook Login"
 msgstr "Přihlásit pomocí Facebooku"
 
-#: minigalaxy/ui/preferences.py:122
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
@@ -136,20 +155,20 @@ msgstr ""
 "Nepodařilo se změnit jazyk aplikace. Ujistěte se, že je na Vašem systému "
 "vygenerováno příslušné locale."
 
-#: minigalaxy/ui/gametilelist.py:340 minigalaxy/ui/gametile.py:337
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Instalace {} se nezdařila"
 
-#: minigalaxy/ui/library.py:146
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Knihovnu se nepodařilo získat"
 
-#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:134
-#: minigalaxy/ui/gametile.py:131
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "{} se nezdařilo spustit:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:35
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Finština"
 
@@ -157,7 +176,7 @@ msgstr "Finština"
 msgid "Forum"
 msgstr "Fórum"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Francouzština"
 
@@ -165,11 +184,11 @@ msgstr "Francouzština"
 msgid "GameMode wasn't found. Using GameMode cannot be enabled."
 msgstr "GameMode nebyl nalezen. GameMode nelze zapnout."
 
-#: minigalaxy/ui/information.py:138
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Žánr"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:37
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Němčina"
 
@@ -179,11 +198,11 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "Stránka na GitHubu"
 
-#: minigalaxy/constants.py:50
+#: minigalaxy/constants.py:47
 msgid "Greek"
 msgstr "Řečtina"
 
-#: minigalaxy/constants.py:55
+#: minigalaxy/constants.py:52
 msgid "Grid"
 msgstr "Mřížka"
 
@@ -191,25 +210,35 @@ msgstr "Mřížka"
 msgid "Hide game:"
 msgstr "Skrýt hru:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Maďarština"
 
-#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:223
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "ve frontě…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
 msgid "Information"
 msgstr "Informace"
 
-#: minigalaxy/ui/information.py:28
+#: minigalaxy/ui/information.py:29
 msgid "Information about {}"
 msgstr "Informace o {}"
 
-#: minigalaxy/installer.py:149
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Rozbalení pomocí Innoextract se nezdařilo."
 
-#: minigalaxy/installer.py:166
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Balík Innoextract není nainstalován."
+
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Nainstalované"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -223,15 +252,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Nainstalované"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:38
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "instalace…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italština"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japonština"
 
-#: minigalaxy/ui/preferences.py:48
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -245,7 +279,7 @@ msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Ponechat instalátory: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Korejština"
 
@@ -255,7 +289,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Jazyk: "
 
-#: minigalaxy/constants.py:56
+#: minigalaxy/constants.py:53
 msgid "List"
 msgstr "Seznam"
 
@@ -277,19 +311,19 @@ msgstr "Balík MangoHud nebyl nalezen. MangoHud nelze zapnout."
 msgid "No executable was found in {}"
 msgstr "{} neobsahuje žádný spustitelný soubor"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norština"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Norština Bokmål"
 
-#: minigalaxy/constants.py:40
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Norština Nynorsk"
 
-#: minigalaxy/installer.py:98
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr "Nedostatek místa pro rozbalení hry. Požadované: {} Dostupné: {}"
 
@@ -301,17 +335,21 @@ msgstr "Budiž"
 msgid "Open files"
 msgstr "Otevřít soubory"
 
-#: minigalaxy/ui/information.py:53 minigalaxy/ui/information.py:63
-#: minigalaxy/ui/information.py:73 minigalaxy/ui/information.py:83
-#: minigalaxy/ui/information.py:93
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Zkontrolujte připojení k internetu"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Polština"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugalština"
 
@@ -331,7 +369,7 @@ msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Preferovaný jazyk hry: "
 
-#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:238
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Možnosti"
 
@@ -353,11 +391,11 @@ msgstr "Regedit"
 msgid "Reset wine executable"
 msgstr "Obnovit cestu k wine"
 
-#: minigalaxy/constants.py:26 minigalaxy/constants.py:51
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
 msgid "Romanian"
 msgstr "Rumunština"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:42
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Ruština"
 
@@ -389,15 +427,15 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Zobrazit pouze nainstalované hry"
 
-#: minigalaxy/constants.py:43
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Zjednodušená čínština"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Španělština"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:42
 msgid "Spanish (Spain)"
 msgstr "Španělština (Španělsko)"
 
@@ -415,15 +453,15 @@ msgstr "Obchod"
 msgid "Support"
 msgstr "Podpora"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Švédština"
 
-#: minigalaxy/constants.py:30
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Výchozí hodnota systému"
 
-#: minigalaxy/installer.py:129
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Instalace {} se nezdařila. Zkuste to znovu."
 
@@ -442,7 +480,7 @@ msgctxt "view_tooltip"
 msgid "The preferred view of game library"
 msgstr "Preferované zobrazení knihovny"
 
-#: minigalaxy/ui/gametilelist.py:235 minigalaxy/ui/gametile.py:232
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -455,25 +493,35 @@ msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Sem se budou instalovat hry"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Tradiční čínština"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:48
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Turečtina"
 
-#: minigalaxy/constants.py:49
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Ukrajinština"
 
-#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Odinstalovat"
 
-#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:172
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "odinstalace…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Aktualizovat"
+
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "aktualizace…"
 
 #: data/ui/properties.ui:178
 msgid "Use GameMode:"
@@ -493,7 +541,7 @@ msgstr "Použít tmavé téma: "
 msgid "Variable flags:"
 msgstr "Příznaky proměnných:"
 
-#: minigalaxy/ui/information.py:140
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Verze"
 
@@ -534,11 +582,11 @@ msgstr "Určuje zdali se mají vytvářet zástupci pro nově nainstalované hry
 msgid "Wine executable:"
 msgstr "Cesta k wine:"
 
-#: minigalaxy/installer.py:180
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Rozbalení Wine se nezdařilo."
 
-#: minigalaxy/ui/preferences.py:192
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr "Wine nebyl nalezen. Zobrazení her pro Windows nemůže být zapnuto."
 
@@ -554,55 +602,54 @@ msgstr "Winetricks"
 msgid "Winetricks wasn't found and cannot be used."
 msgstr "Balík Winetricks nebyl nalezen a nemůže být použit."
 
-#: minigalaxy/ui/gametilelist.py:507 minigalaxy/ui/gametile.py:504
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "stáhnout"
 
-#: minigalaxy/ui/gametilelist.py:547 minigalaxy/ui/gametile.py:544
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "stahování…"
 
-#: minigalaxy/ui/gametilelist.py:538 minigalaxy/ui/gametile.py:535
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "ve frontě…"
 
-#: minigalaxy/ui/gametilelist.py:526 minigalaxy/ui/gametile.py:523
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "nainstalovat"
 
-#: minigalaxy/ui/gametilelist.py:558 minigalaxy/ui/gametile.py:555
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "instalace…"
 
-#: minigalaxy/ui/gametilelist.py:573 minigalaxy/ui/gametilelist.py:603
-#: minigalaxy/ui/gametile.py:570 minigalaxy/ui/gametile.py:600
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "hrát"
 
-#: minigalaxy/ui/gametilelist.py:589 minigalaxy/ui/gametile.py:586
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "odinstalace…"
 
-#: minigalaxy/ui/information.py:134
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "neznámé"
 
-#: minigalaxy/ui/gametilelist.py:612 minigalaxy/ui/gametile.py:609
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "aktualizace…"
 
-#: minigalaxy/installer.py:131
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} nemohl být rozbalen."
 
-#: minigalaxy/installer.py:74
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} se nezdařilo stáhnout."
 
-#: minigalaxy/ui/preferences.py:204
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} není použitelná cesta"
 
-#: minigalaxy/installer.py:86
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} byl poškozen. Stáhněte ho znovu."

--- a/data/po/de.po
+++ b/data/po/de.po
@@ -239,7 +239,7 @@ msgstr "Innoextract ist nicht installiert."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Installiert"
+msgstr "Installieren"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -342,7 +342,7 @@ msgstr "Dateien öffnen"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "Spielen"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/de.po
+++ b/data/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: minigalaxy 0.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-10-10 21:36+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -33,32 +33,32 @@ msgctxt "about"
 msgid "About"
 msgstr "Info"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Wird am Ende des Befehls zum Starten des Spiels eingefügt"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Wird vor dem Befehl zum Starten des Spiels eingefügt"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Bist du sicher, dass du den Download von {} abbrechen möchtest?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Bist du sicher, dass du dich von GOG abmelden möchtest?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Bist du sicher, dass du %s deinstallieren möchtest?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Brasilianisches Portugiesisch"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -67,83 +67,129 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Chinesisch"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Kommandozeilenparameter:"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Konnte die Store-Seite nicht öffnen"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Konnte die Store-Seite nicht öffnen"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Konnte die Store-Seite nicht öffnen"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Konnte die Store-Seite nicht öffnen"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Konnte die Support-Seite nicht öffnen"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Menü-Verknüpfungen erstellen: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Dänisch"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "Herunterladen"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Download-Fehler"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "Wird heruntergeladen…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Niederländisch"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Englisch"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Fehler beim Installieren von {}"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Fehler beim Abrufen der Bibliothek"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Fehler beim Starten von {}:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Finnisch"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Französisch"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr ""
+"Wine wurde nicht gefunden. Das Anzeigen von Windows-Spielen kann nicht "
+"aktiviert werden."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Genre"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Deutsch"
 
@@ -153,24 +199,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "GitHub-Seite"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Spiel verstecken:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Ungarisch"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "In der Warteschlange…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Entpacken mit Innoextract fehlgeschlagen."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract ist nicht installiert."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Installiert"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Installationspfad: "
@@ -181,15 +253,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Installiert"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "Wird installiert…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italienisch"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japanisch"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -197,21 +274,25 @@ msgstr ""
 "Installationsdateien behalten, nachdem ein Spiel heruntergeladen wurde.\n"
 "Installationsdateien werden gespeichert in: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Installationsdateien behalten: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Koreanisch"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Sprache: "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -223,48 +304,61 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Abmelden"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr ""
+"Wine wurde nicht gefunden. Das Anzeigen von Windows-Spielen kann nicht "
+"aktiviert werden."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Es wurden keine Ausführbaren Dateien in  {} gefunden"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norwegisch"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Norwegisch Bokmål"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Norwegisch Nynorsk"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr ""
 "Nicht genug Speicher, um das Spiel zu entpacken. Benötigt: {} Verfügbar: {}"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "OK"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Dateien öffnen"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Bitte überprüfe deine Internetverbindung"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Polnisch"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugiesisch"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Einstellungen"
 
@@ -274,17 +368,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Bevorzugte Sprache für Spiele: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Eigenschaften"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Eigenschaften von {}"
 
@@ -294,11 +388,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Spieleliste aktualisieren"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Russisch"
 
@@ -308,18 +410,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Speichern"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "FPS im Spiel anzeigen:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Windows-Spiele anzeigen: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "Versteckte Spiele anzeigen: "
@@ -330,37 +432,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Nur installierte Spiele anzeigen"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Vereinfachtes Chinesisch"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Spanisch"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Spanisch"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Angemeldet bleiben:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Store"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Support"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Schwedisch"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Systemstandard"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Die Installation von {} ist fehlgeschlagen. Bitte versuche es erneut."
 
@@ -374,7 +481,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "Die bevorzugte Sprache beim Start von Minigalaxy"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "Die bevorzugte Sprache beim Start von Minigalaxy"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -382,136 +495,176 @@ msgstr ""
 "Fehler beim Abrufen des Download-Links!\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Ort, an dem Spiele installiert werden"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Traditionelles Chinesisch"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Ukrainisch"
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Deinstallieren"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "Wird deinstalliert…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Aktualisieren"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "Wird aktualisiert…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Dunkles Farbschema verwenden: "
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Umgebungsvariablen:"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Version"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "Wenn deaktiviert, wirst du bei jedem Start von Minigalaxy aufgefordert, dich "
 "anzumelden"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Ob Minigalaxy ein dunkles Farbschema verwenden soll oder nicht"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Ob Windows-Spiele in der Bibliothek angezeigt werden oder nicht"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Ob versteckte Spiele in der Bibliothek angezeigt werden oder nicht"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr ""
 "Ob Verknüpfungen für neu installierte Spiele erstellt werden oder nicht"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Entpacken mit Wine fehlgeschlagen."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Entpacken mit Wine fehlgeschlagen."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr ""
 "Wine wurde nicht gefunden. Das Anzeigen von Windows-Spielen kann nicht "
 "aktiviert werden."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr ""
+"Wine wurde nicht gefunden. Das Anzeigen von Windows-Spielen kann nicht "
+"aktiviert werden."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "Herunterladen"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "Wird heruntergeladen…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "In der Warteschlange…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "Installieren"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "Wird installiert…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "Spielen"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "Wird deinstalliert…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "Wird aktualisiert…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} konnte nicht entpackt werden."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "Der Download von {} schlug fehl."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} ist kein gültiger Pfad"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} wurde beschädigt. Bitte starte den Download erneut."
 

--- a/data/po/el.po
+++ b/data/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 18:47+0300\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2022-06-02 18:51+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -46,20 +46,20 @@ msgstr ""
 "Χρησιμοποιείται για την εκκίνηση του παιχνιδιού,Προστίθεται στην αρχή της "
 "εντολής"
 
-#: minigalaxy/ui/gametilelist.py:143 minigalaxy/ui/gametile.py:140
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Είστε σίγουρος/η ότι θέλετε να ακυρώσετε την εγκατάσταση του {};"
 
-#: minigalaxy/ui/window.py:98
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Είστε σίγουρος/η ότι θέλετε να αποσυνδεθείτε από το GOG;"
 
-#: minigalaxy/ui/gametilelist.py:156 minigalaxy/ui/gametile.py:153
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Είστε σίγουρος/η ότι θέλετε να απεγκαταστήσετε το %s ;"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Πορτογαλικά (Βραζιλίας)"
 
@@ -76,7 +76,7 @@ msgstr "Ακύρωση"
 msgid "Check for updates:"
 msgstr "Έλεγχος για ενημερώσεις:"
 
-#: minigalaxy/constants.py:8
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Κινεζικά"
 
@@ -84,16 +84,25 @@ msgstr "Κινεζικά"
 msgid "Command flags:"
 msgstr "Παράμετροι εντολών:"
 
-#: minigalaxy/ui/information.py:72 minigalaxy/ui/information.py:82
-#: minigalaxy/ui/information.py:92
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Δεν μπορούσαμε να ανοίξουμε την σελίδα του καταστήματος"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Δεν μπορούσαμε να ανοίξουμε την σελίδα φόρουμ"
+
+#: minigalaxy/ui/information.py:75
 msgid "Couldn't open forum page"
 msgstr "Δεν μπορούσαμε να ανοίξουμε την σελίδα φόρουμ"
 
-#: minigalaxy/ui/information.py:62
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Δεν μπορούσαμε να ανοίξουμε την σελίδα του καταστήματος"
 
-#: minigalaxy/ui/information.py:52
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Δεν μπορούσαμε να ανοίξουμε την σελίδα υποστήριξης"
 
@@ -103,28 +112,38 @@ msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Δημιουργία καταχωρίσεων μενού: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr "Τσέχικα"
 
-#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:193
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Δανέζικα"
 
-#: minigalaxy/ui/gametilelist.py:222 minigalaxy/ui/gametilelist.py:252
-#: minigalaxy/ui/gametile.py:219 minigalaxy/ui/gametile.py:249
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "λήψη"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Σφάλμα κατα την διαρκεια κατεβασματος"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "ενυμέρωση…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Ολλανδικά"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Αγγλικά"
 
@@ -132,7 +151,7 @@ msgstr "Αγγλικά"
 msgid "Facebook Login"
 msgstr "Σύνδεση μέσο Facebook"
 
-#: minigalaxy/ui/preferences.py:122
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
@@ -140,20 +159,20 @@ msgstr ""
 "Αδυναμία αλλαγής γλωσσάς προγράμματος.Βεβαιωθείτε ότι έχει δημιουργηθεί η "
 "καταχώρηση τοπικότητας στο σύστημα σας."
 
-#: minigalaxy/ui/gametilelist.py:318 minigalaxy/ui/gametile.py:315
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Αδυναμία εγκατάστασης {}"
 
-#: minigalaxy/ui/library.py:146
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Αδυναμία εύρεσης βιβλιοθήκης"
 
-#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:127
-#: minigalaxy/ui/gametile.py:124
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Αδυναμία έναρξης {}:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Φινλανδικά"
 
@@ -161,7 +180,7 @@ msgstr "Φινλανδικά"
 msgid "Forum"
 msgstr "Φόρουμ"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Γαλλικά"
 
@@ -171,11 +190,11 @@ msgstr ""
 "Αποτυχία εύρεσης του GameMode. Δεν είναι δυνατή η ενεργοποιήσει χρίσης "
 "GameMode."
 
-#: minigalaxy/ui/information.py:138
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Είδος"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Γερμανικά"
 
@@ -185,11 +204,11 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "Σελίδα GitHub"
 
-#: minigalaxy/constants.py:49
+#: minigalaxy/constants.py:47
 msgid "Greek"
 msgstr "Ελληνικά"
 
-#: minigalaxy/constants.py:53
+#: minigalaxy/constants.py:52
 msgid "Grid"
 msgstr "Πλέγμα"
 
@@ -197,25 +216,35 @@ msgstr "Πλέγμα"
 msgid "Hide game:"
 msgstr "Απόκρυψη παιχνιδιού:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Ουγγαρέζικα"
 
-#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:223
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "σε αναμονή…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: minigalaxy/ui/information.py:28
+#: minigalaxy/ui/information.py:29
 msgid "Information about {}"
 msgstr "Πληροφορίες περί {}"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Αποτυχία αποσυμπίεσης Innoextract."
 
-#: minigalaxy/installer.py:164
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Δεν εγκαταστάθηκε το Innoextract."
+
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Εγκατεστημένα"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -229,15 +258,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Εγκατεστημένα"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "εγκαθίσταται…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Ιταλικά"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Ιαπωνικά"
 
-#: minigalaxy/ui/preferences.py:48
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -251,7 +285,7 @@ msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Διατήρηση αρχείων εγκατάστασης: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Κορεάτικα"
 
@@ -261,7 +295,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Γλώσσα: "
 
-#: minigalaxy/constants.py:54
+#: minigalaxy/constants.py:53
 msgid "List"
 msgstr "Λίστα"
 
@@ -281,23 +315,23 @@ msgstr ""
 "Αποτυχία εύρεσης του MangoHud. Δεν είναι δυνατή η ενεργοποιήσει χρίσης "
 "MangoHud."
 
-#: minigalaxy/launcher.py:205
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Αποτυχία εύρεσης εκτελέσιμου {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Νορβηγικά"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Νορβηγικά Bokmål"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Νορβηγικά Nynorsk"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr ""
 "Δεν επαρκεί χώρος για την αποσυμπίεση του παιχνιδιού.Χρειάζονται:{}Διαθέσιμα:"
@@ -311,17 +345,21 @@ msgstr "Εντάξει"
 msgid "Open files"
 msgstr "Άνοιγμα αρχείων"
 
-#: minigalaxy/ui/information.py:53 minigalaxy/ui/information.py:63
-#: minigalaxy/ui/information.py:73 minigalaxy/ui/information.py:83
-#: minigalaxy/ui/information.py:93
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Παρακαλώ ελέγξτε την σύνδεση του δικτύου σας"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Πολωνικά"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Πορτογάλικα"
 
@@ -341,7 +379,7 @@ msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Προεπιλεγμένη γλωσσά παιχνιδιών: "
 
-#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:238
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Ιδιότητες"
 
@@ -363,7 +401,11 @@ msgstr "Επεξεργασία μητρώου wine"
 msgid "Reset wine executable"
 msgstr "Επαναφορά εκτελέσιμου wine"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Ρώσικα"
 
@@ -395,15 +437,15 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Προβολή μόνο εγκατεστημένων παιχνιδιών"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Κινεζικά Απλοποιημένα"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Ισπανικά"
 
-#: minigalaxy/constants.py:44
+#: minigalaxy/constants.py:42
 msgid "Spanish (Spain)"
 msgstr "Ισπανικά (Ισπανίας)"
 
@@ -421,15 +463,15 @@ msgstr "Κατάστημα"
 msgid "Support"
 msgstr "Υποστήριξη"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:45
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Σουηδικά"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Προκαθορισμένη Συστήματος"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Η εγκατάσταση του {} απέτυχε.Παρακαλώ προσπαθήστε ξανά."
 
@@ -448,7 +490,7 @@ msgctxt "view_tooltip"
 msgid "The preferred view of game library"
 msgstr "Επιθυμητή απεικόνιση βιβλιοθήκης παιχνιδιών"
 
-#: minigalaxy/ui/gametilelist.py:223 minigalaxy/ui/gametile.py:220
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -459,25 +501,35 @@ msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Εδώ θα εγκαθίστανται τα παιχνίδια"
 
-#: minigalaxy/constants.py:46
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Κινεζικά Παραδοσιακά"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:47
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Τουρκικά"
 
-#: minigalaxy/constants.py:48
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Ουκρανικά"
 
-#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Απεγκατάσταση"
 
-#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:172
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "απ εγκαθίσταται…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Ενημέρωση"
+
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "ενημερώνεται…"
 
 #: data/ui/properties.ui:178
 msgid "Use GameMode:"
@@ -497,7 +549,7 @@ msgstr "Χρύση σκοτεινού θέματος: "
 msgid "Variable flags:"
 msgstr "Μεταβλητές παραμέτρων:"
 
-#: minigalaxy/ui/information.py:140
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Εκδοσή"
 
@@ -543,11 +595,11 @@ msgstr ""
 msgid "Wine executable:"
 msgstr "Εκτελέσιμο wine:"
 
-#: minigalaxy/installer.py:178
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Αποτυχία αποσυμπίεσης wine."
 
-#: minigalaxy/ui/preferences.py:192
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr ""
 "Αποτυχία εύρεσης wine.Δεν είναι δυνατή η δυνατότητα προβολής παιχνιδιών "
@@ -565,55 +617,54 @@ msgstr "Winetricks"
 msgid "Winetricks wasn't found and cannot be used."
 msgstr "Αποτυχία εύρεσης winetricks.Δεν είναι δυνατή η χρήση του."
 
-#: minigalaxy/ui/gametilelist.py:483 minigalaxy/ui/gametile.py:480
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "λήψη"
 
-#: minigalaxy/ui/gametilelist.py:523 minigalaxy/ui/gametile.py:520
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "ενυμέρωση…"
 
-#: minigalaxy/ui/gametilelist.py:514 minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "σε αναμονή…"
 
-#: minigalaxy/ui/gametilelist.py:502 minigalaxy/ui/gametile.py:499
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "εγκατάστασή"
 
-#: minigalaxy/ui/gametilelist.py:534 minigalaxy/ui/gametile.py:531
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "εγκαθίσταται…"
 
-#: minigalaxy/ui/gametilelist.py:549 minigalaxy/ui/gametilelist.py:579
-#: minigalaxy/ui/gametile.py:546 minigalaxy/ui/gametile.py:576
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "παίξε"
 
-#: minigalaxy/ui/gametilelist.py:565 minigalaxy/ui/gametile.py:562
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "απ εγκαθίσταται…"
 
-#: minigalaxy/ui/information.py:134
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "άγνωστο"
 
-#: minigalaxy/ui/gametilelist.py:588 minigalaxy/ui/gametile.py:585
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "ενημερώνεται…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} αδυναμία αποσυμπίεσης."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "() αποτυχία λήψης."
 
-#: minigalaxy/ui/preferences.py:204
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "()μη εύχρηστη διαδρομη"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "()διαφθείρει.Παρακαλώ κατεβαστε το ξανά."

--- a/data/po/el.po
+++ b/data/po/el.po
@@ -244,7 +244,7 @@ msgstr "Δεν εγκαταστάθηκε το Innoextract."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Εγκατεστημένα"
+msgstr "εγκατάστασή"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -347,7 +347,7 @@ msgstr "Άνοιγμα αρχείων"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "παίξε"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/es.po
+++ b/data/po/es.po
@@ -244,7 +244,7 @@ msgstr "Innoextract no instalado."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Instalados"
+msgstr "instalar"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -349,7 +349,7 @@ msgstr "Abrir Archivos"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "jugar"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/es.po
+++ b/data/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-10-07 18:22+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,32 +34,32 @@ msgctxt "about"
 msgid "About"
 msgstr "Acerca de"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Añadido al final del comando utilizado para lanzar el juego"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Añadido al comienzo del comando utilizado para lanzar el juego"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "¿Estás seguro que deseas cancelar la descarga de {}?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "¿Estás seguro que quieres cerrar la sesión de GOG?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "¿Estás seguro que deseas desinstalar %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Portugués de Brasil"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 #, fuzzy
 msgid "Cancel"
 msgstr "Cancelar"
@@ -69,55 +69,89 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Chino"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Argumentos del comando:"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "No se pudo abrir la página de soporte"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "No se pudo abrir la página de soporte"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "No se pudo abrir la página de soporte"
+
+#: minigalaxy/ui/information.py:65
 #, fuzzy
 msgid "Couldn't open store page"
 msgstr "No se pudo abrir la página de soporte"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "No se pudo abrir la página de soporte"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Crear accesos directos en el menú: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr ""
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Danés"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "descarga"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 #, fuzzy
 msgid "Download error"
 msgstr "Error en la descarga"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "descargando…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Holandés"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Inglés"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
@@ -125,31 +159,42 @@ msgstr ""
 "Fallo al cambiar el idioma del programa. Asegúrate de que el local se "
 "hagenerado en tu sistema"
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "No se pudo instalar {}"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "No se pudo recuperar la biblioteca"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "No se pudo iniciar {}"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Francés"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr ""
+"No se encontro Wine. Mostrar los juegos para Windows no se puede activar"
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Género"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Alemán"
 
@@ -159,24 +204,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "Página de GitHub"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Ocultar juego:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "en cola…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "La extracción de Innoextract falló."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract no instalado."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Instalados"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Ruta de instalación: "
@@ -187,15 +258,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Instalados"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "instalando…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italiano"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japones"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -203,21 +279,25 @@ msgstr ""
 "Guardar los instaladores al descargar un juego.\n"
 "Los instaladores se guardan en: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Guardar los instaladores: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Coreano"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Idioma: "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -229,51 +309,63 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Cerrar sesión"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr ""
+"No se encontro Wine. Mostrar los juegos para Windows no se puede activar"
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "No se encontró ningún ejecutable en {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Noruego"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 #, fuzzy
 msgid "Norwegian Bokmål"
 msgstr "Noruego"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 #, fuzzy
 msgid "Norwegian Nynorsk"
 msgstr "Noruego"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr ""
 "No hay suficiente espacio para extraer el juego. Se necesita: {} Disponible: "
 "{}"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "Aceptar"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Abrir Archivos"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Por favor, verifique su conexión a internet"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Polaco"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Preferencias"
 
@@ -283,17 +375,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Preferencias"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Idioma preferido: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Propiedades"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Propiedades de {}"
 
@@ -303,11 +395,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Refrescar lista de juegos"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr ""
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Ruso"
 
@@ -317,19 +417,19 @@ msgctxt "save"
 msgid "Save"
 msgstr "Guardar"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 #, fuzzy
 msgid "Show FPS in game:"
 msgstr "Mostrar el indicador de FPS en los juegos:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Mostrar los juegos para Windows: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 #, fuzzy
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
@@ -341,39 +441,44 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Mostrar solo los juegos instalados"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Chino simplificado"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Español"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Español"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Permanecer conectado:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 #, fuzzy
 msgid "Store"
 msgstr "Pagina de la tienda"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 #, fuzzy
 msgid "Support"
 msgstr "Soporte"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Sueco"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Por defecto del sistema"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "La instalación de {} ha fallado. Por favor, intentelo de nuevo."
 
@@ -388,7 +493,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "El lenguage preferido en el que lanzar Minigalaxy"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "El lenguage preferido en el que lanzar Minigalaxy"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -396,137 +507,176 @@ msgstr ""
 "¡Ocurrio un error al intentar obtener el enlace de descarga!\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "La ruta donde se instalaran los juegos"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Chino tradicional"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Turco"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 #, fuzzy
 msgid "Uninstall"
 msgstr "Desinstalar"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "desinstalando…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Actualizar"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "descargando…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Usar tema oscuro: "
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Parámetros"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Versión"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "Si se desactiva se te requerira que inicies sesion cada vez que abras "
 "Minigalaxy"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Si Minigalaxy ha de utilizar el tema oscuro o no"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Si mostrar los juegos para Windows en la biblioteca o no"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 #, fuzzy
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Si mostrar los juegos para Windows en la biblioteca o no"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr "Si los atajos son creados al instalar nuevos juegos o no"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "La extracción de Wine fallo."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "La extracción de Wine fallo."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr ""
 "No se encontro Wine. Mostrar los juegos para Windows no se puede activar"
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr ""
+"No se encontro Wine. Mostrar los juegos para Windows no se puede activar"
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "descarga"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "descargando…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "en cola…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "instalar"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "instalando…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "jugar"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "desinstalando…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 #, fuzzy
 msgid "updating…"
 msgstr "descargando…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} no se pudo descomprimir."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} no se pudo descargar."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} no es una ruta valida"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} se ha corrompido. Por favor descargalo nuevamente."
 

--- a/data/po/es_ES.po
+++ b/data/po/es_ES.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-16 11:49+0100\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2022-02-16 11:49+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,32 +34,32 @@ msgctxt "about"
 msgid "About"
 msgstr "Acerca de"
 
-#: data/ui/properties.ui:255
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Añadido al final del comando utilizado para lanzar el juego"
 
-#: data/ui/properties.ui:230
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Añadido al comienzo del comando utilizado para lanzar el juego"
 
-#: minigalaxy/ui/gametilelist.py:143 minigalaxy/ui/gametile.py:140
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "¿Estás seguro de que quieres cancelar la descarga de {}?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "¿Estás seguro de que quieres cerrar la sesión de GOG?"
 
-#: minigalaxy/ui/gametilelist.py:156 minigalaxy/ui/gametile.py:153
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "¿Estás seguro de que quieres desinstalar %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Portugués de Brasil"
 
-#: data/ui/properties.ui:289
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -68,28 +68,37 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: data/ui/properties.ui:93
+#: data/ui/properties.ui:103
 msgid "Check for updates:"
 msgstr "Comprobar actualizaciones:"
 
-#: minigalaxy/constants.py:8
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Chino"
 
-#: data/ui/properties.ui:243
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Argumentos del comando:"
 
-#: minigalaxy/ui/information.py:70 minigalaxy/ui/information.py:80
-#: minigalaxy/ui/information.py:90
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "No se ha podido abrir la página de la tienda"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "No se ha podido abrir la página del foro"
+
+#: minigalaxy/ui/information.py:75
 msgid "Couldn't open forum page"
 msgstr "No se ha podido abrir la página del foro"
 
-#: minigalaxy/ui/information.py:60
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "No se ha podido abrir la página de la tienda"
 
-#: minigalaxy/ui/information.py:50
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "No se ha podido abrir la página de soporte"
 
@@ -99,32 +108,46 @@ msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Crear accesos directos en el menú: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr "Checo"
 
-#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:193
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "Contenido descargable"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Danés"
 
-#: minigalaxy/ui/gametilelist.py:218 minigalaxy/ui/gametilelist.py:248
-#: minigalaxy/ui/gametile.py:215 minigalaxy/ui/gametile.py:245
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "descargar"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Error en la descarga"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "descargando…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Holandés"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Inglés"
 
-#: minigalaxy/ui/preferences.py:122
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
@@ -132,20 +155,20 @@ msgstr ""
 "Fallo al cambiar el idioma del programa. Asegúrate de que el local se ha "
 "generado en tu sistema."
 
-#: minigalaxy/ui/gametilelist.py:312 minigalaxy/ui/gametile.py:309
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "No se ha podido instalar {}"
 
-#: minigalaxy/ui/library.py:146
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "No se ha podido recuperar la biblioteca"
 
-#: minigalaxy/launcher.py:41 minigalaxy/ui/gametilelist.py:127
-#: minigalaxy/ui/gametile.py:124
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "No se ha podido iniciar {}:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Finlandés"
 
@@ -153,20 +176,20 @@ msgstr "Finlandés"
 msgid "Forum"
 msgstr "Foro"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Francés"
 
-#: minigalaxy/ui/properties.py:73
+#: minigalaxy/ui/properties.py:82
 msgid "GameMode wasn't found. Using GameMode cannot be enabled."
 msgstr ""
 "No se ha encontrado GameMode. No es posible activar el uso de GameMode."
 
-#: minigalaxy/ui/information.py:127
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Género"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Alemán"
 
@@ -176,33 +199,47 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "Página de GitHub"
 
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
 #: minigalaxy/constants.py:52
 msgid "Grid"
 msgstr "Rejilla"
 
-#: data/ui/properties.ui:143
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Ocultar juego:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:223
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "en cola…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
 msgid "Information"
 msgstr "Información"
 
-#: minigalaxy/ui/information.py:26
+#: minigalaxy/ui/information.py:29
 msgid "Information about {}"
 msgstr "Información sobre {}"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Ha fallado la extracción de Innoextract."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract no está instalado."
+
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Instalados"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -216,15 +253,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Instalados"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "instalando…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italiano"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japonés"
 
-#: minigalaxy/ui/preferences.py:48
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -238,7 +280,7 @@ msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Guardar los instaladores: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Coreano"
 
@@ -262,52 +304,56 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Cerrar sesión"
 
-#: minigalaxy/ui/properties.py:78
+#: minigalaxy/ui/properties.py:87
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr ""
 "No se ha encontrado MangoHud. No es posible activar el uso de MangoHud."
 
-#: minigalaxy/launcher.py:191
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "No se ha encontrado ningún ejecutable en {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Noruego"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Noruego Bokmål"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Noruego Nynorsk"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr ""
 "No hay suficiente espacio para extraer el juego. Se necesita: {} Disponible: "
 "{}"
 
-#: data/ui/information.ui:165 data/ui/properties.ui:303
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "Aceptar"
 
-#: data/ui/properties.ui:64
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Abrir archivos"
 
-#: minigalaxy/ui/information.py:51 minigalaxy/ui/information.py:61
-#: minigalaxy/ui/information.py:71 minigalaxy/ui/information.py:81
-#: minigalaxy/ui/information.py:91
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Por favor, compruebe su conexión a Internet"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Polaco"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugués"
 
@@ -327,11 +373,11 @@ msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Idioma preferido para el juego: "
 
-#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:238
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Propiedades"
 
-#: minigalaxy/ui/properties.py:31
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Propiedades de {}"
 
@@ -341,11 +387,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Refrescar lista de juegos"
 
-#: data/ui/properties.ui:38
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Ruso"
 
@@ -355,7 +409,7 @@ msgctxt "save"
 msgid "Save"
 msgstr "Guardar"
 
-#: data/ui/properties.ui:118
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Mostrar indicador de FPS en el juego:"
 
@@ -377,15 +431,15 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Mostrar solo los juegos instalados"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Chino simplificado"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Español"
 
-#: minigalaxy/constants.py:44
+#: minigalaxy/constants.py:42
 msgid "Spanish (Spain)"
 msgstr "Español (España)"
 
@@ -403,15 +457,15 @@ msgstr "Tienda"
 msgid "Support"
 msgstr "Soporte"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:45
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Sueco"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Por defecto del sistema"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Ha fallado la instalación de {}. Por favor, inténtalo de nuevo."
 
@@ -430,7 +484,7 @@ msgctxt "view_tooltip"
 msgid "The preferred view of game library"
 msgstr "La vista preferida de la biblioteca de juegos"
 
-#: minigalaxy/ui/gametilelist.py:219 minigalaxy/ui/gametile.py:216
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -443,31 +497,41 @@ msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "La ruta donde se instalarán los juegos"
 
-#: minigalaxy/constants.py:46
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Chino tradicional"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:47
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Turco"
 
-#: minigalaxy/constants.py:48
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Desinstalar"
 
-#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:172
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "desinstalando…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Actualizar"
 
-#: data/ui/properties.ui:168
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "actualizando…"
+
+#: data/ui/properties.ui:178
 msgid "Use GameMode:"
 msgstr "Usar GameMode:"
 
-#: data/ui/properties.ui:193
+#: data/ui/properties.ui:203
 msgid "Use MangoHud:"
 msgstr "Usar MangoHud:"
 
@@ -477,11 +541,11 @@ msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Usar tema oscuro: "
 
-#: data/ui/properties.ui:218
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Parámetros:"
 
-#: minigalaxy/ui/information.py:129
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Versión"
 
@@ -518,77 +582,81 @@ msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr "Si los atajos son creados al instalar nuevos juegos o no"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Ha fallado la extracción de Wine."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Ha fallado la extracción de Wine."
 
-#: minigalaxy/ui/preferences.py:192
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr ""
 "No se ha encontrado Wine. No es posible activar mostrar los juegos para "
 "Windows."
 
-#: data/ui/properties.ui:51
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: data/ui/properties.ui:77
+#: data/ui/properties.ui:87
 msgid "Winetricks"
 msgstr "Winetricks"
 
-#: minigalaxy/ui/properties.py:99
+#: minigalaxy/ui/properties.py:113
 msgid "Winetricks wasn't found and cannot be used."
 msgstr "No se ha encontrado Winetricks y no se puede utilizar."
 
-#: minigalaxy/ui/gametilelist.py:475 minigalaxy/ui/gametile.py:472
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "descargar"
 
-#: minigalaxy/ui/gametilelist.py:515 minigalaxy/ui/gametile.py:512
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "descargando…"
 
-#: minigalaxy/ui/gametilelist.py:506 minigalaxy/ui/gametile.py:503
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "en cola…"
 
-#: minigalaxy/ui/gametilelist.py:494 minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "instalar"
 
-#: minigalaxy/ui/gametilelist.py:526 minigalaxy/ui/gametile.py:523
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "instalando…"
 
-#: minigalaxy/ui/gametilelist.py:541 minigalaxy/ui/gametilelist.py:571
-#: minigalaxy/ui/gametile.py:538 minigalaxy/ui/gametile.py:568
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "jugar"
 
-#: minigalaxy/ui/gametilelist.py:557 minigalaxy/ui/gametile.py:554
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "desinstalando…"
 
-#: minigalaxy/ui/information.py:123
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "desconocido"
 
-#: minigalaxy/ui/gametilelist.py:580 minigalaxy/ui/gametile.py:577
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "actualizando…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} no se ha podido descomprimir."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} no se ha podido descargar."
 
-#: minigalaxy/ui/preferences.py:204
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} no es una ruta válida"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} se ha corrompido. Por favor, descárgalo nuevamente."

--- a/data/po/es_ES.po
+++ b/data/po/es_ES.po
@@ -239,7 +239,7 @@ msgstr "Innoextract no está instalado."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Instalados"
+msgstr "instalar"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -341,7 +341,7 @@ msgstr "Abrir archivos"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "jugar"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/fi.po
+++ b/data/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-09-30 12:59+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -35,32 +35,32 @@ msgctxt "about"
 msgid "About"
 msgstr "Tietoja"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Lisätään pelin käynnistämiseen käytettävän komennon loppuun"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Lisätään pelin käynnistämiseen käytettävän komennon alkuun"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Oletko varma että haluat keskeyttää latauksen {}?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Oletko varma että halua kirjautua ulos palvelusta GOG?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Oletko varma että haluat poistaa asennuksen %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Brasilian portugali"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Peruuta"
 
@@ -69,83 +69,128 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Kiina"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Komentoparametrit:"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Kauppasivua ei voitu avata"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Kauppasivua ei voitu avata"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Kauppasivua ei voitu avata"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Kauppasivua ei voitu avata"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Tukisivua ei voitu avata"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Luo valikon pikakuvakkeet: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC-lisäosa"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Tanska"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "lataa"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Latausvirhe"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "ladataan…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Hollanti"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Englanti"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "{} asentaminen epäonnistui"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Kirjaston noutaminen epäonnistui"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Kohteen {} käynnistäminen epäonnistui:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Suomi"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Ranska"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr ""
+"Wine-ohjelmaa ei löytynyt. Windows-pelien näyttämistä ei voida kytkeä päälle."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Genre"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Saksa"
 
@@ -155,24 +200,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "GitHub-sivu"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Piilota peli:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Unkari"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "jonossa…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Innoextract-purku epäonnistui."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract ei asennettu."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Asennetut"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Asennuspolku: "
@@ -183,15 +254,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Asennetut"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "asennetaan…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italia"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japani"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -199,21 +275,25 @@ msgstr ""
 "Säilytä asennusohjelmat pelin lataamisen jälkeen.\n"
 "Asennusohjelmat löytyvät täältä: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Säilytä asennusohjelmat: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Korea"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Kieli: "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -225,48 +305,60 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Kirjaudu ulos"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr ""
+"Wine-ohjelmaa ei löytynyt. Windows-pelien näyttämistä ei voida kytkeä päälle."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Ajettavaa käynnistystiedostoa ei löytynyt kohteelle {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norja"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Norja (kirjakieli)"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Norja (Nynorsk)"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr ""
 "Levytilaa ei ole tarpeeksi pelin purkamiseen. Tarvitaan {} Saatavilla {}"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "OK"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Avaa tiedostot"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Ole hyvä ja tarkista, että internet-yhteytesi on toiminnassa"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Puola"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Asetukset"
 
@@ -276,17 +368,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Asetukset"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Ensisijainen kieli peleille: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Ominaisuudet"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Ominaisuudet kohteelle {}"
 
@@ -296,11 +388,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Virkistä peliluettelo"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit-muokkaus"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Venäjä"
 
@@ -310,18 +410,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Tallenna"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Näytä ruudunpäivitysnopeus pelissä:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Näytä Windows-pelit: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "Näytä piilotetut pelit: "
@@ -332,37 +432,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Näytä ainoastaan asennetut pelit"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Yksinkertaistettu kiina"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Espanja"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Espanja"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Pysy kirjautuneena:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Kauppa"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Tuki"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Ruotsi"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Järjestelmän oletus"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Asennus {} epäonnistui. Yritä uudelleen."
 
@@ -376,7 +481,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "Ensisijainen kieli jota minigalaxy itsessään käyttää"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "Ensisijainen kieli jota minigalaxy itsessään käyttää"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -384,133 +495,172 @@ msgstr ""
 "Ilmeni virhe noudettaessa latauslinkkiä!\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Tämä on sijainti johon pelit asennetaan"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Perinteinen kiina"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Turkki"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Poista asennus"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "poistetaan asennusta…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Päivitä"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "päivitetään…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Käytä tummaa teemaa: "
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Muuttujat:"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Versio"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "Mikäli pois päältä, sinua pyydetään kirjautumaan uudelleen aina Minigalaxyn "
 "käynnistyksessä"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Tulisiko minigalaxyn käyttää tummaa teemaa vai ei"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Näytetäänkö Windows-pelit kirjastossa vaiko ei"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Näytetäänkö piilotetut pelit kirjastossa vaiko ei"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr "Luodaanko uusille peleille pikakuvakkeet vaiko ei"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Wine-purku epäonnistui."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Wine-purku epäonnistui."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr ""
 "Wine-ohjelmaa ei löytynyt. Windows-pelien näyttämistä ei voida kytkeä päälle."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg-asetukset"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr ""
+"Wine-ohjelmaa ei löytynyt. Windows-pelien näyttämistä ei voida kytkeä päälle."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "lataa"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "ladataan…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "jonossa…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "asenna"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "asennetaan…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "pelaa"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "poistetaan asennusta…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "päivitetään…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} ei voitu purkaa."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} lataus epäonnistui."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} ei ole käytettävä polku"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} korruptoitui. Suorita lataus uudelleen."

--- a/data/po/fi.po
+++ b/data/po/fi.po
@@ -240,7 +240,7 @@ msgstr "Innoextract ei asennettu."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Asennetut"
+msgstr "asenna"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -342,7 +342,7 @@ msgstr "Avaa tiedostot"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "pelaa"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/fr.po
+++ b/data/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-10-23 16:33+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,32 +34,32 @@ msgctxt "about"
 msgid "About"
 msgstr "À propos"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Ajouté à la fin de la commande utilisée pour lancer le jeu"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Ajouté devant la commande utilisée pour lancer le jeu"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Êtes-vous sûr de vouloir annuler le téléchargement {} ?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Êtes-vous sûr de vouloir vous déconnecter de GOG ?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Êtes-vous sûr de vouloir désinstaller %s ?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Portugais Brésilien"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -68,83 +68,129 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Chinois"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Paramètres de la commande :"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Impossible d'ouvrir la page de la boutique"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Impossible d'ouvrir la page de la boutique"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Impossible d'ouvrir la page de la boutique"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Impossible d'ouvrir la page de la boutique"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Impossible d'ouvrir la page de support"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Créez des raccourcis dans le menu : "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Danois"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "Télécharger"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Erreur de téléchargement"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "Téléchargement…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Néerlandais"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Anglais"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Impossible de démarrer {} :"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Impossible de récupérer la bibliothèque"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Impossible de démarrer {} :"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Finlandais"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Français"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr ""
+"Wine n'a pas été trouvé. L'affichage des jeux Windows ne peut pas être "
+"activé."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Genre"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Allemand"
 
@@ -154,24 +200,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "Page GitHub"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Cacher le jeu :"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Hongrois"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "Dans la file d'attente…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "L'extraction de l'Innoextract a échoué."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract n'est pas installé."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Installer"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Chemin d'installation : "
@@ -182,15 +254,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Installé"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "Installation…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italien"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japonais"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -198,21 +275,25 @@ msgstr ""
 "Conservez les installateurs après avoir téléchargé un jeu.\n"
 "Les installateurs sont stockés dans : {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Conserver les installateurs : "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Coréen"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Langue : "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -224,47 +305,60 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Déconnexion"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr ""
+"Wine n'a pas été trouvé. L'affichage des jeux Windows ne peut pas être "
+"activé."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Aucun exécutable n'a été trouvé dans {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norvégien"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Norvégien Bokmål"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Norvégien Nynorsk"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr "Pas assez d'espace pour extraire le jeu. Requis : {} Disponible : {}"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "OK"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Ouvrir le dossier"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr "Jouer"
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Veuillez vérifier votre connexion Internet"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Polonais"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugais"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Préférences"
 
@@ -274,17 +368,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Préférences"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Langue préférée : "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Propriétés"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Propriétés de {}"
 
@@ -294,11 +388,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Rafraîchir la liste de jeux"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Russe"
 
@@ -308,18 +410,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Montrer les IPS en jeu :"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Montrer les jeux Windows : "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "Montrer les jeux cachés : "
@@ -330,37 +432,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Afficher uniquement les jeux installés"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Chinois simplifié"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Espagnol"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Espagnol"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Rester connecté :"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Boutique"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Support"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Suédois"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Système par défaut"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "L'installation de {} a échoué. Veuillez réessayer."
 
@@ -374,7 +481,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "La langue préférée au démarrage de Minigalaxy"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "La langue préférée au démarrage de Minigalaxy"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -382,136 +495,176 @@ msgstr ""
 "Il y a eu une erreur en essayant de récupérer le lien de téléchargement !\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "C'est ici que les jeux seront installés"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Chinois traditionnel"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Turc"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Ukrainien"
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Désinstaller"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "Désinstallation…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Mise à jour"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "Mise à jour…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Utilisez le thème sombre : "
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Paramètres variables :"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Version"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "Lorsque cette option est désactivée, il vous sera demandé de vous connecter "
 "à chaque démarrage de Minigalaxy"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Minigalaxy doit-il utiliser un thème sombre ou non"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Si les jeux Windows sont affichés dans la bibliothèque ou non"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Si les jeux cachés sont montrés dans la bibliothèque ou non"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr ""
 "Si les raccourcis sont créés pour les jeux nouvellement installés ou non"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "L'extraction de Wine a échoué."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "L'extraction de Wine a échoué."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr ""
 "Wine n'a pas été trouvé. L'affichage des jeux Windows ne peut pas être "
 "activé."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr ""
+"Wine n'a pas été trouvé. L'affichage des jeux Windows ne peut pas être "
+"activé."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "télécharger"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "téléchargement…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "dans la file d'attente…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "installer"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "installation…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "jouer"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "désinstallation…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "mise à jour…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} n'a pas pu être décompressé."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} n'a pas pu être téléchargé."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} n'est pas un chemin utilisable"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} a été corrompu. Veuillez le télécharger à nouveau."
 

--- a/data/po/it_IT.po
+++ b/data/po/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-05-25 19:07+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,32 +34,32 @@ msgctxt "about"
 msgid "About"
 msgstr "Informazioni"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr ""
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Sei sicuro di voler annullare lo scaricamento di {}?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Sei sicuro di voler disinstallare %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Portoghese Brasiliano"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -68,85 +68,131 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Cinese"
 
 # I don't know where it's used, so this translation might be wrong.
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 #, fuzzy
 msgid "Command flags:"
 msgstr "Opzione dei comandi"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Apertura della pagina del negozio non riuscita"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Apertura della pagina del negozio non riuscita"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Apertura della pagina del negozio non riuscita"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Apertura della pagina del negozio non riuscita"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Apertura della pagina di supporto non riuscita"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr ""
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Danese"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "scarica"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Errore di download"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "scaricando…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Olandese"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Inglese"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Installazione di {} fallita"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Recupero della libreria fallito"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Apertura di {} fallita:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Finlandese"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Francese"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr ""
+"Wine non è stato trovato. Non potrai abilitare la Visualizzazione dei giochi "
+"di Windows."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr ""
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Tedesco"
 
@@ -156,24 +202,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "Pagina di GitHub"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr ""
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "in coda…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr ""
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr ""
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Installati"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Percorso di installazione: "
@@ -184,15 +256,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Installati"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "installando…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italiano"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Giapponese"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -200,20 +277,24 @@ msgstr ""
 "Mantieni i file di installazione dopo aver scaricato un gioco.\n"
 "I file di installazione sono salvati in: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Mantieni file di installazione: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Coreano"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
+msgstr ""
+
+#: minigalaxy/constants.py:53
+msgid "List"
 msgstr ""
 
 #: minigalaxy/ui/login.py:20
@@ -226,49 +307,62 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Disconnettiti"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr ""
+"Wine non è stato trovato. Non potrai abilitare la Visualizzazione dei giochi "
+"di Windows."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Nessun eseguibile trovato in {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norvegese"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 #, fuzzy
 msgid "Norwegian Bokmål"
 msgstr "Norvegese"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 #, fuzzy
 msgid "Norwegian Nynorsk"
 msgstr "Norvegese"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr ""
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "OK"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Apri cartella"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Controlla la tua connessione a internet"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Polacco"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portoghese"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Impostazioni"
 
@@ -278,17 +372,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Impostazioni"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Lingua preferita: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Proprietà"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Proprietà di {}"
 
@@ -298,11 +392,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Aggiorna lista dei giochi"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Russo"
 
@@ -312,18 +414,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Salva"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Visualizza FPS in gioco:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Visualizza giochi di Windows: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 #, fuzzy
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
@@ -335,37 +437,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Visualizza solo i giochi installati"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr ""
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Spagnolo"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Spagnolo"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Mantieni l'accesso:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Negozio"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Supporto"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Svedese"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr ""
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "L'installazione di {} è fallita. Riprova."
 
@@ -380,7 +487,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "La lingua in cui si preferisce avere i giochi scaricati"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "La lingua in cui si preferisce avere i giochi scaricati"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -388,138 +501,177 @@ msgstr ""
 "C'è stato un errore cercando di recuperare il link per lo scaricamento!\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Qui è dove i giochi verranno installati"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr ""
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Turco"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr ""
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Disinstalla"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "disinstallando…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Aggiorna"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "aggiornando…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr ""
 
 # I don't know where it's used, so this translation might be wrong.
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 #, fuzzy
 msgid "Variable flags:"
 msgstr "Opzione delle variabili"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr ""
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "Se disabilitato ti verrà richiesto di fare l'accesso ogni volta che avvierai "
 "Minigalaxy"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr ""
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Se abilitato visualizza anche i giochi di Windows nella libreria"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 #, fuzzy
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Se abilitato visualizza anche i giochi di Windows nella libreria"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr ""
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+msgid "Wine executable:"
+msgstr ""
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr ""
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr ""
 "Wine non è stato trovato. Non potrai abilitare la Visualizzazione dei giochi "
 "di Windows."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr ""
+"Wine non è stato trovato. Non potrai abilitare la Visualizzazione dei giochi "
+"di Windows."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "scarica"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "scaricando…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "in coda…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "installa"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "installando…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "gioca"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "disinstallando…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "aggiornando…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "Estrazione di {} non riuscita."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "Scaricamento di {} fallito."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} non è un percorso utilizzabile"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} era corrotto. Riscaricalo."
 

--- a/data/po/it_IT.po
+++ b/data/po/it_IT.po
@@ -242,7 +242,7 @@ msgstr ""
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Installati"
+msgstr "installa"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -346,7 +346,7 @@ msgstr "Apri cartella"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "gioca"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/nb_NO.po
+++ b/data/po/nb_NO.po
@@ -238,7 +238,7 @@ msgstr "Innoextract er ikke innstallert."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Installert"
+msgstr "installer"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -337,7 +337,7 @@ msgstr "Åpne filer"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "spill"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/nb_NO.po
+++ b/data/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-22 12:15+0200\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-11-10 14:20+0100\n"
 "Last-Translator: Kim Malmo <berencamlost@msn.com>\n"
 "Language-Team: \n"
@@ -42,20 +42,20 @@ msgstr "Lagt til etter kommandoen brukt til å starte spillet"
 msgid "Added in front of the command used to launch the game"
 msgstr "Lagt til foran kommandoen brukt til å starte spillet"
 
-#: minigalaxy/ui/gametilelist.py:150 minigalaxy/ui/gametile.py:147
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Er du sikker på at du vil avbryte nedlastingen av {}?"
 
-#: minigalaxy/ui/window.py:98
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Er du sikker på at du vil logge ut av GOG?"
 
-#: minigalaxy/ui/gametilelist.py:163 minigalaxy/ui/gametile.py:160
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Er du sikker på at du vil avinstallere %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:31
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Brasiliansk Portugisisk"
 
@@ -72,7 +72,7 @@ msgstr "Avbryt"
 msgid "Check for updates:"
 msgstr "Se etter oppdateringer:"
 
-#: minigalaxy/constants.py:8
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Kinesisk"
 
@@ -80,16 +80,25 @@ msgstr "Kinesisk"
 msgid "Command flags:"
 msgstr "Kommando flagg:"
 
-#: minigalaxy/ui/information.py:72 minigalaxy/ui/information.py:82
-#: minigalaxy/ui/information.py:92
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Kunne ikke åpne butikksiden"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Kunne ikke åpne forumsiden"
+
+#: minigalaxy/ui/information.py:75
 msgid "Couldn't open forum page"
 msgstr "Kunne ikke åpne forumsiden"
 
-#: minigalaxy/ui/information.py:62
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Kunne ikke åpne butikksiden"
 
-#: minigalaxy/ui/information.py:52
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Kunne ikke åpne siden for støtte"
 
@@ -99,28 +108,38 @@ msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Lag menysnarvei: "
 
-#: minigalaxy/constants.py:32
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr "Tsjekkisk"
 
-#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:193
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "Tillegg"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Dansk"
 
-#: minigalaxy/ui/gametilelist.py:234 minigalaxy/ui/gametilelist.py:273
-#: minigalaxy/ui/gametile.py:231 minigalaxy/ui/gametile.py:270
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "last ned"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Feil ved nedlasting"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "laster ned…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Nederlandsk"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Engelsk"
 
@@ -128,7 +147,7 @@ msgstr "Engelsk"
 msgid "Facebook Login"
 msgstr "Facebook innlogging"
 
-#: minigalaxy/ui/preferences.py:122
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
@@ -136,20 +155,20 @@ msgstr ""
 "Kunne ikke forandre språk for programmet. Sørg for at lokasjonsdata er "
 "generert på systemet ditt."
 
-#: minigalaxy/ui/gametilelist.py:340 minigalaxy/ui/gametile.py:337
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Kunne ikke installere {}:"
 
-#: minigalaxy/ui/library.py:146
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Kunne ikke hente bibliotek"
 
-#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:134
-#: minigalaxy/ui/gametile.py:131
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Kunne ikke starte {}:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:35
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Finsk"
 
@@ -157,7 +176,7 @@ msgstr "Finsk"
 msgid "Forum"
 msgstr ""
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Fransk"
 
@@ -165,11 +184,11 @@ msgstr "Fransk"
 msgid "GameMode wasn't found. Using GameMode cannot be enabled."
 msgstr "GameMode ble ikke funnet. GameMode kan ikke aktiveres."
 
-#: minigalaxy/ui/information.py:138
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Sjanger"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:37
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Tysk"
 
@@ -179,11 +198,11 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "GitHub side"
 
-#: minigalaxy/constants.py:50
+#: minigalaxy/constants.py:47
 msgid "Greek"
 msgstr "Gresk"
 
-#: minigalaxy/constants.py:55
+#: minigalaxy/constants.py:52
 msgid "Grid"
 msgstr "Rutenett"
 
@@ -191,25 +210,35 @@ msgstr "Rutenett"
 msgid "Hide game:"
 msgstr "Skjul spill:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:223
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "i kø…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
 msgid "Information"
 msgstr "Informasjon"
 
-#: minigalaxy/ui/information.py:28
+#: minigalaxy/ui/information.py:29
 msgid "Information about {}"
 msgstr "Informasjon om {}"
 
-#: minigalaxy/installer.py:149
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Utpakking av Innoextract feilet."
 
-#: minigalaxy/installer.py:166
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract er ikke innstallert."
+
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Installert"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -223,15 +252,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Installert"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:38
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "installerer…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italiensk"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japansk"
 
-#: minigalaxy/ui/preferences.py:48
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -245,7 +279,7 @@ msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Behold installere: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Koreansk"
 
@@ -255,7 +289,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Språk: "
 
-#: minigalaxy/constants.py:56
+#: minigalaxy/constants.py:53
 msgid "List"
 msgstr "Liste"
 
@@ -277,19 +311,19 @@ msgstr "MangoHud ble ikke funnet. MangoHud kan ikke aktiveres."
 msgid "No executable was found in {}"
 msgstr "Ingen kjørbar fil funnet i {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norsk"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Norsk Bokmål"
 
-#: minigalaxy/constants.py:40
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Nynorsk"
 
-#: minigalaxy/installer.py:98
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr "Ikke nok plass til å pakke ut spillet. Trenger: {} Tilgjengelig: {}"
 
@@ -301,17 +335,21 @@ msgstr "Ok"
 msgid "Open files"
 msgstr "Åpne filer"
 
-#: minigalaxy/ui/information.py:53 minigalaxy/ui/information.py:63
-#: minigalaxy/ui/information.py:73 minigalaxy/ui/information.py:83
-#: minigalaxy/ui/information.py:93
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Vennligst sjekk internettforbindelsen din"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Polsk"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugisisk"
 
@@ -331,7 +369,7 @@ msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Foretrukket språk: "
 
-#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:238
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Egenskaper"
 
@@ -353,11 +391,11 @@ msgstr ""
 msgid "Reset wine executable"
 msgstr ""
 
-#: minigalaxy/constants.py:26 minigalaxy/constants.py:51
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
 msgid "Romanian"
 msgstr "Rumensk"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:42
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Russisk"
 
@@ -389,15 +427,15 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Vis kun installerte spill"
 
-#: minigalaxy/constants.py:43
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Simplifisert Kinesisk"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Spansk"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:42
 msgid "Spanish (Spain)"
 msgstr "Spansk (Spania)"
 
@@ -415,15 +453,15 @@ msgstr "Butikkside"
 msgid "Support"
 msgstr "Støtte"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Svensk"
 
-#: minigalaxy/constants.py:30
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Systemstandard"
 
-#: minigalaxy/installer.py:129
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Feil ved installasjon av {}. Vennligst prøv igjen."
 
@@ -442,7 +480,7 @@ msgctxt "view_tooltip"
 msgid "The preferred view of game library"
 msgstr "Foretrukket visning av spillbibliotek"
 
-#: minigalaxy/ui/gametilelist.py:235 minigalaxy/ui/gametile.py:232
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -455,25 +493,35 @@ msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Dette er hvor spill vil bli installert"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Tradisjonell Kinesisk"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:48
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Tyrkisk"
 
-#: minigalaxy/constants.py:49
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Ukrainsk"
 
-#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Avinstaller"
 
-#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:172
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "avinstallerer…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Oppdater"
+
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "oppdaterer…"
 
 #: data/ui/properties.ui:178
 msgid "Use GameMode:"
@@ -493,7 +541,7 @@ msgstr "Bruk mørkt tema: "
 msgid "Variable flags:"
 msgstr "Variable flagg:"
 
-#: minigalaxy/ui/information.py:140
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Versjon"
 
@@ -533,11 +581,11 @@ msgstr "Om snarveier blir opprettet for nylig innstallerte spill eller ikke"
 msgid "Wine executable:"
 msgstr "Kjørbar fil for Wine:"
 
-#: minigalaxy/installer.py:180
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Utpakking av Wine feilet."
 
-#: minigalaxy/ui/preferences.py:192
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr "Wine ble ikke funnet. Visning av Windows spill kan ikke aktiveres."
 
@@ -553,56 +601,55 @@ msgstr ""
 msgid "Winetricks wasn't found and cannot be used."
 msgstr "Winetricks ble ikke funnet. Winetricks kan ikke aktiveres."
 
-#: minigalaxy/ui/gametilelist.py:507 minigalaxy/ui/gametile.py:504
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "last ned"
 
-#: minigalaxy/ui/gametilelist.py:547 minigalaxy/ui/gametile.py:544
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "laster ned…"
 
-#: minigalaxy/ui/gametilelist.py:538 minigalaxy/ui/gametile.py:535
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "i kø…"
 
-#: minigalaxy/ui/gametilelist.py:526 minigalaxy/ui/gametile.py:523
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "installer"
 
-#: minigalaxy/ui/gametilelist.py:558 minigalaxy/ui/gametile.py:555
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "installerer…"
 
-#: minigalaxy/ui/gametilelist.py:573 minigalaxy/ui/gametilelist.py:603
-#: minigalaxy/ui/gametile.py:570 minigalaxy/ui/gametile.py:600
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "spill"
 
-#: minigalaxy/ui/gametilelist.py:589 minigalaxy/ui/gametile.py:586
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "avinstallerer…"
 
-#: minigalaxy/ui/information.py:134
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "ukjent"
 
-#: minigalaxy/ui/gametilelist.py:612 minigalaxy/ui/gametile.py:609
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "oppdaterer…"
 
-#: minigalaxy/installer.py:131
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} kunne ikke pakkes ut."
 
-#: minigalaxy/installer.py:74
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} kunne ikke lastes ned."
 
-#: minigalaxy/ui/preferences.py:204
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} er ikke en brukbar sti"
 
-#: minigalaxy/installer.py:86
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} ble ødelagt. Vennligst last ned på nytt."
 

--- a/data/po/nl.po
+++ b/data/po/nl.po
@@ -242,7 +242,7 @@ msgstr "Innoextract is niet geïnstalleerd."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Geïnstalleerd"
+msgstr "installeren"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -344,7 +344,7 @@ msgstr "Bestanden openen"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "spelen"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/nl.po
+++ b/data/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: minigalaxy 0.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-09-30 11:00+0200\n"
 "Last-Translator: Wouter Wijsman <wwijsman@live.nl>\n"
 "Language-Team: Dutch\n"
@@ -34,34 +34,34 @@ msgctxt "about"
 msgid "About"
 msgstr "Over Minigalaxy"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr ""
 "Wordt aan het commando dat gebruikt wordt om de game te starten toegevoegd"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr ""
 "Wordt voor het commando dat gebruikt wordt om de game te starten toegevoegd"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Weet je zeker dat je de {} download wilt stoppen?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Weet je zeker dat je uit wilt loggen?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Weet je zeker dat je %s wilt verwijderen?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Braziliaans-Portugees"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -70,83 +70,129 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Chinees"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Commando flaggetjes:"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "De pagina kon niet worden geopend"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "De pagina kon niet worden geopend"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "De pagina kon niet worden geopend"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "De pagina kon niet worden geopend"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "De ondersteuningspagina kon niet worden geopend"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Maak menusnelkoppelingen: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Deens"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "download"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Downloadfout"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "downloaden…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Engels"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Kon {} niet geïnstalleerd worden:"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "De lijst me games kon niet opgehaald worden"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Kon {} niet starten:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Fins"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Frans"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr ""
+"Wine kon niet gevonden worden. Het tonen van Windows games kan niet aangezet "
+"worden."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Genre"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Duits"
 
@@ -156,24 +202,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "GitHub pagina"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Verberg game:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Hongaars"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "in de wachtrij…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Innoextract kon de game niet uitpakken."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract is niet geïnstalleerd."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Geïnstalleerd"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Installatiepad: "
@@ -184,15 +256,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Geïnstalleerd"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "installeren…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italiaans"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japans"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -200,21 +277,25 @@ msgstr ""
 "Behoud installatiebestanden nadat een game is gedownload.\n"
 "Installatie bestanden worden opgeslagen in: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Behoud installatiebestanden: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Koreaans"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Taal: "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -226,47 +307,60 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Uitloggen"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr ""
+"Wine kon niet gevonden worden. Het tonen van Windows games kan niet aangezet "
+"worden."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Geen programma gevonden in {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Noors"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Noors (Bokmål)"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Noors (Nynorsk)"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr "Niet genoeg ruimt om"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "OK"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Bestanden openen"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Controleer je internetverbinding"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Pools"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugees"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Voorkeuren"
 
@@ -276,17 +370,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Voorkeurstaal: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Instellingen"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Instellingen van {}"
 
@@ -296,11 +390,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Haal gamelijst opnieuw op"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Russisch"
 
@@ -310,18 +412,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Opslaan"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Laat FPS zijn tijdens het spelen:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Toon games voor Windows: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "Toon verborgen games: "
@@ -332,37 +434,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Laat alleen geïnstalleerde games zien"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Vereenvoudigd Chinees"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Spaans"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Spaans"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Blijf ingelogd:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Winkelpagina"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Ondersteuning"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Zweeds"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Systeemsstandard"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "De installatie van {} is mislukt. Probeer het opnieuw."
 
@@ -376,7 +483,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "De voorkeurstaal voorMinigalaxy bij het starten"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "De voorkeurstaal voorMinigalaxy bij het starten"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -384,137 +497,177 @@ msgstr ""
 "Er is een fout opgetreden bij het ophalen van de downloadlink!\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Dit is waar games geinstalleerd worden"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Traditioneel Chinees"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Turks"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Oekraïens"
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Verwijderen"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "verwijderen…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Update"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "updaten…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Gebruik donker thema: "
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Variabelen:"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Versie"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "Als deze optie uitgeschakeld is, zal Minigalaxy altijd het inlogscherm tonen "
 "bij het opstarten"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Of Minigalaxy een donkerder thema gebruikt of niet"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Of Windows games zichtbaar zijn in de bibliotheek"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Of verborgen games zichtbaar zijn in de bibliotheek"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr ""
 "Of snelkoppelingen in het menu van het besturingssysteem aangemaakt worden "
 "voor nieuw geïnstalleerde games"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Het uitpakken met wine is mislukt."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Het uitpakken met wine is mislukt."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr ""
 "Wine kon niet gevonden worden. Het tonen van Windows games kan niet aangezet "
 "worden."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr ""
+"Wine kon niet gevonden worden. Het tonen van Windows games kan niet aangezet "
+"worden."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "download"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "downloaden…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "in de wachtrij…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "installeren"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "installeren…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "spelen"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "verwijderen…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "updaten…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} kan niet uitgepakt worden."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} kon niet gedownload worden."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} is geen bruikbaar pad"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} is beschadigd. Download het opnieuw."
 

--- a/data/po/nn_NO.po
+++ b/data/po/nn_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-10-04 11:33+0200\n"
 "Last-Translator: Jan Kjetil Myklebust\n"
 "Language-Team: \n"
@@ -34,32 +34,32 @@ msgctxt "about"
 msgid "About"
 msgstr "Om"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Lagt til bakom kommandoen som er brukt for å starte spelet"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Lagt til framføre kommandoen som er brukt for å starte spelet"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Er du sikker på at du vil avbryte nedlastinga av {}?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Er du sikker på at du vil logge ut av GOG?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Er du sikker på at du vil avinstallere %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Brasiliansk Portugisisk"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -68,83 +68,127 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Kinesisk"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Kommandolinjeflagg:"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Kunne ikkje opne produktsida"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Kunne ikkje opne produktsida"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Kunne ikkje opne produktsida"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Kunne ikkje opne produktsida"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Kunne ikkje opne hjelpesida"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Opprett menysnarvegar: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Dansk"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "last ned"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Nedlastingsfeil"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "lastar ned…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Nederlandsk"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Engelsk"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Klarte ikkje å installere {}"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Klarte ikkje å hente bibliotek"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Klarte ikkje å starte {}:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Finsk"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Fransk"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr "Fann ikkje Wine. Kan ikkje skru på vising av Windows-spel."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Sjanger"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Tysk"
 
@@ -154,24 +198,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "GitHub-side"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Skjul spel:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "i kø…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Innoextract utpakking feila."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract er ikkje installert."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Installert"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Installasjonssti: "
@@ -182,15 +252,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Installert"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "installerar…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italiensk"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japansk"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -198,21 +273,25 @@ msgstr ""
 "Behalde installeringsfiler etter nedlasting av spel.\n"
 "Installerarar ligg under: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Behalde installerarar: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Koreansk"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Språk: "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -224,47 +303,58 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Logg ut"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr "Fann ikkje Wine. Kan ikkje skru på vising av Windows-spel."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Inga køyrbar fil funnen i {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norsk"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Norsk Bokmål"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Norsk Nynorsk"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr "Ikkje nok plass til å pakke ut spelet. Trengs: {} Tilgjengeleg: {}"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "OK"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Opne filer"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Ver venleg og sjekk internettilkoplinga di"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Polsk"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugisisk"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Brukarval"
 
@@ -274,17 +364,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Brukarval"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Foretrukke språk: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Eigenskapar"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Eigenskapar for {}"
 
@@ -294,11 +384,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Oppdater spelelista"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Russisk"
 
@@ -308,18 +406,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Lagre"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Vis FPS i spelet:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Vis spel for Windows: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "Vis spel for Windows: "
@@ -330,37 +428,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Vis berre installerte spel"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Foreinkla Kinesisk"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Spansk"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Spansk"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Bli verande pålogga:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Produktside"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Støtte"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Svensk"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "System standardverdi"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Installasjonen av {} feila. Ver venleg og prøv på nytt."
 
@@ -374,7 +477,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "Foretrukke språk ved oppstart av Minigalaxy"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "Foretrukke språk ved oppstart av Minigalaxy"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -382,132 +491,170 @@ msgstr ""
 "Ein feil oppstod ved henting av nedlastingslink!\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Spel vil verte installerte her"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Tradisjonell kinesisk"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Tyrkisk"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Ukrainsk"
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Avinstaller"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "avinstallerar…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Oppdater"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "oppdaterar…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Bruk mørkt tema: "
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Variabelflagg:"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Versjon"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "Viss deaktivert vil du bli spurd om å logge på kvar gong Minigalaxy starter"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Om Minigalaxy skal nytte mørtk tema eller ikkje"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Om spel for Windows vert vist i biblioteket eller ikkje"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Om skjulte spel vert vist i biblioteket eller ikkje"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr "Om snarvegar blir oppretta for nyinstallerte spel eller ikkje"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Wine utpakking feila."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Wine utpakking feila."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr "Fann ikkje Wine. Kan ikkje skru på vising av Windows-spel."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr "Fann ikkje Wine. Kan ikkje skru på vising av Windows-spel."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "last ned"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "lastar ned…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "i kø…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "installer"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "installerar…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "spel"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "avinstallerar…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "oppdaterar…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} kunne ikkje pakkast ut."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} kunne ikkje lastast ned."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} er ikkje ein brukbar sti"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} var korrumpert. Ver venleg å last den ned på ny."
 

--- a/data/po/nn_NO.po
+++ b/data/po/nn_NO.po
@@ -238,7 +238,7 @@ msgstr "Innoextract er ikkje installert."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Installert"
+msgstr "installer"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -338,7 +338,7 @@ msgstr "Opne filer"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "spel"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/pl.po
+++ b/data/po/pl.po
@@ -241,7 +241,7 @@ msgstr "Innoextract nie jest zainstalowany."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Zainstalowane"
+msgstr "zainstaluj"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -343,7 +343,7 @@ msgstr "Otwórz pliki"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "graj"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/pl.po
+++ b/data/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-09-30 10:17+0200\n"
 "Last-Translator: \n"
 "Language-Team: Artur Wróblewski\n"
@@ -35,32 +35,32 @@ msgctxt "about"
 msgid "About"
 msgstr "O programie"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Dodano na końcu polecenie służące do uruchomienia gry"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Dodano przed komendą służącą do uruchomienia gry"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Czy na pewno chcesz anulować pobieranie {}?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Czy na pewno chcesz wylogować się z GOG?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Czy na pewno chcesz odinstalować %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Portugalski brazylijski"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -69,83 +69,129 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Chiński"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Flagi poleceń:"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Nie można otworzyć strony w sklepie"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Nie można otworzyć strony w sklepie"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Nie można otworzyć strony w sklepie"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Nie można otworzyć strony w sklepie"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Nie można otworzyć strony pomocy technicznej"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Utwórz skróty w menu: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Duński"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "pobierz"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Błąd pobierania"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "pobieranie…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Holenderski"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Angielski"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Instalacja {} nie powiodła się"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Nie można pobrać biblioteki"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Nie można uruchomić {}:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Fiński"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Francuski"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr ""
+"Wine nie został znaleziony. Nie można włączyć wyświetlania gier systemu "
+"Windows."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Gatunek"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Niemiecki"
 
@@ -155,24 +201,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "Strona GitHub"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Ukryj grę:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Węgierski"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "w kolejce…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Ekstrakcja Innoextract nie powiodła się."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract nie jest zainstalowany."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Zainstalowane"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Ścieżka instalacji: "
@@ -183,15 +255,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Zainstalowane"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "instalowanie…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Włoski"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japoński"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -199,21 +276,25 @@ msgstr ""
 "Zachowaj pliki instalacyjne po pobraniu gry.\n"
 "Pliki instalacyjne są przechowywane w: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Zachowaj pliki instalacyjne: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Koreański"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Język: "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -225,47 +306,60 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Wyloguj"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr ""
+"Wine nie został znaleziony. Nie można włączyć wyświetlania gier systemu "
+"Windows."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Nie znaleziono pliku wykonywalnego w {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norweski"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Norweski Bokmål"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Norweski Nynorsk"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr ""
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "OK"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Otwórz pliki"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Sprawdź swoje połączenie internetowe"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Polski"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Ustawienia"
 
@@ -275,17 +369,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Ustawienia"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Preferowany język: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Właściwości"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Właściwości {}"
 
@@ -295,11 +389,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Odśwież listę gier"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Rosyjski"
 
@@ -309,18 +411,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Zapis"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Pokaż FPS w grze:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Wyświetl gry dla Systemu Windows: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "Pokaż ukryte gry: "
@@ -331,37 +433,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Pokaż tylko zainstalowane gry"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Chiński uproszczony"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Hiszpański"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Hiszpański"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Pozostań zalogowany:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Sklep"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Wsparcie"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Szwedzki"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Domyślny systemu"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Instalacja {} zakończona niepowodzeniem. Proszę spróbować ponownie."
 
@@ -375,7 +482,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "Preferowany język podczas uruchamiania Minigalaxy"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "Preferowany język podczas uruchamiania Minigalaxy"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -383,137 +496,177 @@ msgstr ""
 "Wystąpił błąd podczas próby pozyskania linku do pobrania!\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "W tym miejscu zostaną zainstalowane gry"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Chinski tradycyjny"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Turecki"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr ""
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Odinstaluj"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "odinstalowywanie…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Aktualizuj"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "aktualizowanie..."
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Użyj ciemnego motywu: "
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Flagi zmienne:"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Wersja"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "Po wyłączeniu zostanie wyświetlony monit o zalogowanie się przy każdym "
 "uruchomieniu Minigalaxy"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Czy Minigalaxy ma używać ciemnego motywu, czy nie"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr ""
 "Czy gry natywnie przeznaczone dla systemu Windows mają być wyświetlane w "
 "bibliotece, czy nie"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Czy ukryte gry są wyświetlane w bibliotece, czy nie"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr "Czy skróty mają być tworzone dla nowo zainstalowanych gier, czy nie"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Ekstrakcja Wine nie powiodła się."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Ekstrakcja Wine nie powiodła się."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr ""
 "Wine nie został znaleziony. Nie można włączyć wyświetlania gier systemu "
 "Windows."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr ""
+"Wine nie został znaleziony. Nie można włączyć wyświetlania gier systemu "
+"Windows."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "pobierz"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "pobieranie…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "w kolejce…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "zainstaluj"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "instalowanie…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "graj"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "odinstalowywanie…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "aktualizowanie..."
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} nie można rozpakować."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} nie udało się pobrać."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} nie jest poprawną ścieżką"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} jest uszkodzony. Pobierz go ponownie."
 

--- a/data/po/pt_BR.po
+++ b/data/po/pt_BR.po
@@ -239,7 +239,7 @@ msgstr ""
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Instalados"
+msgstr "Instalar"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -340,7 +340,7 @@ msgstr "Abrir arquivos"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "Jogar"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/pt_BR.po
+++ b/data/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2020-11-17 03:06-0300\n"
 "Last-Translator: Esdras Tarsis <esdrastarsis@gmail.com>\n"
 "Language-Team: \n"
@@ -34,32 +34,32 @@ msgctxt "about"
 msgid "About"
 msgstr "Sobre"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr ""
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Tem certeza de que deseja cancelar o download do game {}?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Você tem certeza de que deseja desinstalar %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Português Brasileiro"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 #, fuzzy
 msgid "Cancel"
 msgstr "Cancelar"
@@ -69,84 +69,127 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Chinês"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr ""
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Não foi possível abrir a página de suporte"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Não foi possível abrir a página de suporte"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Não foi possível abrir a página de suporte"
+
+#: minigalaxy/ui/information.py:65
 #, fuzzy
 msgid "Couldn't open store page"
 msgstr "Não foi possível abrir a página de suporte"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Não foi possível abrir a página de suporte"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr ""
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "Baixar"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Erro ao baixar"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "Baixando…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Holandês"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Inglês"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Falha ao instalar {}"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Falha ao recuperar a biblioteca"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Falha ao iniciar {}:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Francês"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr ""
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr ""
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Alemão"
 
@@ -156,24 +199,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "Página no GitHub"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr ""
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "na fila…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr ""
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr ""
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Instalados"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Caminho de instalação: "
@@ -184,15 +253,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Instalados"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "Instalando…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italiano"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japonês"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -200,20 +274,24 @@ msgstr ""
 "Manter instaladores após baixar um jogo.\n"
 "Instaladores são armazenados em: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Manter instaladores: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Coreano"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
+msgstr ""
+
+#: minigalaxy/constants.py:53
+msgid "List"
 msgstr ""
 
 #: minigalaxy/ui/login.py:20
@@ -226,49 +304,59 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Logout"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr ""
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Nenhum executável foi encontrado em {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norueguês"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 #, fuzzy
 msgid "Norwegian Bokmål"
 msgstr "Norueguês"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 #, fuzzy
 msgid "Norwegian Nynorsk"
 msgstr "Norueguês"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr ""
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr ""
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Abrir arquivos"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Por favor, verifique sua conexão à internet"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Polonês"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Português"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Preferências"
 
@@ -278,17 +366,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Preferências"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Idioma preferido: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr ""
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr ""
 
@@ -298,11 +386,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Recarregar lista de jogos"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr ""
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Russo"
 
@@ -312,19 +408,19 @@ msgctxt "save"
 msgid "Save"
 msgstr "Salvar"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 #, fuzzy
 msgid "Show FPS in game:"
 msgstr "Mostrar FPS nos jogos:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Mostrar jogos para Windows: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 #, fuzzy
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
@@ -336,39 +432,44 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Mostrar apenas jogos instalados"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr ""
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Espanhol"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Espanhol"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Permanecer conectado:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 #, fuzzy
 msgid "Store"
 msgstr "Página da Loja"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 #, fuzzy
 msgid "Support"
 msgstr "Suporte"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Sueco"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr ""
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "A instalação de {} falhou. Por favor tente novamente."
 
@@ -383,7 +484,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "O idioma preferido para baixar os jogos"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "O idioma preferido para baixar os jogos"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -391,136 +498,172 @@ msgstr ""
 "Ocorreu um erro ao tentar obter o link de download!\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "É onde os jogos serão instalados"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr ""
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Turco"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr ""
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 #, fuzzy
 msgid "Uninstall"
 msgstr "Desinstalar"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "Desinstalando…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 #, fuzzy
 msgid "Update"
 msgstr "Atualizar"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "Atualizando…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr ""
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr ""
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr ""
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "Quando desativado, você será solicitado a fazer login sempre que o "
 "Minigalaxy for iniciado"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr ""
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Mostrar jogos para Windows na biblioteca ou não"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 #, fuzzy
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Mostrar jogos para Windows na biblioteca ou não"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr ""
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+msgid "Wine executable:"
+msgstr ""
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr ""
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr ""
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+msgid "Winetricks wasn't found and cannot be used."
+msgstr ""
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "Baixar"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "Baixando…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "na fila…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "Instalar"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "Instalando…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "Jogar"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "Desinstalando…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "Atualizando…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} não pode ser descompactado."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} falhou ao realizar o download."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} não é um caminho utilizável"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} está corrompido. Por favor faça o download novamente."
 

--- a/data/po/ro.po
+++ b/data/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-09-29 19:02+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,8 +16,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #. A short description of what Minigalaxy is
 #: data/ui/about.ui:10
@@ -35,32 +35,32 @@ msgctxt "about"
 msgid "About"
 msgstr "Despre"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Adăugat la sfârșitul comenzii folosită pentru pornirea jocului"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Adăugat în fața comenzii folosită pentru pornirea jocului"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Ești sigur că vrei să oprești descărcarea jocului {}?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Ești sigur că vrei să te deconectezi din GOG?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Ești sigur că vrei să dezinstalezi %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Portugheză Braziliană"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Anulează"
 
@@ -69,84 +69,129 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Anulează"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Chineză"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Flag-uri comandă:"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Nu s-a putut deschide pagina magazinului"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Nu s-a putut deschide pagina magazinului"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Nu s-a putut deschide pagina magazinului"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Nu s-a putut deschide pagina magazinului"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Nu s-a putut deschide pagina de suport"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Creează scurtături meniu: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr "Ceh"
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Danez"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "descarcă"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Eroare de descărcare"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "se descarcă…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Olandeză"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Engleză"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
-msgstr "Nu s-a putut schimba limba programului. Asigură-te că locale-ul este generat"
-"în sistemul tău"
+msgstr ""
+"Nu s-a putut schimba limba programului. Asigură-te că locale-ul este "
+"generatîn sistemul tău"
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Nu s-a putut instala {}"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Nu s-a putut descărca libraria"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Nu s-a putut porni {}:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Finlandeză"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Franceză"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr "Wine nu a fost găsit. Arătarea jocurilor Windows nu poate fi pornită."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Gen"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Germană"
 
@@ -156,24 +201,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "Pagină GitHub"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Ascunde joc:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Maghiară"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "în coadă…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Nu s-a putut extrage innoextract."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract nu s-a instalat."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Instalat"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Locație instalare: "
@@ -184,15 +255,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Instalat"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "se instalează…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italiană"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japoneză"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -200,21 +276,25 @@ msgstr ""
 "Ține installer-urile dupa descărcarea unui joc\n"
 "Installerele sunt salvate în: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Ține installerele: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Koreană"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Limbă: "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -226,47 +306,59 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Deconectare"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr "Wine nu a fost găsit. Arătarea jocurilor Windows nu poate fi pornită."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Nici-un executabil nu a fost găsit în {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norvegiană"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Norvegiană Bokmål"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Norvegiană Nynorsk"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
-msgstr "Nu-i destul de mult spațiu pentru extragerea jocului. Necesar: {} Valabil: {}"
+msgstr ""
+"Nu-i destul de mult spațiu pentru extragerea jocului. Necesar: {} Valabil: {}"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "ОК"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Deschide fișiere"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Te rog verifică conexiunea la internet"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Poloneză"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugheză"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Preferințe"
 
@@ -276,17 +368,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Preferințe"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Limbaj preferat pentru joc: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Proprietăți"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Proprietățile {}"
 
@@ -296,11 +388,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Reîmprospătează listă jocuri"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr "Română"
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Rusă"
 
@@ -310,18 +410,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Salvează"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Arată FPS în joc:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Arată jocuri Windows: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "Arată jocuri ascunse: "
@@ -332,37 +432,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Arată doar jocurile instalate"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Chineză Simplificată"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Spaniolă"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Spaniolă"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Rămâi conectat:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Magazin"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Suport"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Suedeză"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Implicit sistemului"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Instalarea a eșuat. Te rog incearcă din nou."
 
@@ -376,7 +481,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "Limbajul preferat la deschiderea Minigalaxy-ului"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "Limbajul preferat la deschiderea Minigalaxy-ului"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -384,137 +495,170 @@ msgstr ""
 "A fost o eroare la luat-ul linkului de descărcare!\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Aici vor fi jocurile descărcate"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Chineză Tradițională"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Turcă"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Ukraineană"
 
-#: minigalaxy/constants.py:26 minigalaxy/constants.py:51
-msgid "Romanian"
-msgstr "Română"
-
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Dezinstalează"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "se dezinstalează…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Actualizează"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "se actualizează…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Folosește mod întunecat"
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Flag-uri variabile:"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Versiune"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
-"Cât timp este dezactivat, vei fi întrebat de fiecare dată când Minigalaxy se deschide "
-"să te autentifici"
+"Cât timp este dezactivat, vei fi întrebat de fiecare dată când Minigalaxy se "
+"deschide să te autentifici"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Dacă Minigalaxy să folosească modul întunecat sau nu"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Dacă jocurile Windows sunt afișate în librărie sau nu"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Dacă jocurile ascunse sunt afișate în librărie sau nu"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr "Dacă scurtăturile sunt create pentru jocuri nou-instalate sau nu"
-""
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Extragerea Wine a eșuat."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Extragerea Wine a eșuat."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr "Wine nu a fost găsit. Arătarea jocurilor Windows nu poate fi pornită."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr "Wine nu a fost găsit. Arătarea jocurilor Windows nu poate fi pornită."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "descarcă"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "se descarcă…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "în coadă…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "instalează"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "se instalează…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "joacă"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "se dezinstalează…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "necunoscut"
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "se actualizează…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} nu poate fi unzipped."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "Nu s-a putut descărca {}."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} nu este o locație validă"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} este corupt. Te rog descarcă din nou."

--- a/data/po/ro.po
+++ b/data/po/ro.po
@@ -241,7 +241,7 @@ msgstr "Innoextract nu s-a instalat."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Instalat"
+msgstr "instalează"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -342,7 +342,7 @@ msgstr "Deschide fișiere"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "joacă"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/ru_RU.po
+++ b/data/po/ru_RU.po
@@ -242,7 +242,7 @@ msgstr "Не установлен Innoextract."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Установленные"
+msgstr "установить"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -342,7 +342,7 @@ msgstr "Открыть файлы"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "играть"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/ru_RU.po
+++ b/data/po/ru_RU.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-11-05 18:00+0300\n"
 "Last-Translator: Artem Polishchuk <ego.cordatus@gmail.com>\n"
 "Language-Team: \n"
@@ -17,8 +17,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.4.1\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #. A short description of what Minigalaxy is
 #: data/ui/about.ui:10
@@ -36,32 +36,32 @@ msgctxt "about"
 msgid "About"
 msgstr "О Minigalaxy"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Добавляется в конце команды запуска игры"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Добавляется в начале команды запуска игры"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Вы уверены, что хотите отменить загрузку {}?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Вы уверены, что хотите выйти из GOG?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Вы уверены, что хотите удалить %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Бразильский португальский"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Отменить"
 
@@ -70,53 +70,87 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Отменить"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Китайский"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Флаги команд:"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Не удалось открыть страницу магазина"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Не удалось открыть страницу магазина"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Не удалось открыть страницу магазина"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Не удалось открыть страницу магазина"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Не удалось открыть страницу поддержки"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Создавать ярлыки в меню: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr "Чешский"
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "Дополнения"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Датский"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "загрузить"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Ошибка загрузки"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "загрузка…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Нидерландский"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Английский"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
@@ -124,31 +158,41 @@ msgstr ""
 "Не удалось изменить язык программы. Убедитесь, что на вашей системе "
 "сгенерирована локаль."
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Не удалось установить {}"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Не удалось получить библиотеку"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Не удалось запустить {}:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Финский"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Французский"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr "Wine не найден. Отображение игр для Windows не может быть включено."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Жанр"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Немецкий"
 
@@ -158,24 +202,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "Страница на GitHub"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Скрывать игру:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Венгерский"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "в очереди…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Не удалось извлечь игру с помощью Innoextract."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Не установлен Innoextract."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Установленные"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Путь установки: "
@@ -186,15 +256,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Установленные"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "установка…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Итальянский"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Японский"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -202,21 +277,25 @@ msgstr ""
 "Сохранять файлы установки после загрузки игры.\n"
 "Файлы установки хранятся в: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Сохранять файлы установки: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Корейский"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Язык: "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -228,47 +307,58 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Выйти"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr "Wine не найден. Отображение игр для Windows не может быть включено."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Не найден запускаемый файл в {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Норвежский"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Норвежский букмол"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Норвежский нюнорск"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr "Недостаточно места для извлечения игры. Требуется: {} Доступно: {}"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr ""
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Открыть файлы"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Проверьте ваше подключение к Интернету"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Польский"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Португальский"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Настройки"
 
@@ -278,17 +368,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Настройки"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Предпочтительный язык игр: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Свойства"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Свойства {}"
 
@@ -298,11 +388,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Обновить список игр"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr ""
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Русский"
 
@@ -312,18 +410,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Сохранить"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Показывать FPS в игре:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Показывать игры для Windows: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "Показывать скрытые игры: "
@@ -334,37 +432,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Показывать только установленные игры"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Китайский упрощенный"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Испанский"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Испанский"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Не выходить из системы:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Магазин"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Поддержка"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Шведский"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Системный по умолчанию"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Не удалось установить {}. Попробуйте ещё раз."
 
@@ -378,7 +481,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "Язык, на котором вы хотите запускать Minigalaxy"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "Язык, на котором вы хотите запускать Minigalaxy"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -386,132 +495,170 @@ msgstr ""
 "Произошла ошибка при получении ссылки для скачивания!\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Место, куда будут установлены игры"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Китайский традиционный"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Турецкий"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Украинский"
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Удалить"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "удаление…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Обновить"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "обновление…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Использовать темную тему: "
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Переменные-флаги:"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Версия"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "Если эта опция отключена, вам придется всегда входить в GOG при запуске "
 "Minigalaxy"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Использовать темную тему для Minigalaxy или нет"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Показывать игры для Windows в библиотеке или нет"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Показывать скрытые игры в библиотеке или нет"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr "Создавать ярлыки для недавно установленных игр или нет"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Не удалось извлечь игру с помощью Wine."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Не удалось извлечь игру с помощью Wine."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr "Wine не найден. Отображение игр для Windows не может быть включено."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr "Wine не найден. Отображение игр для Windows не может быть включено."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "загрузить"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "загрузка…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "в очереди…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "установить"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "установка…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "играть"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "удаление…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "обновление…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "Не удалось распаковать {}."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "Не удалось загрузить {}."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "Невозможно использовать {} для установки"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} поврежден. Пожалуйста, загрузите заново."

--- a/data/po/sv_SE.po
+++ b/data/po/sv_SE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-10-01 12:46+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,32 +34,32 @@ msgctxt "about"
 msgid "About"
 msgstr "Om"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Läggs till vid slutet av kommandot som används för att starta spelet"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Läggs till vid början av kommandot som används för att starta spelet"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Är du säker på att du vill avbryta nedladdningen av {}?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Är du säker på att du vill logga ut från GOG?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Är du säker på att du vill avinstallera %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Brasiliansk portugisiska"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -68,83 +68,127 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Kinesiska"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Kommandoflaggor:"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Kunde inte öppna butikssidan"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Kunde inte öppna butikssidan"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Kunde inte öppna butikssidan"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Kunde inte öppna butikssidan"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Kunde inte öppna supportsidan"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Skapa menygenvägar: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "Nedladdningsbart innehåll"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Danska"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "ladda ner"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Nedladdningsfel"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "laddar ner…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Nederländska"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Engelska"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Misslyckades att installera {}"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Misslyckades att hämta bibliotek"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Misslyckades att starta {}:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Finska"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Franska"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr "Wine kunde inte hittas. Visning av Windowsspel kan inte slås på."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Genre"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Tyska"
 
@@ -154,24 +198,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "GitHub sida"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Göm spel:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Ungerska"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "i kö…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Innoextract-extraheringen misslyckades."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract är inte installerat."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Installerade"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Installationssökväg: "
@@ -182,15 +252,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Installerade"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "installerar…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Italienska"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japanska"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -198,21 +273,25 @@ msgstr ""
 "Behåll installationsprogram efter spel är nedladdade.\n"
 "Installationsprogram sparas i: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Behåll installationsprogram: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Koreanska"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Språk: "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -224,50 +303,61 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Logga ut"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr "Wine kunde inte hittas. Visning av Windowsspel kan inte slås på."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "Ingen körbar fil hittades i {}"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norska"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Bokmål"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Nynorska"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr ""
 "Det finns inte tillräckligt mycket utrymme för att packa upp spelet. Behövs: "
 "{} Tillgängligt: {}"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 #, fuzzy
 msgid "OK"
 msgstr "OK"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Öppna filer"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Var god kontrollera din internetanslutning"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Polska"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portugisiska"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Inställningar"
 
@@ -277,17 +367,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Inställningar"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Föredraget språk: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Egenskaper"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Egenskaper för {}"
 
@@ -297,11 +387,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Uppdatera spellistan"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Ryska"
 
@@ -311,18 +409,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Spara"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Visa bilder per sekund (FPS) i spel:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Visa Windowsspel: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "Visa gömda spel: "
@@ -333,37 +431,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Visa endast installerade spel"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Förenklad kinesiska"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Spanska"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Spanska"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Håll mig inloggad:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Butikssida"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Support"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Svenska"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Standardvärde för systemet"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Installationen av {} misslyckades. Var god försök igen."
 
@@ -377,7 +480,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "Det föredragna språket vid uppstart av Minigalaxy"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "Det föredragna språket vid uppstart av Minigalaxy"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -385,133 +494,171 @@ msgstr ""
 "Ett fel uppstod när ledladdningslänken hämtades\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Detta är var spel kommer installeras"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Traditionell kinesiska"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Turkiska"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "Ukrainska"
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Avinstallera"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "avinstallerar…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Uppdatera"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "uppdaterar…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Använd mörkt tema: "
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Variabelflaggor:"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Version"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "När detta är avstängt kommer du bli frågad att logga in varje gång "
 "Minigalaxy startas"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Om Minigalaxy ska använda mörkt tema eller inte"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Om Windowsspel ska visas i biblioteket eller inte"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Om gömda spel ska visas i biblioteket eller inte"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr "Om genvägar ska skapas för nyinstallerade spel eller inte"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Extrahering av Wine misslyckades."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Extrahering av Wine misslyckades."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr "Wine kunde inte hittas. Visning av Windowsspel kan inte slås på."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr "Wine kunde inte hittas. Visning av Windowsspel kan inte slås på."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "ladda ner"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "laddar ner…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "i kö…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "installera"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "installerar…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "spela"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "avinstallerar…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "uppdaterar…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} kunde inte packas upp."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} kunde inte laddas ner."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} är inte en korrekt filsökväg"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} var korrupt. Försök ladda ner det igen."
 

--- a/data/po/sv_SE.po
+++ b/data/po/sv_SE.po
@@ -238,7 +238,7 @@ msgstr "Innoextract är inte installerat."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Installerade"
+msgstr "installera"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -341,7 +341,7 @@ msgstr "Öppna filer"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "spela"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/tr.po
+++ b/data/po/tr.po
@@ -238,7 +238,7 @@ msgstr "Innoextract yüklü değil."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Yüklendi"
+msgstr "yükle"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -338,7 +338,7 @@ msgstr "Dosyaları Aç"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "oyna"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/tr.po
+++ b/data/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-09-30 11:22+0300\n"
 "Last-Translator: Hüseyin Fahri Uzun <mail@fahriuzun.com>\n"
 "Language-Team: \n"
@@ -34,32 +34,32 @@ msgctxt "about"
 msgid "About"
 msgstr "Hakkında"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Oyun çalıştırılırken kullanılacak olan komutun sonuna eklendi"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Oyun çalıştırılırken kullanılacak olan komutun başına eklendi"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "{} indirmesini iptal etmek istediğine emin misin?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "GOG üzerinden çıkış yapmak istediğinize emin misiniz?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "%s silmek istediğine emin misin?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Brezilya Portekizçesi"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "İptal"
 
@@ -68,83 +68,127 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "İptal"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Çince"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Komut bayrakları:"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Mağaza sayfası açılamadı"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Mağaza sayfası açılamadı"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Mağaza sayfası açılamadı"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Mağaza sayfası açılamadı"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Destek sayfası açılamadı"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Menü kısayolları oluştur: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Danimarka Dili"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "indir"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "İndirme hatası"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "indirliyor…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Flemenkçe"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "İngilzce"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "{} yüklenemedi:"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Kütüphane alınamadı"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "{} başlatılamadı:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Fince"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Fransızca"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr "Wine bulunamadı. Windows oyunlarının gösterimi etkinleştirilemez."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Genre"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Almanca"
 
@@ -154,24 +198,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "GitHub sayfası"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Oyunu gizle:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Macarca"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "sırada…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Innoextract dışa aktarım başarısız."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract yüklü değil."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Yüklendi"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Yükleme klasör yolu: "
@@ -182,15 +252,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Yüklendi"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "yükleniyor…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "İtalyanca"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Japonca"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -198,21 +273,25 @@ msgstr ""
 "Oyun indirmesi sonrasında yükleyiciyi saklı tut.\n"
 "Yükleyiciler şurada tutuluyor: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Yükleyicileri saklı tut: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Korece"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Dil:  "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -224,47 +303,58 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Çıkış Yap"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr "Wine bulunamadı. Windows oyunlarının gösterimi etkinleştirilemez."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "{} burada başlatma dosyası bulunamadı"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Norveçce"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Norveçce"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Norveçce"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr "Oyunu dışarı çıkartmak için yeterli alan yok. Gerekli: {} Mevcut {}"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "Tamam"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Dosyaları Aç"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Lütfen internet bağlantınızı kontrol ediniz"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Lehçe"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Portekizce"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Ayarlar"
 
@@ -274,17 +364,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Ayarlar"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Tercih edilen dil: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Seçenekler"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "{} Seçenekleri"
 
@@ -294,11 +384,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Oyun listesini güncelle"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Rusça"
 
@@ -308,18 +406,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Kaydet"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Oyunlarda FPS göster:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Windows oyunlarını göster: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "Gizli oyunları göster: "
@@ -330,37 +428,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Sadece yüklü oyunları göster"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Basitleştirilmiş Çince"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "İspanyolca"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "İspanyolca"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Çevrimci tut:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Market Sayfası"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Destek"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "İsveçce"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "Sistem varsayılanları"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "{} yüklemesi başarısız oldu. Lütfen bir daha deneyiniz."
 
@@ -374,137 +477,181 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "Minigalaxy çalıştırıldığında tercih edilecek dil"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "Minigalaxy çalıştırıldığında tercih edilecek dil"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
 msgstr "İndirme linki alınırken bir hata oluştu! {}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Burası oyunların indireleceği yerdir"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Geleneksel Çince"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Türkçe"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr ""
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Kaldır"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "siliniyor…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Güncelle"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "güncelleniyor…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Koyu tema kullan: "
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Değişken bayrakları:"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Versiyon"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr "Etkin değilken her Minigalaxy açıldığında giriş yapılması istenir"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Minigalaxy'nin koyu tema kullanıp kullanmayacağı"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Windows oyunları kütüphanede gözükmeli mi"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Gizlenmiş oyunların kütüphanede gözükmeli mi"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr "Yeni yüklenen oyunların kısa yol oluşturup oluşturmayacağı"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Wine dışarı aktarım başarısız."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Wine dışarı aktarım başarısız."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr "Wine bulunamadı. Windows oyunlarının gösterimi etkinleştirilemez."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr "Wine bulunamadı. Windows oyunlarının gösterimi etkinleştirilemez."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "indir"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "indirliyor…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "sırada…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "yükle"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "yükleniyor…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "oyna"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "siliniyor…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "güncelleniyor…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} arşivden çıkartılamadı."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} indirirken hata."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} kullanılabilinir bir yol değil"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} bozuk. Lütfen yeniden indirin."
 

--- a/data/po/uk.po
+++ b/data/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-09-29 19:02+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,8 +16,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #. A short description of what Minigalaxy is
 #: data/ui/about.ui:10
@@ -35,32 +35,32 @@ msgctxt "about"
 msgid "About"
 msgstr "Інформація"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "Додано в кінці команди, яка використовується для запуску гри"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "Додано перед командою, яка використовується для запуску гри"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Ви впевнені, що хочете скасувати завантаження {}?"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Ви дійсно хочете вийти з GOG?"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "Ви впевнені, що хочете видалити %s?"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "Бразильський Португальська"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "Скасувати"
 
@@ -69,83 +69,127 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "Китайська"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "Флажки для команди:"
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "Не вдалося відкрити сторінку магазину"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "Не вдалося відкрити сторінку магазину"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "Не вдалося відкрити сторінку магазину"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "Не вдалося відкрити сторінку магазину"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "Не вдалося відкрити сторінку підтримки"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "Створити ярлики меню: "
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "Датська"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "завантажити"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "Помилка при завантаженні"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "завантаження…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "Голландська"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "Англійська"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "Не вдалося встановити {}"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "Не вдалося отримати бібліотеку"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "Не вдалося запустити {}:"
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "Фінська"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "Французька"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr "Wine не знайдено. Показ ігор Windows не може бути ввімкнено."
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "Жанр"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "Німецька"
 
@@ -155,24 +199,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "Сторінка GitHub"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "Сховати гру:"
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "Угорська"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "в черзі…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "Помилка вилучення Innoextract."
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "Innoextract не встановлено."
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "Встановлено"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "Шлях установки: "
@@ -183,15 +253,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "Встановлено"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "встановлення…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "Італійська"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "Японська"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -199,21 +274,25 @@ msgstr ""
 "Зберегти інсталятори після завантаження гри.\n"
 "Інсталятори зберігаються в: {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "Зберігати інсталятори: "
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "Корейська"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "Мова: "
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -225,47 +304,58 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "Вийти"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr "Wine не знайдено. Показ ігор Windows не може бути ввімкнено."
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "У {} не знайдено жодного виконуваного файлу"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "Норвезька"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "Норвезька Букмол"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "Норвезька Ньорск"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr "Не вистачає місця для розпакування гри. Потрібно: {} Доступно: {}"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "ОК"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "Відкрийте файли"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "Перевірте підключення до Інтернету"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "Польська"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "Португальська"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "Налаштування"
 
@@ -275,17 +365,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "Налаштування"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "Бажана мова: "
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "Властивості"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "Властивості {}"
 
@@ -295,11 +385,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Оновити список ігор"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit (регіт)"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "Російська"
 
@@ -309,18 +407,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "Зберегти"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "Показати FPS у грі:"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "Показати ігри для Windows: "
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "Показати приховані ігри: "
@@ -331,37 +429,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Показати лише встановлені ігри"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "Спрощена Китайська"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "Іспанська"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "Іспанська"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Залишатися в системі:"
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "Магазин"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "Підтримка"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "Шведська"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "За замовчуванням"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "Не вдалося встановити {}. Спробуйте ще раз."
 
@@ -375,7 +478,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "Бажана мова для запуску Minigalaxy"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "Бажана мова для запуску Minigalaxy"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -383,133 +492,171 @@ msgstr ""
 "Під час спроби отримати посилання для завантаження сталася помилка!\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "Тут будуть встановлені ігри"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "Традиційна Китайська"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "Турецька"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr ""
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "Видалити"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "видалення…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "Оновити"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "оновлення…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "Використовувати темну тему: "
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "Флажки для змінної:"
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "Версія"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr ""
 "Коли вимкнено, вам буде запропоновано входити в систему кожного разу при "
 "запуску Minigalaxy"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "Використовувати темну тему для Minigalaxy чи ні"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Відображати ігри Windows у бібліотеці чи ні"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Показувати приховані ігри в бібліотеці чи ні"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr ""
 "Незалежно від того, створені ярлики для нещодавно встановлених ігор чи ні"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Помилка вилучення Wine."
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Помилка вилучення Wine."
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr "Wine не знайдено. Показ ігор Windows не може бути ввімкнено."
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr "Wine не знайдено. Показ ігор Windows не може бути ввімкнено."
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "завантажити"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "завантаження…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "в черзі…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "встановити"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "встановлення…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "грати"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "видалення…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "оновлення…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} не вдалося розпакувати."
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "Не вдалося завантажити {}."
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} некоректний шлях"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} пошкоджено. Завантажте ще раз."

--- a/data/po/uk.po
+++ b/data/po/uk.po
@@ -239,7 +239,7 @@ msgstr "Innoextract не встановлено."
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "Встановлено"
+msgstr "встановити"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -339,7 +339,7 @@ msgstr "Відкрийте файли"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "грати"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/zh_CN.po
+++ b/data/po/zh_CN.po
@@ -238,7 +238,7 @@ msgstr "未安装Innoextract"
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "仅显示已安装的游戏"
+msgstr "安装"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -336,7 +336,7 @@ msgstr "打开文件"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "开始游戏"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/zh_CN.po
+++ b/data/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2021-11-06 23:37+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,32 +34,32 @@ msgctxt "about"
 msgid "About"
 msgstr "关于"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr "已添加至游戏启动命令末尾处"
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr "已添加至游戏启动命令开头处"
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "确定要取消下载 {} 吗？"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr "确定要登出GOG吗？"
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "确定要卸载 %s 吗？"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "巴西葡萄牙语"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 msgid "Cancel"
 msgstr "取消"
 
@@ -68,83 +68,127 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "取消"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "汉语"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr "命令标记："
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "无法打开商店页面"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "无法打开商店页面"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "无法打开商店页面"
+
+#: minigalaxy/ui/information.py:65
 msgid "Couldn't open store page"
 msgstr "无法打开商店页面"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "无法打开支持页面"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr "创建菜单快捷方式"
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr "捷克语"
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "丹麦语"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "下载"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "下载错误"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "正在下载…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "荷兰语"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "英语"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr "更改软件语言失败。请确保已生成locale。"
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "安装 {} 失败"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "获取游戏库失败"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "启动 {} 失败："
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "芬兰语"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "法语"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+#, fuzzy
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr "未找到 Wine。无法启用显示 Windows 游戏"
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr "类型"
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "德语"
 
@@ -154,24 +198,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "GitHub 页面"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr "隐藏游戏："
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "队列中…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr "使用Innoextract提取失败。"
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr "未安装Innoextract"
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "仅显示已安装的游戏"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "安装路径："
@@ -182,35 +252,44 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "仅显示已安装的游戏"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "正在安装…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "意大利语"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "日语"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
 msgstr "下载后保留安装包。安装包会保存在： {}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "保留安装包："
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "韩语"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
 msgstr "语言"
+
+#: minigalaxy/constants.py:53
+msgid "List"
+msgstr ""
 
 #: minigalaxy/ui/login.py:20
 msgid "Login"
@@ -222,47 +301,58 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "退出登录"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+#, fuzzy
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr "未找到 Wine。无法启用显示 Windows 游戏"
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "在 {} 内未找到可执行文件"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "挪威语"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 msgid "Norwegian Bokmål"
 msgstr "书面挪威语"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 msgid "Norwegian Nynorsk"
 msgstr "新挪威语"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr "可用空间不足，无法解压游戏。需要：{}，可用：{}"
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr "好"
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "打开文件"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "请检查网络连接"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "波兰语"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "偏好设置"
 
@@ -272,17 +362,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "偏好设置"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "首选语言："
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr "属性"
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr "{} 的属性"
 
@@ -292,11 +382,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "刷新游戏列表"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "注册表"
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "俄语"
 
@@ -306,18 +404,18 @@ msgctxt "save"
 msgid "Save"
 msgstr "保存"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 msgid "Show FPS in game:"
 msgstr "在游戏内显示 FPS："
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "显示 Windows 游戏："
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
 msgstr "显示隐藏的游戏："
@@ -328,37 +426,42 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "只显示已安装的游戏"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr "简体中文"
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "西班牙语"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "西班牙语"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "保持登录："
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 msgid "Store"
 msgstr "商店"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 msgid "Support"
 msgstr "支持"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "瑞典语"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr "系统默认"
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "{} 安装错误，请重试。"
 
@@ -372,7 +475,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "启动 Minigalaxy 时有限选择的语言"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "启动 Minigalaxy 时有限选择的语言"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -380,131 +489,169 @@ msgstr ""
 "尝试获取下载链接时发生错误！\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "游戏会被安装到这里"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr "繁体中文"
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr "乌克兰语"
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 msgid "Uninstall"
 msgstr "卸载"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "正在卸载…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 msgid "Update"
 msgstr "更新"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "正在更新…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr "使用暗色主题："
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr "变量标记："
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr "版本"
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr "如果禁用，Minigalaxy 每次启动时将会请求您登录"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr "是否让 Minigalaxy 使用暗色主题"
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "是否在游戏库内显示 Windows 游戏"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "是否在游戏库内显示隐藏的游戏"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr "游戏安装完成后是否创建快捷方式"
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+#, fuzzy
+msgid "Wine executable:"
+msgstr "Wine 提取失败"
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr "Wine 提取失败"
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr "未找到 Wine。无法启用显示 Windows 游戏"
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+#, fuzzy
+msgid "Winetricks wasn't found and cannot be used."
+msgstr "未找到 Wine。无法启用显示 Windows 游戏"
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "下载"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "正在下载…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "队列中…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "安装"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "正在安装…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "开始游戏"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "正在卸载…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "正在更新…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "{} 无法解压。"
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} 下载失败。"
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} 路径不可用"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} 已损坏，请重新下载。"
 

--- a/data/po/zh_TW.po
+++ b/data/po/zh_TW.po
@@ -238,7 +238,7 @@ msgstr ""
 #: minigalaxy/ui/gametile.py:538
 #, fuzzy
 msgid "Install"
-msgstr "已安裝"
+msgstr "安裝"
 
 #. The place directory in which games are installed. Has to end with ": "
 #: data/ui/preferences.ui:143
@@ -339,7 +339,7 @@ msgstr "開啟檔案"
 
 #: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
 msgid "Play"
-msgstr ""
+msgstr "遊玩"
 
 #: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
 #: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86

--- a/data/po/zh_TW.po
+++ b/data/po/zh_TW.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 14:30-0800\n"
+"POT-Creation-Date: 2023-02-22 20:10+0100\n"
 "PO-Revision-Date: 2020-11-15 07:53+0800\n"
 "Last-Translator: Jeff Huang <s8321414@gmail.com>\n"
 "Language-Team: Chinese <zh-l10n@linux.org.tw>\n"
@@ -33,32 +33,32 @@ msgctxt "about"
 msgid "About"
 msgstr "關於"
 
-#: data/ui/properties.ui:129
+#: data/ui/properties.ui:265
 msgid "Added at the end of the command used to launch the game"
 msgstr ""
 
-#: data/ui/properties.ui:141
+#: data/ui/properties.ui:240
 msgid "Added in front of the command used to launch the game"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:132
+#: minigalaxy/ui/gametilelist.py:154 minigalaxy/ui/gametile.py:154
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "您確定您想要取消下載 {} 嗎？"
 
-#: minigalaxy/ui/window.py:100
+#: minigalaxy/ui/window.py:101
 msgid "Are you sure you want to log out of GOG?"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:145
+#: minigalaxy/ui/gametilelist.py:167 minigalaxy/ui/gametile.py:167
 #, python-format
 msgid "Are you sure you want to uninstall %s?"
 msgstr "您確定要解除安裝 %s 嗎？"
 
-#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
+#: minigalaxy/constants.py:4 minigalaxy/constants.py:28
 msgid "Brazilian Portuguese"
 msgstr "葡萄牙文（巴西）"
 
-#: data/ui/properties.ui:266
+#: data/ui/properties.ui:336
 #, fuzzy
 msgid "Cancel"
 msgstr "取消"
@@ -68,84 +68,127 @@ msgctxt "cancel"
 msgid "Cancel"
 msgstr "取消"
 
-#: minigalaxy/constants.py:8
+#: data/ui/properties.ui:103
+msgid "Check for updates:"
+msgstr ""
+
+#: minigalaxy/constants.py:5
 msgid "Chinese"
 msgstr "中文"
 
-#: data/ui/properties.ui:180
+#: data/ui/properties.ui:253
 msgid "Command flags:"
 msgstr ""
 
-#: minigalaxy/ui/properties.py:103
+#: minigalaxy/ui/information.py:85
+#, fuzzy
+msgid "Couldn't open GOG Database page"
+msgstr "無法開啟支援頁面"
+
+#: minigalaxy/ui/information.py:95
+#, fuzzy
+msgid "Couldn't open PCGamingWiki page"
+msgstr "無法開啟支援頁面"
+
+#: minigalaxy/ui/information.py:75
+#, fuzzy
+msgid "Couldn't open forum page"
+msgstr "無法開啟支援頁面"
+
+#: minigalaxy/ui/information.py:65
 #, fuzzy
 msgid "Couldn't open store page"
 msgstr "無法開啟支援頁面"
 
-#: minigalaxy/ui/properties.py:93
+#: minigalaxy/ui/information.py:55
 msgid "Couldn't open support page"
 msgstr "無法開啟支援頁面"
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:288
+#: data/ui/preferences.ui:313
 msgctxt "create_menu_shortcuts"
 msgid "Create menu shortcuts: "
 msgstr ""
 
-#: minigalaxy/constants.py:31
+#: minigalaxy/constants.py:29
 msgid "Czech"
 msgstr ""
 
-#: data/ui/gametile.ui:178
+#: data/ui/gametilelist.ui:194 data/ui/gametile.ui:192
 msgid "DLC"
 msgstr "DLC"
 
-#: minigalaxy/constants.py:9
+#: minigalaxy/constants.py:6
 msgid "Danish"
 msgstr "丹麥文"
 
-#: minigalaxy/ui/gametile.py:207 minigalaxy/ui/gametile.py:237
+#: minigalaxy/ui/gametile.py:519
+#, fuzzy
+msgid "Download"
+msgstr "下載"
+
+#: minigalaxy/ui/gametilelist.py:238 minigalaxy/ui/gametilelist.py:277
+#: minigalaxy/ui/gametile.py:238 minigalaxy/ui/gametile.py:277
 msgid "Download error"
 msgstr "下載錯誤"
 
-#: minigalaxy/constants.py:10 minigalaxy/constants.py:32
+#: minigalaxy/ui/gametile.py:559
+#, fuzzy
+msgid "Downloading…"
+msgstr "正在下載…"
+
+#: minigalaxy/constants.py:7 minigalaxy/constants.py:30
 msgid "Dutch"
 msgstr "荷蘭文"
 
-#: minigalaxy/constants.py:11 minigalaxy/constants.py:33
+#: minigalaxy/constants.py:8 minigalaxy/constants.py:31
 msgid "English"
 msgstr "英文"
 
-#: minigalaxy/ui/preferences.py:102
+#: minigalaxy/ui/login.py:45
+msgid "Facebook Login"
+msgstr ""
+
+#: minigalaxy/ui/preferences.py:123
 msgid ""
 "Failed to change program language. Make sure locale is generated on your "
 "system."
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:301
+#: minigalaxy/ui/gametilelist.py:353 minigalaxy/ui/gametile.py:353
 msgid "Failed to install {}"
 msgstr "安裝 {} 失敗"
 
-#: minigalaxy/ui/library.py:141
+#: minigalaxy/ui/library.py:161
 msgid "Failed to retrieve library"
 msgstr "擷取收藏庫失敗"
 
-#: minigalaxy/launcher.py:34 minigalaxy/ui/gametile.py:122
+#: minigalaxy/launcher.py:52 minigalaxy/ui/gametilelist.py:138
+#: minigalaxy/ui/gametile.py:138
 msgid "Failed to start {}:"
 msgstr "啟動 {} 失敗："
 
-#: minigalaxy/constants.py:12 minigalaxy/constants.py:34
+#: minigalaxy/constants.py:9 minigalaxy/constants.py:32
 msgid "Finnish"
 msgstr "芬蘭文"
 
-#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
+#: data/ui/information.ui:89
+msgid "Forum"
+msgstr ""
+
+#: minigalaxy/constants.py:10 minigalaxy/constants.py:33
 msgid "French"
 msgstr "法文"
 
-#: minigalaxy/ui/properties.py:140
+#: minigalaxy/ui/properties.py:82
+msgid "GameMode wasn't found. Using GameMode cannot be enabled."
+msgstr ""
+
+#: minigalaxy/ui/information.py:141
 msgid "Genre"
 msgstr ""
 
-#: minigalaxy/constants.py:14 minigalaxy/constants.py:36
+#: minigalaxy/constants.py:11 minigalaxy/constants.py:34
 msgid "German"
 msgstr "德文"
 
@@ -155,24 +198,50 @@ msgctxt "github_page_link"
 msgid "GitHub page"
 msgstr "GitHub 頁面"
 
-#: data/ui/properties.ui:105
+#: minigalaxy/constants.py:47
+msgid "Greek"
+msgstr ""
+
+#: minigalaxy/constants.py:52
+msgid "Grid"
+msgstr ""
+
+#: data/ui/properties.ui:153
 msgid "Hide game:"
 msgstr ""
 
-#: minigalaxy/constants.py:15
+#: minigalaxy/constants.py:12
 msgid "Hungarian"
 msgstr "匈牙利文"
 
-#: minigalaxy/installer.py:147
+#: minigalaxy/ui/gametile.py:550
+#, fuzzy
+msgid "In queue…"
+msgstr "在佇列中…"
+
+#: data/ui/gametilelist.ui:239 data/ui/gametile.ui:222
+msgid "Information"
+msgstr ""
+
+#: minigalaxy/ui/information.py:29
+msgid "Information about {}"
+msgstr ""
+
+#: minigalaxy/installer.py:157
 msgid "Innoextract extraction failed."
 msgstr ""
 
-#: minigalaxy/installer.py:158
+#: minigalaxy/installer.py:174
 msgid "Innoextract not installed."
 msgstr ""
 
-#. The place directory in which games are installed. Ends with ": ".
-#: data/ui/preferences.ui:118
+#: minigalaxy/ui/gametile.py:538
+#, fuzzy
+msgid "Install"
+msgstr "已安裝"
+
+#. The place directory in which games are installed. Has to end with ": "
+#: data/ui/preferences.ui:143
 msgctxt "install_path"
 msgid "Installation path: "
 msgstr "安裝路徑："
@@ -183,15 +252,20 @@ msgctxt "installed"
 msgid "Installed"
 msgstr "已安裝"
 
-#: minigalaxy/constants.py:16 minigalaxy/constants.py:37
+#: minigalaxy/ui/gametile.py:570
+#, fuzzy
+msgid "Installing…"
+msgstr "正在安裝…"
+
+#: minigalaxy/constants.py:13 minigalaxy/constants.py:35
 msgid "Italian"
 msgstr "義大利文"
 
-#: minigalaxy/constants.py:17
+#: minigalaxy/constants.py:14
 msgid "Japanese"
 msgstr "日文"
 
-#: minigalaxy/ui/preferences.py:46
+#: minigalaxy/ui/preferences.py:49
 msgid ""
 "Keep installers after downloading a game.\n"
 "Installers are stored in: {}"
@@ -199,20 +273,24 @@ msgstr ""
 "在下載遊戲後保留安裝程式。\n"
 "安裝程式儲存於：{}"
 
-#. Whether installer files are kept after download. Ends with ": ".
-#: data/ui/preferences.ui:145
+#. Whether installer files are kept after download. Has to end with ": "
+#: data/ui/preferences.ui:170
 msgctxt "keep_installer"
 msgid "Keep installers: "
 msgstr "保留安裝程式："
 
-#: minigalaxy/constants.py:18
+#: minigalaxy/constants.py:15
 msgid "Korean"
 msgstr "韓文"
 
-#. The preferred language on Minigalaxy start. Ends with ": ".
+#. The preferred language on Minigalaxy start. Has to end with ": "
 #: data/ui/preferences.ui:68
 msgctxt "language"
 msgid "Language: "
+msgstr ""
+
+#: minigalaxy/constants.py:53
+msgid "List"
 msgstr ""
 
 #: minigalaxy/ui/login.py:20
@@ -225,49 +303,59 @@ msgctxt "logout"
 msgid "Logout"
 msgstr "登出"
 
-#: minigalaxy/launcher.py:179
+#: minigalaxy/ui/properties.py:87
+msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
+msgstr ""
+
+#: minigalaxy/launcher.py:212
 msgid "No executable was found in {}"
 msgstr "在 {} 找不到可執行檔"
 
-#: minigalaxy/constants.py:19
+#: minigalaxy/constants.py:16
 msgid "Norwegian"
 msgstr "挪威文"
 
-#: minigalaxy/constants.py:38
+#: minigalaxy/constants.py:36
 #, fuzzy
 msgid "Norwegian Bokmål"
 msgstr "挪威文"
 
-#: minigalaxy/constants.py:39
+#: minigalaxy/constants.py:37
 #, fuzzy
 msgid "Norwegian Nynorsk"
 msgstr "挪威文"
 
-#: minigalaxy/installer.py:97
+#: minigalaxy/installer.py:106
 msgid "Not enough space to extract game. Required: {} Available: {}"
 msgstr ""
 
-#: data/ui/properties.ui:280
+#: data/ui/information.ui:165 data/ui/properties.ui:350
 msgid "OK"
 msgstr ""
 
-#: data/ui/properties.ui:216
+#: data/ui/properties.ui:74
 msgid "Open files"
 msgstr "開啟檔案"
 
-#: minigalaxy/ui/properties.py:94 minigalaxy/ui/properties.py:104
+#: minigalaxy/ui/gametile.py:585 minigalaxy/ui/gametile.py:617
+msgid "Play"
+msgstr ""
+
+#: minigalaxy/ui/information.py:56 minigalaxy/ui/information.py:66
+#: minigalaxy/ui/information.py:76 minigalaxy/ui/information.py:86
+#: minigalaxy/ui/information.py:96
 msgid "Please check your internet connection"
 msgstr "請檢查您的網際網路連線"
 
-#: minigalaxy/constants.py:20 minigalaxy/constants.py:40
+#: minigalaxy/constants.py:17 minigalaxy/constants.py:38
 msgid "Polish"
 msgstr "波蘭文"
 
-#: minigalaxy/constants.py:21
+#: minigalaxy/constants.py:18
 msgid "Portuguese"
 msgstr "葡萄牙文"
 
-#: minigalaxy/ui/preferences.py:30
+#: minigalaxy/ui/preferences.py:31
 msgid "Preferences"
 msgstr "偏好設定"
 
@@ -277,17 +365,17 @@ msgctxt "preferences"
 msgid "Preferences"
 msgstr "偏好設定"
 
-#. Preferred language for downloading games in. Ends with ": ".
+#. Preferred language for downloading games in. Has to end with ": "
 #: data/ui/preferences.ui:93
 msgctxt "preferred_game_language"
 msgid "Preferred game language: "
 msgstr "偏好的語言："
 
-#: data/ui/gametile.ui:223
+#: data/ui/gametilelist.ui:254 data/ui/gametile.ui:237
 msgid "Properties"
 msgstr ""
 
-#: minigalaxy/ui/properties.py:33
+#: minigalaxy/ui/properties.py:34
 msgid "Properties of {}"
 msgstr ""
 
@@ -297,11 +385,19 @@ msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "重新整理遊戲清單"
 
-#: data/ui/properties.ui:203
+#: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr ""
 
-#: minigalaxy/constants.py:22 minigalaxy/constants.py:41
+#: data/ui/properties.ui:275
+msgid "Reset wine executable"
+msgstr ""
+
+#: minigalaxy/constants.py:23 minigalaxy/constants.py:48
+msgid "Romanian"
+msgstr ""
+
+#: minigalaxy/constants.py:19 minigalaxy/constants.py:39
 msgid "Russian"
 msgstr "俄文"
 
@@ -311,19 +407,19 @@ msgctxt "save"
 msgid "Save"
 msgstr "儲存"
 
-#: data/ui/properties.ui:154
+#: data/ui/properties.ui:128
 #, fuzzy
 msgid "Show FPS in game:"
 msgstr "在遊戲中顯示 FPS："
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:250
+#: data/ui/preferences.ui:275
 msgctxt "show_windows_games"
 msgid "Show Windows games: "
 msgstr "顯示 Windows 遊戲："
 
 #. Has to end with ": "
-#: data/ui/preferences.ui:224
+#: data/ui/preferences.ui:249
 #, fuzzy
 msgctxt "show_hidden_games"
 msgid "Show hidden games: "
@@ -335,39 +431,44 @@ msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "僅顯示已安裝的遊戲"
 
-#: minigalaxy/constants.py:42
+#: minigalaxy/constants.py:40
 msgid "Simplified Chinese"
 msgstr ""
 
-#: minigalaxy/constants.py:23 minigalaxy/constants.py:43
+#: minigalaxy/constants.py:20 minigalaxy/constants.py:41
 msgid "Spanish"
 msgstr "西班牙文"
 
-#. Whether the user will stay logged in after closing Minigalaxy. Ends with ": ".
-#: data/ui/preferences.ui:171
+#: minigalaxy/constants.py:42
+#, fuzzy
+msgid "Spanish (Spain)"
+msgstr "西班牙文"
+
+#. Whether the user will stay logged in after closing Minigalaxy. Has to end with ": "
+#: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "保持登入："
 
-#: data/ui/properties.ui:77
+#: data/ui/information.ui:76
 #, fuzzy
 msgid "Store"
 msgstr "商店頁面"
 
-#: data/ui/properties.ui:63
+#: data/ui/information.ui:63
 #, fuzzy
 msgid "Support"
 msgstr "支援"
 
-#: minigalaxy/constants.py:24 minigalaxy/constants.py:44
+#: minigalaxy/constants.py:21 minigalaxy/constants.py:43
 msgid "Swedish"
 msgstr "瑞典文"
 
-#: minigalaxy/constants.py:29
+#: minigalaxy/constants.py:27
 msgid "System default"
 msgstr ""
 
-#: minigalaxy/installer.py:128
+#: minigalaxy/installer.py:137
 msgid "The installation of {} failed. Please try again."
 msgstr "{} 安裝失敗。請再試一次。"
 
@@ -382,7 +483,13 @@ msgctxt "language_tooltip"
 msgid "The preferred language on Minigalaxy start"
 msgstr "下載遊戲的偏好語言"
 
-#: minigalaxy/ui/gametile.py:208
+#: data/ui/preferences.ui:115
+#, fuzzy
+msgctxt "view_tooltip"
+msgid "The preferred view of game library"
+msgstr "下載遊戲的偏好語言"
+
+#: minigalaxy/ui/gametilelist.py:239 minigalaxy/ui/gametile.py:239
 msgid ""
 "There was an error when trying to fetch the download link!\n"
 "{}"
@@ -390,134 +497,170 @@ msgstr ""
 "嘗試擷取下載連結時發生錯誤！\n"
 "{}"
 
-#: data/ui/preferences.ui:115
+#: data/ui/preferences.ui:140
 msgctxt "install_path_tooltip"
 msgid "This is where games will be installed"
 msgstr "遊戲會安裝在"
 
-#: minigalaxy/constants.py:45
+#: minigalaxy/constants.py:44
 msgid "Traditional Chinese"
 msgstr ""
 
-#: minigalaxy/constants.py:25 minigalaxy/constants.py:46
+#: minigalaxy/constants.py:22 minigalaxy/constants.py:45
 msgid "Turkish"
 msgstr "土耳其文"
 
-#: minigalaxy/constants.py:47
+#: minigalaxy/constants.py:46
 msgid "Ukrainian"
 msgstr ""
 
-#: data/ui/gametile.ui:208
+#: data/ui/gametilelist.ui:224 data/ui/gametile.ui:207
 #, fuzzy
 msgid "Uninstall"
 msgstr "解除安裝"
 
-#: data/ui/gametile.ui:193
+#: minigalaxy/ui/gametile.py:602
+#, fuzzy
+msgid "Uninstalling…"
+msgstr "正在解除安裝…"
+
+#: data/ui/gametilelist.ui:209 data/ui/gametile.ui:171
 #, fuzzy
 msgid "Update"
 msgstr "更新"
 
+#: minigalaxy/ui/gametile.py:626
+#, fuzzy
+msgid "Updating…"
+msgstr "正在更新…"
+
+#: data/ui/properties.ui:178
+msgid "Use GameMode:"
+msgstr ""
+
+#: data/ui/properties.ui:203
+msgid "Use MangoHud:"
+msgstr ""
+
 #. Has to end with ": "
-#: data/ui/preferences.ui:198
+#: data/ui/preferences.ui:223
 msgctxt "use_dark_theme"
 msgid "Use dark theme: "
 msgstr ""
 
-#: data/ui/properties.ui:167
+#: data/ui/properties.ui:228
 msgid "Variable flags:"
 msgstr ""
 
-#: minigalaxy/ui/properties.py:142
+#: minigalaxy/ui/information.py:143
 msgid "Version"
 msgstr ""
 
-#: data/ui/preferences.ui:168
+#. The preferred view of game library. Has to end with ": "
+#: data/ui/preferences.ui:118
+msgctxt "view"
+msgid "View: "
+msgstr ""
+
+#: data/ui/preferences.ui:193
 msgctxt "stay_logged_in_tooltip"
 msgid "When disabled you'll be asked to log in each time Minigalaxy is started"
 msgstr "若停用，您每次打開 Minigalaxy 時都會被要求登入"
 
-#: data/ui/preferences.ui:195
+#: data/ui/preferences.ui:220
 msgctxt "use_dark_theme_tooltip"
 msgid "Whether Minigalaxy should use dark theme or not"
 msgstr ""
 
-#: data/ui/preferences.ui:247
+#: data/ui/preferences.ui:272
 msgctxt "show_windows_games_tooltip"
 msgid "Whether Windows games are shown in the library or not"
 msgstr "Windows 遊戲是否要顯示在收藏庫中"
 
-#: data/ui/preferences.ui:221
+#: data/ui/preferences.ui:246
 #, fuzzy
 msgctxt "show_hidden_games_tooltip"
 msgid "Whether hidden games are shown in the library or not"
 msgstr "Windows 遊戲是否要顯示在收藏庫中"
 
-#: data/ui/preferences.ui:285
+#: data/ui/preferences.ui:310
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
 msgstr ""
 
-#: minigalaxy/installer.py:172
+#: data/ui/properties.ui:291
+msgid "Wine executable:"
+msgstr ""
+
+#: minigalaxy/installer.py:188
 msgid "Wine extraction failed."
 msgstr ""
 
-#: minigalaxy/ui/preferences.py:162
+#: minigalaxy/ui/preferences.py:193
 msgid "Wine wasn't found. Showing Windows games cannot be enabled."
 msgstr ""
 
-#: data/ui/properties.ui:190
+#: data/ui/properties.ui:61
 msgid "Winecfg"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:460
+#: data/ui/properties.ui:87
+msgid "Winetricks"
+msgstr ""
+
+#: minigalaxy/ui/properties.py:113
+msgid "Winetricks wasn't found and cannot be used."
+msgstr ""
+
+#: minigalaxy/ui/gametilelist.py:519
 msgid "download"
 msgstr "下載"
 
-#: minigalaxy/ui/gametile.py:500
+#: minigalaxy/ui/gametilelist.py:559
 msgid "downloading…"
 msgstr "正在下載…"
 
-#: minigalaxy/ui/gametile.py:491
+#: minigalaxy/ui/gametilelist.py:550
 msgid "in queue…"
 msgstr "在佇列中…"
 
-#: minigalaxy/ui/gametile.py:479
+#: minigalaxy/ui/gametilelist.py:538
 msgid "install"
 msgstr "安裝"
 
-#: minigalaxy/ui/gametile.py:511
+#: minigalaxy/ui/gametilelist.py:570
 msgid "installing…"
 msgstr "正在安裝…"
 
-#: minigalaxy/ui/gametile.py:526 minigalaxy/ui/gametile.py:556
+#: minigalaxy/ui/gametilelist.py:585 minigalaxy/ui/gametilelist.py:615
 msgid "play"
 msgstr "遊玩"
 
-#: minigalaxy/ui/gametile.py:542
+#: minigalaxy/ui/gametilelist.py:601
 msgid "uninstalling…"
 msgstr "正在解除安裝…"
 
-#: minigalaxy/ui/properties.py:136
+#: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr ""
 
-#: minigalaxy/ui/gametile.py:565
+#: minigalaxy/ui/gametilelist.py:624
 msgid "updating…"
 msgstr "正在更新…"
 
-#: minigalaxy/installer.py:130
+#: minigalaxy/installer.py:139
 msgid "{} could not be unzipped."
 msgstr "無法解壓縮 {}。"
 
-#: minigalaxy/installer.py:73
+#: minigalaxy/installer.py:82
 msgid "{} failed to download."
 msgstr "{} 下載失敗。"
 
-#: minigalaxy/ui/preferences.py:174
+#: minigalaxy/ui/preferences.py:205
 msgid "{} isn't a usable path"
 msgstr "{} 不是可用的路徑"
 
-#: minigalaxy/installer.py:85
+#: minigalaxy/installer.py:94
 msgid "{} was corrupted. Please download it again."
 msgstr "{} 已損毀。請再下載一次。"
 

--- a/data/style.css
+++ b/data/style.css
@@ -3,7 +3,16 @@
   color: red;
   background-color: purple;
 }
-button {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
+.button-left {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+  border-right-width: 0px;
+  margin-right: 0px;
+}
+.button-right {
+  margin-left: 0px;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-left-radius: 0px;
 }

--- a/data/ui/gametile.ui
+++ b/data/ui/gametile.ui
@@ -59,34 +59,6 @@
                 <property name="position">0</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkMenuButton" id="menu_button">
-                <property name="can-focus">True</property>
-                <property name="focus-on-click">False</property>
-                <property name="receives-default">True</property>
-                <property name="no-show-all">True</property>
-                <property name="halign">end</property>
-                <property name="valign">start</property>
-                <property name="relief">none</property>
-                <property name="use-popover">False</property>
-                <property name="popover">menu</property>
-                <child>
-                  <object class="GtkImage" id="menu_icon">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">center</property>
-                    <property name="valign">center</property>
-                    <property name="icon-name">applications-system-symbolic</property>
-                    <property name="icon_size">3</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
           </object>
         </child>
         <child type="overlay">
@@ -121,24 +93,51 @@
       </packing>
     </child>
     <child>
-      <object class="GtkButton" id="button">
-        <property name="width-request">196</property>
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="receives-default">True</property>
-        <property name="halign">center</property>
-        <property name="valign">end</property>
-        <signal name="clicked" handler="on_button_clicked" swapped="no"/>
+        <property name="can_focus">False</property>
+        <property name="width-request">196</property>
         <child>
-          <placeholder/>
+          <object class="GtkButton" id="button">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <signal name="clicked" handler="on_button_clicked" swapped="no"/>
+            <style>
+              <class name="button-left"/>
+            </style>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+            <packing>
+              <property name="expand">True</property>
+              <property name="fill">True</property>
+              <property name="pack-type">start</property>
+              <property name="position">0</property>
+            </packing>
         </child>
+        <child>
+          <object class="GtkMenuButton" id="menu_button">
+            <property name="use_action_appearance">False</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="use-popover">False</property>
+            <property name="popover">menu</property>
+            <property name="receives-default">True</property>
+            <style>
+              <class name="button-right"/>
+            </style>
+          </object>
+          <packing>
+              <property name="expand">False</property>
+              <property name="fill">True</property>
+              <property name="pack-type">start</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="pack-type">end</property>
-        <property name="position">1</property>
-      </packing>
     </child>
     <child>
       <placeholder/>

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -544,7 +544,7 @@ class GameTile(Gtk.Box):
             self.progress_bar.destroy()
 
     def __state_queued(self):
-        self.button.set_label(_("in queue…"))
+        self.button.set_label(_("In queue…"))
         self.button.set_sensitive(False)
         self.image.set_sensitive(False)
         self.menu_button_uninstall.hide()
@@ -553,7 +553,7 @@ class GameTile(Gtk.Box):
         self.__create_progress_bar()
 
     def __state_downloading(self):
-        self.button.set_label(_("downloading…"))
+        self.button.set_label(_("Downloading…"))
         self.button.set_sensitive(False)
         self.image.set_sensitive(False)
         self.menu_button_uninstall.hide()
@@ -564,7 +564,7 @@ class GameTile(Gtk.Box):
         self.progress_bar.show_all()
 
     def __state_installing(self):
-        self.button.set_label(_("installing…"))
+        self.button.set_label(_("Installing…"))
         self.button.set_sensitive(False)
         self.image.set_sensitive(True)
         self.menu_button_uninstall.hide()
@@ -579,7 +579,7 @@ class GameTile(Gtk.Box):
         self.parent.filter_library()
 
     def __state_installed(self):
-        self.button.set_label(_("play"))
+        self.button.set_label(_("Play"))
         self.button.get_style_context().add_class("suggested-action")
         self.button.set_sensitive(True)
         self.image.set_sensitive(True)
@@ -595,7 +595,7 @@ class GameTile(Gtk.Box):
         self.update_icon.hide()
 
     def __state_uninstalling(self):
-        self.button.set_label(_("uninstalling…"))
+        self.button.set_label(_("Uninstalling…"))
         self.button.get_style_context().remove_class("suggested-action")
         self.button.set_sensitive(False)
         self.image.set_sensitive(False)
@@ -609,7 +609,7 @@ class GameTile(Gtk.Box):
     def __state_updatable(self):
         self.update_icon.show()
         self.update_icon.set_from_icon_name("emblem-synchronizing", Gtk.IconSize.LARGE_TOOLBAR)
-        self.button.set_label(_("play"))
+        self.button.set_label(_("Play"))
         self.menu_button.show()
         tooltip_text = "{} (update{})".format(self.game.name, ", Wine" if self.game.platform == "windows" else "")
         self.image.set_tooltip_text(tooltip_text)
@@ -618,7 +618,7 @@ class GameTile(Gtk.Box):
             self.wine_icon.set_margin_left(22)
 
     def __state_updating(self):
-        self.button.set_label(_("updating…"))
+        self.button.set_label(_("Updating…"))
 
     STATE_UPDATE_HANDLERS = {
         state.DOWNLOADABLE: __state_downloadable,

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -516,7 +516,7 @@ class GameTile(Gtk.Box):
             self.update_to_state(self.state.DOWNLOADABLE)
 
     def __state_downloadable(self):
-        self.button.set_label(_("download"))
+        self.button.set_label(_("Download"))
         self.button.set_sensitive(True)
         self.image.set_sensitive(False)
 
@@ -535,7 +535,7 @@ class GameTile(Gtk.Box):
             self.progress_bar.destroy()
 
     def __state_installable(self):
-        self.button.set_label(_("install"))
+        self.button.set_label(_("Install"))
         self.button.set_sensitive(True)
         self.image.set_sensitive(False)
         self.menu_button.hide()

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -59,6 +59,9 @@ class GameTile(Gtk.Box):
         Gtk.StyleContext.add_provider(self.button.get_style_context(),
                                       CSS_PROVIDER,
                                       Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        Gtk.StyleContext.add_provider(self.menu_button.get_style_context(),
+                                      CSS_PROVIDER,
+                                      Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         self.parent = parent
         self.game = game
         self.api = api
@@ -581,6 +584,7 @@ class GameTile(Gtk.Box):
     def __state_installed(self):
         self.button.set_label(_("Play"))
         self.button.get_style_context().add_class("suggested-action")
+        self.menu_button.get_style_context().add_class("suggested-action")
         self.button.set_sensitive(True)
         self.image.set_sensitive(True)
         self.menu_button.show()
@@ -597,6 +601,7 @@ class GameTile(Gtk.Box):
     def __state_uninstalling(self):
         self.button.set_label(_("Uninstalling…"))
         self.button.get_style_context().remove_class("suggested-action")
+        self.menu_button.get_style_context().remove_class("suggested-action")
         self.button.set_sensitive(False)
         self.image.set_sensitive(False)
         self.menu_button.hide()


### PR DESCRIPTION
Not sure of this pull-request as this is an opinionated change.

The menu button, located at the top right corner of the thumbnail, is barely visible for some games. I think it would be better the have this button alongside of the action button (play/download/...).
Should we keep the previous icon ("applications-system-symbolic") or use the default icon for GtkMenuButton?

Also, the first letter of the action button is now capitalized.

Any comments are welcome (I'm not very confident with Gtk).

Before:
![Screenshot from 2023-02-19 16-12-29](https://user-images.githubusercontent.com/1508181/219957260-233b8a51-cadb-4f65-9e62-b377367c27de.png)

After:
![Screenshot from 2023-02-19 16-11-17](https://user-images.githubusercontent.com/1508181/219957282-9083b8d2-cfb3-4580-9a5e-403e65791d0f.png)
