### PR TITLE
Fix progress bar position in gametiles

### DIFF
--- a/bin/minigalaxy
+++ b/bin/minigalaxy
@@ -48,8 +48,10 @@ def main():
     from minigalaxy.config import Config
     from minigalaxy.api import Api
     from minigalaxy.download_manager import DownloadManager
+    from minigalaxy.css import load_css
 
     # Start the application
+    load_css()
     config = Config()
     session = requests.Session()
     session.headers.update({'User-Agent': 'Minigalaxy/{} (Linux {})'.format(VERSION, platform.machine())})

--- a/data/style.css
+++ b/data/style.css
@@ -3,16 +3,20 @@
   color: red;
   background-color: purple;
 }
-.button-left {
+
+#gametile .button-left {
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
   border-bottom-right-radius: 0px;
   border-right-width: 0px;
   margin-right: 0px;
 }
-.button-right {
+#gametile .button-right {
   margin-left: 0px;
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
   border-bottom-left-radius: 0px;
+}
+#gametile .progress-bar * {
+  border-radius: 0px;
 }

--- a/data/ui/gametile.ui
+++ b/data/ui/gametile.ui
@@ -3,6 +3,7 @@
 <interface domain="minigalaxy">
   <requires lib="gtk+" version="3.20"/>
   <template class="GameTile" parent="GtkBox">
+    <property name="name">gametile</property>
     <property name="width-request">196</property>
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -84,6 +85,16 @@
           <packing>
             <property name="index">3</property>
           </packing>
+        </child>
+        <child type="overlay">
+          <object class="GtkProgressBar" id="progress_bar">
+            <property name="visible">False</property>
+            <property name="no-show-all">True</property>
+            <property name="valign">end</property>
+            <style>
+              <class name="progress-bar"/>
+            </style>
+          </object>
         </child>
       </object>
       <packing>

--- a/minigalaxy/css.py
+++ b/minigalaxy/css.py
@@ -1,9 +1,13 @@
-from minigalaxy.ui.gtk import Gtk
+from minigalaxy.ui.gtk import Gtk, Gdk
 from minigalaxy.paths import CSS_PATH
 
 CSS_PROVIDER = Gtk.CssProvider()
-try:
-    with open(CSS_PATH) as style:
-        CSS_PROVIDER.load_from_data(style.read().encode('utf-8'))
-except Exception:
-    print("The CSS in {} could not be loaded".format(CSS_PATH))
+
+
+def load_css():
+    try:
+        with open(CSS_PATH) as style:
+            CSS_PROVIDER.load_from_data(style.read().encode('utf-8'))
+    except Exception:
+        print("The CSS in {} could not be loaded".format(CSS_PATH))
+    Gtk.StyleContext().add_provider_for_screen(Gdk.Screen.get_default(), CSS_PROVIDER, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)


### PR DESCRIPTION
## Description

Since b8894b0, the download progress bar was positioned at the bottom of gametiles (below buttons).

![Screenshot from 2023-03-07 15-59-09](https://user-images.githubusercontent.com/1508181/223484213-88207eec-ca0c-45e6-892d-74542a398982.png)

This PR fixes this issue and load CSS data from `style.css` for the whole Gtk Window (previously the CSS was loaded only for gametiles).

![Screenshot from 2023-03-07 16-59-55](https://user-images.githubusercontent.com/1508181/223484557-32df0143-4b5e-4d65-8d64-80bf757ccc3d.png)



## Checklist
 
 - [ ] ~~_CHANGELOG.md_ was updated~~ (not needed)
