### PR TITLE
Add notification popup on game installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Update Traditional Chinese translation (thanks to s8321414)
 - Added additional tooltips to buttons, labels, menu items and radio buttons (thanks to orende)
 - Hide CDPR Goodie Pack Content
+- Add notifications on successful download and installation of games (thanks to orende)
 
 **1.2.2**
 - Fix progress bar not showing up for downloads

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -346,7 +346,6 @@ class GameTile(Gtk.Box):
             popup = Notify.Notification.new("Minigalaxy", _("Finished downloading and installing {}")
                                             .format(self.game.name), "dialog-information")
             popup.show()
-            popup.close()
         else:
             GLib.idle_add(self.parent.parent.show_error, _("Failed to install {}").format(self.game.name), err_msg)
             GLib.idle_add(self.update_to_state, failed_state)

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -17,7 +17,7 @@ from minigalaxy.launcher import start_game
 from minigalaxy.installer import uninstall_game, install_game, check_diskspace
 from minigalaxy.paths import ICON_WINE_PATH
 from minigalaxy.api import NoDownloadLinkFound, Api
-from minigalaxy.ui.gtk import Gtk, GLib
+from minigalaxy.ui.gtk import Gtk, GLib, Notify
 from minigalaxy.ui.information import Information
 from minigalaxy.ui.properties import Properties
 
@@ -343,6 +343,10 @@ class GameTile(Gtk.Box):
                 self.game.set_dlc_info("version", self.api.get_version(self.game, dlc_name=dlc_title), dlc_title)
             else:
                 self.game.set_info("version", self.api.get_version(self.game))
+            popup = Notify.Notification.new("Minigalaxy", _("Finished downloading and installing {}")
+                                            .format(self.game.name), "dialog-information")
+            popup.show()
+            popup.close()
         else:
             GLib.idle_add(self.parent.parent.show_error, _("Failed to install {}").format(self.game.name), err_msg)
             GLib.idle_add(self.update_to_state, failed_state)

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -18,7 +18,7 @@ from minigalaxy.installer import uninstall_game, install_game, check_diskspace
 from minigalaxy.css import CSS_PROVIDER
 from minigalaxy.paths import ICON_WINE_PATH
 from minigalaxy.api import NoDownloadLinkFound, Api
-from minigalaxy.ui.gtk import Gtk, GLib
+from minigalaxy.ui.gtk import Gtk, GLib, Notify
 from minigalaxy.ui.information import Information
 from minigalaxy.ui.properties import Properties
 
@@ -324,6 +324,10 @@ class GameTileList(Gtk.Box):
         install_success = self.__install(save_location)
         if install_success:
             self.__check_for_dlc(self.api.get_info(self.game))
+            popup = Notify.Notification.new("Minigalaxy", _("Finished downloading and installing {}")
+                                            .format(self.game.name), "dialog-information")
+            popup.show()
+            popup.close()
 
     def __install(self, save_location, update=False, dlc_title=""):
         if update:

--- a/minigalaxy/ui/gtk.py
+++ b/minigalaxy/ui/gtk.py
@@ -2,3 +2,5 @@ import gi
 
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, Gio, GLib, GdkPixbuf  # noqa: E402,F401
+gi.require_version('Notify', '0.7')
+from gi.repository import Notify  # noqa: E402,F401

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -9,7 +9,7 @@ from minigalaxy.api import Api
 from minigalaxy.paths import UI_DIR, LOGO_IMAGE_PATH, THUMBNAIL_DIR, COVER_DIR, ICON_DIR
 from minigalaxy.translation import _
 from minigalaxy.ui.library import Library
-from minigalaxy.ui.gtk import Gtk, Gdk, GdkPixbuf
+from minigalaxy.ui.gtk import Gtk, Gdk, GdkPixbuf, Notify
 from minigalaxy.config import Config
 
 
@@ -42,6 +42,9 @@ class Window(Gtk.ApplicationWindow):
         self.config = config
         self.search_string = ""
         self.offline = False
+
+        # Initialize notifications module
+        Notify.init("minigalaxy")
 
         # Set library
         self.library = Library(self, config, api, download_manager)

--- a/tests/test_ui_library.py
+++ b/tests/test_ui_library.py
@@ -45,6 +45,9 @@ class UnitTestGiRepository:
     class GLib:
         pass
 
+    class Notify:
+        pass
+
 
 u_gi_repository = UnitTestGiRepository()
 sys.modules['gi.repository'] = u_gi_repository

--- a/tests/test_ui_window.py
+++ b/tests/test_ui_window.py
@@ -45,6 +45,7 @@ class UnitTestGiRepository:
     GdkPixbuf = MagicMock()
     Gio = MagicMock()
     GLib = MagicMock
+    Notify = MagicMock()
 
 
 u_gi_repository = UnitTestGiRepository()


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

Shows a native notification popup when games have been successfully downloaded and installed. Partially addresses #566 .

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
