### PR TITLE
Remove popup.close() call in gametilelist.py

### DIFF
--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -327,7 +327,6 @@ class GameTileList(Gtk.Box):
             popup = Notify.Notification.new("Minigalaxy", _("Finished downloading and installing {}")
                                             .format(self.game.name), "dialog-information")
             popup.show()
-            popup.close()
 
     def __install(self, save_location, update=False, dlc_title=""):
         if update:


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

Removes the call to the close method as it causes the popup to immediately close after showing on the Gnome DE. This changes was accidentally left out of #571.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
