### PR TITLE
Use threads to speed up connectivity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Hide CDPR Goodie Pack Content
 - Add notifications on successful download and installation of games (thanks to orende)
 - Add category filtering dialog for game library (thanks to orende)
+- Parallelize api.can_connect function with threads, futures (thanks to orende)
 
 **1.2.2**
 - Fix progress bar not showing up for downloads

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -73,10 +73,14 @@ class Window(Gtk.ApplicationWindow):
         self.make_directories()
 
         # Interact with the API
+        logger.debug("Checking API connectivity...")
         self.offline = not self.api.can_connect()
+        logger.debug("Done checking API connectivity, status: %s", "offline" if self.offline else "online")
         if not self.offline:
             try:
+                logger.debug("Authenticating...")
                 self.__authenticate()
+                logger.debug("Authenticated as: %s", self.api.get_user_info())
                 self.HeaderBar.set_subtitle(self.api.get_user_info())
             except Exception:
                 logger.warn("Starting in offline mode after receiving exception", exc_info=1)


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

Adds a ThreadPoolExecutor to the api.can_connect function in order to send the requests to embed.gog.com and auth.gog.com from separate threads. This lowers the worst case execution time from 10 seconds to 5 seconds, which is noticeable on slow connections.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
