### PR TITLE
Make changelog builder able to deal with special characters

### DIFF
--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -54,7 +54,7 @@ init_metadata() {
 add_metadata_entry() {
   xmlstarlet ed -L \
   -s /component/releases/release[@version="'$VERSION'"]/description/ul \
-  -t elem -n li -v "$(echo $@|sed 's/^- //')" \
+  -t elem -n li -v "$(echo $@|sed 's/^- //'|sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')" \
   "${METADATA_FILE}"
 }
 


### PR DESCRIPTION
The last time something went wrong with building the metadata file because there was an & in it.

<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

<!-- Describe what was changed -->

## Checklist
 
 - [ ] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
