### PR TITLE
Adding Flatpak to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ sudo xbps-install -S minigalaxy
 </pre>
 </details>
 
+<details><summary>Flatpak</summary>
+
+Available on <a href="https://flathub.org/apps/io.github.sharkwouter.Minigalaxy">Flathub</a>. You can install it with:
+<pre>
+flatpak install flathub io.github.sharkwouter.Minigalaxy
+</pre>
+</details>
+
 <details><summary>Other distributions</summary>
 
 On other distributions, Minigalaxy can be downloaded and started with the following commands:


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

I considered making this an issue, but I figured I could just write the change, and you can decline the pull request if you don't want it. 

I only noticed today that Minigalaxy has what seems to be an [official & maintained release](https://flathub.org/apps/io.github.sharkwouter.Minigalaxy) on Flathub. However, it is not mentioned on the README/website. I added a section under Installation for Flatpak like the other entries. This would help make sure people don't miss this option.

<!-- Describe what was changed -->

## Checklist
 
 - [ ] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
