### PR TITLE
Fix Remove forward slash from desktop filename (Shenzhen I/O)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **1.3.0**
+- Fix Remove forward slash from desktop filename for Shenzhen I/O (thanks to slowsage)
 - Fix race when preparing download location (thanks to viacheslavka)
 - Fix multithreaded downloads of Windows games (thanks to viacheslavka)
 - Fix DLC installation for Windows games (thanks to viacheslavka)

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -19,11 +19,11 @@ class Game:
         self.category = category
         self.status_file_path = self.get_status_file_path()
 
-    def get_stripped_name(self):
-        return self.__strip_string(self.name)
+    def get_stripped_name(self, to_path=False):
+        return self.__strip_string(self.name, to_path)
 
     def get_install_directory_name(self):
-        return re.sub('[^A-Za-z0-9 ]+', '', self.name)
+        return self.__strip_string(self.name, to_path=True)
 
     def get_status_file_path(self):
         if self.install_dir:
@@ -47,8 +47,8 @@ class Game:
             json.dump(json_dict, status_file)
 
     @staticmethod
-    def __strip_string(string):
-        return re.sub('[^A-Za-z0-9]+', '', string)
+    def __strip_string(string, to_path=False):
+        return re.sub('[^A-Za-z0-9]+', '', string) if not to_path else re.sub('[^A-Za-z0-9 ]+', '', string)
 
     def is_installed(self, dlc_title="") -> bool:
         installed = False

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -245,7 +245,7 @@ def get_exec_line(game):
 
 def create_applications_file(game):
     error_message = ""
-    path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))
+    path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.get_stripped_name(to_path=True)))
     exe_cmd = get_exec_line(game)
     # Create desktop file definition
     desktop_context = {
@@ -336,8 +336,9 @@ def uninstall_game(game):
     shutil.rmtree(game.install_dir, ignore_errors=True)
     if os.path.isfile(game.status_file_path):
         os.remove(game.status_file_path)
-    if os.path.isfile(os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name))):
-        os.remove(os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.name)))
+    path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.get_stripped_name(to_path=True)))
+    if os.path.isfile(path_to_shortcut):
+        os.remove(path_to_shortcut)
 
 
 def _exe_cmd(cmd):


### PR DESCRIPTION
## Description

Installing Shenzhen I/O throws the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/minigalaxy/installer.py", line 72, in install_game
    error_message = create_applications_file(game)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/minigalaxy/installer.py", line 271, in create_applications_file
    os.remove(path_to_shortcut)
FileNotFoundError: [Errno 2] No such file or directory: '/home/USERNAME/.local/share/applications/SHENZHEN I/O.desktop'

```
`/` is not a valid character for a filename in linux. This PR removes all `/` from the filename part of the path.
## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))