### PR TITLE
Remove deprecated attributes from AppData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**1.3.1**
+- Minor AppData fixes (thanks to tim77)
+
 **1.3.0**
 - Fix Remove forward slash from desktop filename for Shenzhen I/O (thanks to slowsage)
 - Fix race when preparing download location (thanks to viacheslavka)

--- a/data/io.github.sharkwouter.Minigalaxy.metainfo.xml
+++ b/data/io.github.sharkwouter.Minigalaxy.metainfo.xml
@@ -328,7 +328,6 @@
     <content_attribute id="language-humor">intense</content_attribute>
     <content_attribute id="language-profanity">intense</content_attribute>
     <content_attribute id="money-gambling">none</content_attribute>
-    <content_attribute id="money-purchasing">moderate</content_attribute>
     <content_attribute id="sex-adultery">moderate</content_attribute>
     <content_attribute id="sex-appearance">moderate</content_attribute>
     <content_attribute id="sex-homosexuality">moderate</content_attribute>
@@ -345,7 +344,6 @@
     <content_attribute id="violence-desecration">intense</content_attribute>
     <content_attribute id="violence-fantasy">intense</content_attribute>
     <content_attribute id="violence-realistic">intense</content_attribute>
-    <content_attribute id="violence-sexual">moderate</content_attribute>
     <content_attribute id="violence-slavery">intense</content_attribute>
     <content_attribute id="violence-worship">intense</content_attribute>
   </content_rating>


### PR DESCRIPTION
## Description
Minigalaxy `v1.3.0` doesn't pass [Flathub linter](https://buildbot.flathub.org/#/builders/6/builds/127279) due AppData invalid attributes:
```
"E: io.github.sharkwouter.Minigalaxy:331: content-attribute-value-invalid money-purchasing @ moderate",
"E: io.github.sharkwouter.Minigalaxy:348: content-attribute-value-invalid violence-sexual @ moderate",
"W: io.github.sharkwouter.Minigalaxy:52: tag-empty ul/li"
```

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
