### PR TITLE
Remove unused <li/> tag in AppData

### DIFF
--- a/data/io.github.sharkwouter.Minigalaxy.metainfo.xml
+++ b/data/io.github.sharkwouter.Minigalaxy.metainfo.xml
@@ -49,7 +49,6 @@
         <p>Implements the following changes:</p>
         <ul>
           <li>Fix changing the install path causing an exception</li>
-          <li/>
         </ul>
       </description>
     </release><release version="1.2.5" date="2023-08-11">


### PR DESCRIPTION
## Description
It seems like this one tag is unused. [Flathub liter](https://buildbot.flathub.org/#/builders/6/builds/127346) still complain and threat this as error. Please check. Maybe there is more issues like this one with `tag-empty ul/li`.

```
"W: io.github.sharkwouter.Minigalaxy:52: tag-empty ul/li"
```

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
