### PR TITLE
Fix Windows games with multiple parts not installing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **1.3.1**
+- Fix Windows games with multiple parts not installing with wine
 - Minor AppData fixes (thanks to tim77)
 - Added Portuguese translation (thanks to GLSWV)
 

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -2,7 +2,6 @@ import shutil
 import locale
 import os
 import threading
-import re
 import time
 import urllib.parse
 
@@ -285,7 +284,7 @@ class GameTile(Gtk.Box):
                 break
             info = self.api.get_download_file_info(file_info["downlink"])
             total_file_size += info.size
-            # Extract the filename from the download url (filename is between %2F and &token)
+            # Extract the filename from the download url
             filename = urllib.parse.unquote(urllib.parse.urlsplit(download_url).path)
             filename = filename.split("/")[-1]
             download_path = os.path.join(self.download_dir, filename)

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -285,11 +285,9 @@ class GameTile(Gtk.Box):
                 break
             info = self.api.get_download_file_info(file_info["downlink"])
             total_file_size += info.size
-            try:
-                # Extract the filename from the download url (filename is between %2F and &token)
-                filename = urllib.parse.unquote(re.search('%2F(((?!%2F).)*)&t', download_url).group(1))
-            except AttributeError:
-                filename = "{}-{}.bin".format(self.game.get_stripped_name(), key)
+            # Extract the filename from the download url (filename is between %2F and &token)
+            filename = urllib.parse.unquote(urllib.parse.urlsplit(download_url).path)
+            filename = filename.split("/")[-1]
             download_path = os.path.join(self.download_dir, filename)
             if info.md5:
                 self.game.md5sum[os.path.basename(download_path)] = info.md5

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -2,7 +2,6 @@ import shutil
 import locale
 import os
 import threading
-import re
 import time
 import urllib.parse
 
@@ -291,11 +290,9 @@ class GameTileList(Gtk.Box):
                 break
             info = self.api.get_download_file_info(file_info["downlink"])
             total_file_size += info.size
-            try:
-                # Extract the filename from the download url (filename is between %2F and &token)
-                filename = urllib.parse.unquote(re.search('%2F(((?!%2F).)*)&t', download_url).group(1))
-            except AttributeError:
-                filename = "{}-{}.bin".format(self.game.get_stripped_name(), key)
+            # Extract the filename from the download url
+            filename = urllib.parse.unquote(urllib.parse.urlsplit(download_url).path)
+            filename = filename.split("/")[-1]
             download_path = os.path.join(self.download_dir, filename)
             if info.md5:
                 self.game.md5sum[os.path.basename(download_path)] = info.md5


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

Right now Windows games of which the installer consisting of multiple files are failing to install with 1.3.0. It seems to be caused by the urls on GOGs end having changed to no longer include the token. This PR should fix this in a more future proof way.

<!-- Describe what was changed -->

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
