### PR TITLE
Fix extract_by_wine when PC has optical drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fixed windows install issue for PCs with optical drives (thanks to GB609)
+
 **1.3.1**
 - Fix Windows games with multiple parts not installing with wine
 - Minor AppData fixes (thanks to tim77)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-- Fixed windows install issue for PCs with optical drives (thanks to GB609)
+**1.3.2**
+- Fix issue with windows install via wine on systems with optical drives (thanks to GB609)
 
 **1.3.1**
 - Fix Windows games with multiple parts not installing with wine

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -183,15 +183,13 @@ def extract_by_wine(game, installer, temp_dir):
     err_msg = ""
     # Set the prefix for Windows games
     prefix_dir = os.path.join(game.install_dir, "prefix")
-    """
-    pick a letter that is unlikely to create collisions with the actual mount/hw setup:
+    """pick a letter that is unlikely to create collisions with the actual mount/hw setup:
     wine creates links for mounted media and optical drives
-    this might lead to errors because wine knows 2 names for these - d: and d:: 
+    this might lead to errors because wine knows 2 names for these - d: and d::
     (difference: : exposes directory, :: exposes the block device itself)
-    But they can't exist at the same time within a prefix
-    Changing this letter is a temporary fix, the entire install method requires an overhaul in the long run
-    """
-    drive = os.path.join(prefix_dir, "dosdevices", "x:")
+    But they can't exist at the same time within a prefix.
+    Changing this letter is a temporary fix, the entire install method requires an overhaul in the long run"""
+    drive = os.path.join(prefix_dir, "dosdevices", "t:")
     if not os.path.exists(prefix_dir):
         os.makedirs(prefix_dir, mode=0o755)
         # Creating the prefix before modifying dosdevices
@@ -210,7 +208,8 @@ def extract_by_wine(game, installer, temp_dir):
     if exitcode not in [0]:
         err_msg = _("Wine extraction failed.")
     elif os.path.exists(drive):
-        #check for existence as a pure safety-measure in case some power-user has pre-configured the letter we picked with double colon
+        """check for existence as a pure safety-measure in case
+        some power-user has pre-configured the letter we picked with double colon"""
         os.unlink(drive)
         os.symlink("../../..", drive)
     return err_msg

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -183,7 +183,15 @@ def extract_by_wine(game, installer, temp_dir):
     err_msg = ""
     # Set the prefix for Windows games
     prefix_dir = os.path.join(game.install_dir, "prefix")
-    drive = os.path.join(prefix_dir, "dosdevices", "d:")
+    """
+    pick a letter that is unlikely to create collisions with the actual mount/hw setup:
+    wine creates links for mounted media and optical drives
+    this might lead to errors because wine knows 2 names for these - d: and d:: 
+    (difference: : exposes directory, :: exposes the block device itself)
+    But they can't exist at the same time within a prefix
+    Changing this letter is a temporary fix, the entire install method requires an overhaul in the long run
+    """
+    drive = os.path.join(prefix_dir, "dosdevices", "x:")
     if not os.path.exists(prefix_dir):
         os.makedirs(prefix_dir, mode=0o755)
         # Creating the prefix before modifying dosdevices
@@ -201,7 +209,8 @@ def extract_by_wine(game, installer, temp_dir):
     stdout, stderr, exitcode = _exe_cmd(command)
     if exitcode not in [0]:
         err_msg = _("Wine extraction failed.")
-    else:
+    elif os.path.exists(drive):
+        #check for existence as a pure safety-measure in case some power-user has pre-configured the letter we picked with double colon
         os.unlink(drive)
         os.symlink("../../..", drive)
     return err_msg


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

Changed the temporary secondary drive used in dosdevices during windows wine installation from `d:` to `t:` which is less likely to create name collisions with real drives created by wine itself. Applies whenever wine creates `d::` during prefix creation.

`d:` and `d::` can't exist at the same time, so wine is removing one of the mappings on its own again. When the removed mapping happens to be `d:` created by the installer, the unlink statement after successful installation will fail because `d:` doesn't exist at that point in time anymore. This error will bubble up as unexpected and abort the entire game installation process.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
