### PR TITLE
Support UMU-Launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,15 @@ Other Linux distributions may work as well. Minigalaxy requires the following de
 To run windows games, the following optional dependencies are required:
 
 - wine or umu-launcher (as an alternative to standard wine)
-- innoextract: for installations with native linux tools
+- innoextract: For installations with native linux tools
+- zenity: Used by UMU-Launcher to show progress dialogs when updating the proton framework. Not required to use UMU.
 
 **Note:**
 
 Some 'native' Linux games available on GOG are Windows applications prepackaged with Wine in reality.
-Running them with UMU-Launcher can not be guaranteed to work in all situations. 
+Using UMU-Launcher as runner can not be guaranteed to work in all situations.
 Depending on the game directory structure, Minigalaxy might not be able to detect that it is a windows game
-and thus won't be able to configure or change the actual wine invocation.
+and thus won't be able to change the actual wine invocation of the game itself.
 
 Also, Minigalaxy expects all dependencies of Wine to be setup correctly, it can't install missing drivers, plugins or packages.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ Other Linux distributions may work as well. Minigalaxy requires the following de
 - Python Requests
 - gettext
 
+To run windows games, the following optional dependencies are required:
+
+- wine or umu-launcher (as an alternative to standard wine)
+- innoextract: for installations with native linux tools
+
+**Note:**
+
+Some 'native' Linux games available on GOG are Windows applications prepackaged with Wine in reality.
+Running them with UMU-Launcher can not be guaranteed to work in all situations. 
+Depending on the game directory structure, Minigalaxy might not be able to detect that it is a windows game
+and thus won't be able to configure or change the actual wine invocation.
+
+Also, Minigalaxy expects all dependencies of Wine to be setup correctly, it can't install missing drivers, plugins or packages.
+
 ## Installation
 
 <a href="https://repology.org/project/minigalaxy/versions">

--- a/data/po/de.po
+++ b/data/po/de.po
@@ -446,9 +446,17 @@ msgstr "Ob versteckte Spiele in der Bibliothek angezeigt werden oder nicht"
 #: data/ui/preferences.ui:285
 msgctxt "create_menu_shortcuts_tooltip"
 msgid "Whether shortcuts are created for newly installed games or not"
-msgstr ""
-"Ob Verknüpfungen für neu installierte Spiele erstellt werden oder nicht"
+msgstr "Ob Verknüpfungen für neu installierte Spiele erstellt werden oder nicht"
 
+#: data/ui/preferences.ui:298
+msgctxt "windows_wine_variant_tooltip"
+msgid "Define the wine variant to use as default runner for new windows game installations."
+msgstr "Variante von wine, die standardmäßig für neu installierte Windows-Spiele verwendet werden soll."
+
+#: data/ui/preferences.ui:301
+msgctxt "windows_wine_variant"
+msgid "Default wine variant: "
+msgstr "Standard wine Variante: "
 #: minigalaxy/installer.py:172
 msgid "Wine extraction failed."
 msgstr "Entpacken mit Wine fehlgeschlagen."

--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -292,6 +292,31 @@
               </packing>
             </child>
             <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="windows_wine_variant_tooltip">Define the wine variant to use as default runner for new windows game installations.</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="windows_wine_variant" comments="Has to end with &quot;: &quot;">Default wine variant: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">9</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="combobox_wine_variant">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="valign">center</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">9</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkSwitch" id="switch_create_applications_file">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
@@ -300,7 +325,7 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">9</property>
+                <property name="top-attach">10</property>
               </packing>
             </child>
             <child>
@@ -314,7 +339,7 @@
               </object>
               <packing>
                 <property name="left-attach">0</property>
-                <property name="top-attach">9</property>
+                <property name="top-attach">10</property>
               </packing>
             </child>
             <child>

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -134,6 +134,15 @@ class Config:
         self.__write()
 
     @property
+    def default_wine_runner(self) -> str:
+        return self.__config.get("default_wine_runner", "wine")
+
+    @default_wine_runner.setter
+    def default_wine_runner(self, new_value: str) -> None:
+        self.__config["default_wine_runner"] = new_value
+        self.__write()
+
+    @property
     def keep_window_maximized(self) -> bool:
         return self.__config.get("keep_window_maximized", False)
 

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -54,6 +54,11 @@ VIEWS = [
     ["list", _("List")],
 ]
 
+WINE_VARIANTS = [
+    ["wine", _("Wine")],
+    ["umu-run", _("UMU-Launcher")]
+]
+
 # Game IDs to ignore when received by the API
 IGNORE_GAME_IDS = [
     1424856371,  # Hotline Miami 2: Wrong Number - Digital Comics

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import shlex
 import subprocess
 import hashlib
 import textwrap
@@ -249,21 +250,13 @@ def copy_thumbnail(game):
             error_message = e
     return error_message
 
-
-def get_exec_line(game):
-    exe_cmd_list = get_execute_command(game)
-    for i in range(len(exe_cmd_list)):
-        exe_cmd_list[i] = exe_cmd_list[i].replace(" ", "\\ ")
-    return " ".join(exe_cmd_list)
-
-
 def create_applications_file(game):
     error_message = ""
     path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.get_stripped_name(to_path=True)))
-    exe_cmd = get_exec_line(game)
+    exe_cmd = shlex.join(get_execute_command(game))
     # Create desktop file definition
     desktop_context = {
-        "game_bin_path": os.path.join('"{}"'.format(game.install_dir.replace('"', '\\"')), exe_cmd),
+        "game_bin_path": exe_cmd,
         "game_name": game.name,
         "game_install_dir": game.install_dir,
         "game_icon_path": os.path.join(game.install_dir, 'support/icon.png')

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -217,6 +217,15 @@ def extract_by_wine(game: Game, installer: str, temp_dir: str, config: Config):
     command = ["env", *wine_env, wine_bin, installer, *installer_args]
     stdout, stderr, exitcode = _exe_cmd(command, False, True)
     if exitcode not in [0]:
+        linesToWrite = [
+            "#!/bin/sh",
+            '',
+            shlex.join(command)
+        ]
+        if os.path.exists(game.install_dir):
+            #FIXME fix with test somehow, also do the same for prefix creation
+            with open(os.path.join(game.install_dir, 'minigalaxy_install_wine_game.sh'), 'w') as f:
+                f.writelines(linesToWrite)
         return _("Wine extraction failed.")
 
     return ""

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -11,7 +11,7 @@ from minigalaxy.logger import logger
 from minigalaxy.translation import _
 from minigalaxy.launcher import get_execute_command
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, APPLICATIONS_DIR
-from minigalaxy.wine_utils import is_wine_installed, get_wine_env, get_wine_path
+from minigalaxy.wine_utils import get_wine_env, get_wine_path
 
 
 def get_available_disk_space(location):
@@ -208,7 +208,7 @@ def extract_by_wine(game: Game, installer: str, temp_dir: str, config: Config):
         os.unlink(drive)
     os.symlink(temp_dir, drive)
     _dir = f'{drive_letter}:\\\"{os.path.basename(game.install_dir)}\"'
-    '''It's possible to set install dir as argument before installation, 
+    '''It's possible to set install dir as argument before installation,
     but the argument must be a double-quoted windows-style path: '/DIR="path"'
     Reason: blanks in game.install_dir are processed twice: via POpen and on the WIN cmd in wine again'''
     command = ["env", *wine_env, wine_bin, installer, "\'/DIR={}\'".format(_dir), "/VERYSILENT"]

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -8,14 +8,7 @@ import threading
 
 from minigalaxy.logger import logger
 from minigalaxy.translation import _
-
-
-def get_wine_path(game):
-    binary_name = "wine"
-    custom_wine_path = game.get_info("custom_wine")
-    if custom_wine_path and custom_wine_path != shutil.which(binary_name):
-        binary_name = custom_wine_path
-    return binary_name
+from minigalaxy.wine_utils import is_wine_installed, get_wine_path
 
 
 def config_game(game):
@@ -92,7 +85,7 @@ def determine_launcher_type(files):
         launcher_type = "scummvm"
     elif "start.sh" in files:
         launcher_type = "start_script"
-    elif "prefix" in files and shutil.which("wine"):
+    elif "prefix" in files and is_wine_installed():
         launcher_type = "wine"
     elif "game" in files:
         launcher_type = "final_resort"

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -178,7 +178,7 @@ def get_final_resort_exe_cmd(game, files):
         if re.match(r'^goggame-[0-9]*\.info$', file):
             os.chdir(os.path.join(game.install_dir, game_dir))
             with open(file, 'r') as info_file:
-                info = json.loads(info_file.read())                
+                info = json.loads(info_file.read())
                 exe_cmd = [os.path.join(game.install_dir, info["playTasks"][0]["path"])]
     return exe_cmd
 

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -47,7 +47,7 @@ def get_execute_command(game) -> list:
     is_wine_cmd = False
     launcher_type = determine_launcher_type(files)
     if launcher_type in ["start_script", "wine"]:
-        exe_cmd = get_start_script_exe_cmd()
+        exe_cmd = get_start_script_exe_cmd(game)
     elif launcher_type == "windows":
         exe_cmd = get_windows_exe_cmd(game, files)
         is_wine_cmd = True
@@ -106,7 +106,6 @@ def get_exe_cmd_with_var_command(game, exe_cmd, is_wine_cmd):
 def get_windows_exe_cmd(game, files):
     exe_cmd = []
     prefix = os.path.join(game.install_dir, "prefix")
-    os.environ["WINEPREFIX"] = prefix
 
     # Find game executable file
     for file in files:
@@ -141,7 +140,7 @@ def get_windows_exe_cmd(game, files):
     if not os.path.exists(gamelink):
         os.symlink('../..', gamelink)
 
-    return ['env', *get_wine_env(game)] + exe_cmd
+    return [shutil.which('env'), *get_wine_env(game)] + exe_cmd
 
 
 def get_dosbox_exe_cmd(game, files):
@@ -153,7 +152,7 @@ def get_dosbox_exe_cmd(game, files):
         if re.match(r'^dosbox_?([a-z]|[A-Z]|\d)+_single\.conf$', file):
             dosbox_config_single = file
     logger.info("Using system's dosbox to launch %s", game.name)
-    return ["dosbox", "-conf", dosbox_config, "-conf", dosbox_config_single, "-no-console", "-c", "exit"]
+    return [shutil.which("dosbox"), "-conf", dosbox_config, "-conf", dosbox_config_single, "-no-console", "-c", "exit"]
 
 
 def get_scummvm_exe_cmd(game, files):
@@ -163,11 +162,11 @@ def get_scummvm_exe_cmd(game, files):
             scummvm_config = file
             break
     logger.info("Using system's scrummvm to launch %s", game.name)
-    return ["scummvm", "-c", scummvm_config]
+    return [shutil.which("scummvm"), "-c", scummvm_config]
 
 
-def get_start_script_exe_cmd():
-    return ["./start.sh"]
+def get_start_script_exe_cmd(game):
+    return [os.path.join(game.install_dir, "start.sh")]
 
 
 def get_final_resort_exe_cmd(game, files):
@@ -179,8 +178,8 @@ def get_final_resort_exe_cmd(game, files):
         if re.match(r'^goggame-[0-9]*\.info$', file):
             os.chdir(os.path.join(game.install_dir, game_dir))
             with open(file, 'r') as info_file:
-                info = json.loads(info_file.read())
-                exe_cmd = ["./{}".format(info["playTasks"][0]["path"])]
+                info = json.loads(info_file.read())                
+                exe_cmd = [os.path.join(game.install_dir, info["playTasks"][0]["path"])]
     return exe_cmd
 
 

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -4,6 +4,7 @@ import shutil
 import re
 import json
 import glob
+import shlex
 import threading
 
 from minigalaxy.config import Config
@@ -87,13 +88,13 @@ def determine_launcher_type(files):
 
 
 def get_exe_cmd_with_var_command(game, exe_cmd, is_wine_cmd):
-    command_list = game.get_info("command").split()
+    command_list = shlex.split(game.get_info("command"))
 
     if is_wine_cmd:
         # wine handles all envs on its own
         return exe_cmd + command_list
 
-    var_list = game.get_info("variable").split()
+    var_list = shlex.split(game.get_info("variable"))
     if var_list:
         if var_list[0] not in ["env"]:
             var_list.insert(0, "env")

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -135,7 +135,7 @@ class GameTile(Gtk.Box):
 
     @Gtk.Template.Callback("on_menu_button_properties_clicked")
     def show_properties(self, button):
-        properties_window = Properties(self, self.game, self.api)
+        properties_window = Properties(self, self.game, self.config, self.api)
         properties_window.run()
         properties_window.destroy()
 
@@ -337,10 +337,7 @@ class GameTile(Gtk.Box):
         err_msg = install_game(
             self.game,
             save_location,
-            self.config.lang,
-            self.config.install_dir,
-            self.config.keep_installers,
-            self.config.create_applications_file
+            self.config
         )
         if not err_msg:
             GLib.idle_add(self.update_to_state, success_state)

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -141,7 +141,7 @@ class GameTileList(Gtk.Box):
 
     @Gtk.Template.Callback("on_menu_button_properties_clicked")
     def show_properties(self, button):
-        properties_window = Properties(self, self.game, self.api)
+        properties_window = Properties(self, self.game, self.config, self.api)
         properties_window.run()
         properties_window.destroy()
 
@@ -346,10 +346,7 @@ class GameTileList(Gtk.Box):
         err_msg = install_game(
             self.game,
             save_location,
-            self.config.lang,
-            self.config.install_dir,
-            self.config.keep_installers,
-            self.config.create_applications_file
+            self.config
         )
         if not err_msg:
             GLib.idle_add(self.update_to_state, success_state)

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -1,12 +1,13 @@
 import os
 import locale
-import shutil
+
 from minigalaxy.translation import _
 from minigalaxy.paths import UI_DIR
-from minigalaxy.constants import SUPPORTED_DOWNLOAD_LANGUAGES, SUPPORTED_LOCALES, VIEWS
+from minigalaxy.constants import SUPPORTED_DOWNLOAD_LANGUAGES, SUPPORTED_LOCALES, VIEWS, WINE_VARIANTS
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.ui.gtk import Gtk
 from minigalaxy.config import Config
+from minigalaxy.wine_utils import is_wine_installed
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "preferences.ui"))
@@ -16,6 +17,7 @@ class Preferences(Gtk.Dialog):
     combobox_program_language = Gtk.Template.Child()
     combobox_language = Gtk.Template.Child()
     combobox_view = Gtk.Template.Child()
+    combobox_wine_variant = Gtk.Template.Child()
     button_file_chooser = Gtk.Template.Child()
     label_keep_installers = Gtk.Template.Child()
     switch_keep_installers = Gtk.Template.Child()
@@ -33,9 +35,11 @@ class Preferences(Gtk.Dialog):
         self.config = config
         self.download_manager = download_manager
 
-        self.__set_locale_list()
-        self.__set_language_list()
-        self.__set_view_list()
+        self.__init_combobox(self.combobox_program_language, SUPPORTED_LOCALES, self.config.locale)
+        self.__init_combobox(self.combobox_language, SUPPORTED_DOWNLOAD_LANGUAGES, self.config.lang)
+        self.__init_combobox(self.combobox_view, VIEWS, self.config.view)
+        self.__init_combobox(self.combobox_wine_variant, WINE_VARIANTS, self.config.default_wine_runner)
+
         self.button_file_chooser.set_filename(self.config.install_dir)
         self.switch_keep_installers.set_active(self.config.keep_installers)
         self.switch_stay_logged_in.set_active(self.config.stay_logged_in)
@@ -50,95 +54,54 @@ class Preferences(Gtk.Dialog):
             _("Keep installers after downloading a game.\nInstallers are stored in: {}").format(installer_dir)
         )
 
-    def __set_locale_list(self) -> None:
-        locales = Gtk.ListStore(str, str)
-        for local in SUPPORTED_LOCALES:
-            locales.append(local)
+    def __init_combobox(self, combobox, data_feed: [], active_option) -> None:
+        """expects 2-dimensional array with 2 columns for data
+        first entry per row is the config key, second one the string to display in the UI
+        """
+        datalist = Gtk.ListStore(str, str)
+        for entry in data_feed:
+            datalist.append(entry)
 
-        self.combobox_program_language.set_model(locales)
-        self.combobox_program_language.set_entry_text_column(1)
-        self.renderer_text = Gtk.CellRendererText()
-        self.combobox_program_language.pack_start(self.renderer_text, False)
-        self.combobox_program_language.add_attribute(self.renderer_text, "text", 1)
-
-        # Set the active option
-        current_locale = self.config.locale
-        default_locale = locale.getdefaultlocale()
-        if current_locale is None:
-            locale.setlocale(locale.LC_ALL, default_locale)
-        for key in range(len(locales)):
-            if locales[key][:1][0] == current_locale:
-                self.combobox_program_language.set_active(key)
-                break
-
-    def __set_language_list(self) -> None:
-        languages = Gtk.ListStore(str, str)
-        for lang in SUPPORTED_DOWNLOAD_LANGUAGES:
-            languages.append(lang)
-
-        self.combobox_language.set_model(languages)
-        self.combobox_language.set_entry_text_column(1)
-        self.renderer_text = Gtk.CellRendererText()
-        self.combobox_language.pack_start(self.renderer_text, False)
-        self.combobox_language.add_attribute(self.renderer_text, "text", 1)
+        combobox.set_model(datalist)
+        combobox.set_entry_text_column(1)
+        # renderer can't be shared, no need to put it into a class member
+        renderer_text = Gtk.CellRendererText()
+        combobox.pack_start(renderer_text, False)
+        combobox.add_attribute(renderer_text, "text", 1)
 
         # Set the active option
-        current_lang = self.config.lang
-        for key in range(len(languages)):
-            if languages[key][:1][0] == current_lang:
-                self.combobox_language.set_active(key)
+        for key in range(len(datalist)):
+            if datalist[key][:1][0] == active_option:
+                combobox.set_active(key)
                 break
 
-    def __set_view_list(self) -> None:
-        views = Gtk.ListStore(str, str)
-        for view in VIEWS:
-            views.append(view)
+    def __save_combo_value(self, combobox, prop_name) -> bool:
+        """puts current value (first array element in model for selection) into config[prop_name]
+        returns true if the value has changed"""
+        active_choice = combobox.get_active_iter()
+        current_config = getattr(self.config, prop_name)
+        value = current_config
+        if active_choice is not None:
+            model = combobox.get_model()
+            value, _ = model[active_choice][:2]
+            setattr(self.config, prop_name, value)
+        return value != current_config
 
-        self.combobox_view.set_model(views)
-        self.combobox_view.set_entry_text_column(1)
-        self.renderer_text = Gtk.CellRendererText()
-        self.combobox_view.pack_start(self.renderer_text, False)
-        self.combobox_view.add_attribute(self.renderer_text, "text", 1)
-
-        # Set the active option
-        current_view = self.config.view
-        for key in range(len(views)):
-            if views[key][:1][0] == current_view:
-                self.combobox_view.set_active(key)
-                break
 
     def __save_locale_choice(self) -> None:
-        new_locale = self.combobox_program_language.get_active_iter()
-        if new_locale is not None:
-            model = self.combobox_program_language.get_model()
-            locale_choice = model[new_locale][-2]
-            if locale_choice == '':
-                default_locale = locale.getdefaultlocale()[0]
-                locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
-                self.config.locale = locale_choice
-            else:
-                try:
-                    locale.setlocale(locale.LC_ALL, (locale_choice, 'UTF-8'))
-                    self.config.locale = locale_choice
-                except locale.Error:
-                    self.parent.show_error(_("Failed to change program language. Make sure locale is generated on "
-                                             "your system."))
+        current_locale = self.config.locale
+        if self.__save_combo_value(self.combobox_program_language, 'locale'):
+            new_locale = self.config.locale
+            if new_locale == '':
+                new_locale = locale.getdefaultlocale()[0]
 
-    def __save_language_choice(self) -> None:
-        lang_choice = self.combobox_language.get_active_iter()
-        if lang_choice is not None:
-            model = self.combobox_language.get_model()
-            lang, _ = model[lang_choice][:2]
-            self.config.lang = lang
+            try:
+                locale.setlocale(locale.LC_ALL, (new_locale, 'UTF-8'))
+            except locale.Error:
+                self.config.locale = current_locale
+                self.parent.show_error(_("Failed to change program language. Make sure locale is generated on "
+                                         "your system."))
 
-    def __save_view_choice(self) -> None:
-        view_choice = self.combobox_view.get_active_iter()
-        if view_choice is not None:
-            model = self.combobox_view.get_model()
-            view, _ = model[view_choice][:2]
-            if view != self.config.view:
-                self.parent.reset_library()
-            self.config.view = view
 
     def __save_theme_choice(self) -> None:
         settings = Gtk.Settings.get_default()
@@ -179,9 +142,15 @@ class Preferences(Gtk.Dialog):
 
     @Gtk.Template.Callback("on_button_save_clicked")
     def save_pressed(self, button):
+        library_reset_needed = False
+
+        # comboboxes
         self.__save_locale_choice()
-        self.__save_language_choice()
-        self.__save_view_choice()
+        self.__save_combo_value(self.combobox_language, 'lang')
+        self.__save_combo_value(self.combobox_wine_variant, 'default_wine_runner')
+        library_reset_needed = self.__save_combo_value(self.combobox_view, 'view')
+
+        # on/off switches
         self.__save_theme_choice()
         self.config.keep_installers = self.switch_keep_installers.get_active()
         self.config.stay_logged_in = self.switch_stay_logged_in.get_active()
@@ -190,20 +159,24 @@ class Preferences(Gtk.Dialog):
         self.parent.library.filter_library()
 
         if self.switch_show_windows_games.get_active() != self.config.show_windows_games:
-            if self.switch_show_windows_games.get_active() and not shutil.which("wine"):
+            if self.switch_show_windows_games.get_active() and not is_wine_installed():
                 self.parent.show_error(_("Wine wasn't found. Showing Windows games cannot be enabled."))
                 self.config.show_windows_games = False
             else:
                 self.config.show_windows_games = self.switch_show_windows_games.get_active()
-                self.parent.reset_library()
+                library_reset_needed = True
 
-        # Only change the install_dir is it was actually changed
+        # Only change the install_dir if it was actually changed
         if self.button_file_chooser.get_filename() != self.config.install_dir:
             if self.__save_install_dir_choice():
                 self.download_manager.cancel_all_downloads()
-                self.parent.reset_library()
+                library_reset_needed = True
             else:
                 self.parent.show_error(_("{} isn't a usable path").format(self.button_file_chooser.get_filename()))
+
+        if library_reset_needed:
+            self.parent.reset_library()
+
         self.destroy()
 
     @Gtk.Template.Callback("on_button_cancel_clicked")

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -87,7 +87,6 @@ class Preferences(Gtk.Dialog):
             setattr(self.config, prop_name, value)
         return value != current_config
 
-
     def __save_locale_choice(self) -> None:
         current_locale = self.config.locale
         if self.__save_combo_value(self.combobox_program_language, 'locale'):
@@ -101,7 +100,6 @@ class Preferences(Gtk.Dialog):
                 self.config.locale = current_locale
                 self.parent.show_error(_("Failed to change program language. Make sure locale is generated on "
                                          "your system."))
-
 
     def __save_theme_choice(self) -> None:
         settings = Gtk.Settings.get_default()

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -54,7 +54,7 @@ class Preferences(Gtk.Dialog):
             _("Keep installers after downloading a game.\nInstallers are stored in: {}").format(installer_dir)
         )
 
-    def __init_combobox(self, combobox, data_feed: [], active_option) -> None:
+    def __init_combobox(self, combobox, data_feed, active_option) -> None:
         """expects 2-dimensional array with 2 columns for data
         first entry per row is the config key, second one the string to display in the UI
         """

--- a/minigalaxy/wine_utils.py
+++ b/minigalaxy/wine_utils.py
@@ -1,5 +1,6 @@
 """Some helpers to handle selection, configuration and start of wine commands"""
 import json
+import shlex
 import shutil
 
 from urllib import request, parse
@@ -31,7 +32,7 @@ def get_wine_path(game: Game, config: Config = Config()) -> str:
     return newDefault
 
 
-def get_wine_env(game: Game, config: Config = Config(), quoted=False) -> []:
+def get_wine_env(game: Game, config: Config = Config(), quoted=False):
     if quoted:
         envPattern = '{key}="{value}"'
     else:
@@ -45,9 +46,14 @@ def get_wine_env(game: Game, config: Config = Config(), quoted=False) -> []:
         if shutil.which('zenity'):
             environment.append('UMU_ZENITY=1')
 
-    for var in game.get_info("variable").split():
+    variables = game.get_info('variable')
+    if not variables:
+        return environment
+    
+    for var in shlex.split(variables):
         kvp = var.split('=', 1)
-        environment.append(envPattern.format(key=kvp[0], value=kvp[1]))
+        if len(kvp) == 2:
+            environment.append(envPattern.format(key=kvp[0], value=kvp[1]))
 
     return environment
 

--- a/minigalaxy/wine_utils.py
+++ b/minigalaxy/wine_utils.py
@@ -1,0 +1,60 @@
+"""Some helpers to handle selection, configuration and start of wine commands"""
+import shutil
+import textwrap
+
+from minigalaxy.config import Config
+from minigalaxy.constants import WINE_VARIANTS
+from minigalaxy.game import Game
+
+
+GAMEINFO_UMUID = "umu_id"
+GAMEINFO_CUSTOM_WINE = "custom_wine"
+
+
+def is_wine_installed() -> bool:
+    for wine in WINE_VARIANTS:
+        if shutil.which(wine[0]):
+            return True
+    return False
+
+
+def get_wine_path(game: Game, config: Config = Config()) -> str:
+    custom_wine_path = game.get_info(GAMEINFO_CUSTOM_WINE)
+    if custom_wine_path and shutil.which(custom_wine_path):
+        return custom_wine_path
+
+    newDefault = get_default_wine(config)
+    game.set_info(GAMEINFO_CUSTOM_WINE, newDefault)
+    return newDefault
+
+
+def get_wine_env(game: Game, config: Config = Config()) -> []:
+    environment = ['WINEDLLOVERRIDES="winemenubuilder.exe=d"']
+    environment.append(f'WINEPREFIX="{game.install_dir}/prefix"')
+
+    if 'umu-run' in get_wine_path(game, config):
+        environment.append(f'GAMEID="get_umu_id"')
+        if shutil.which('zenity'):
+            environment.append('UMU_ZENITY=1')
+
+    for var in game.get_info("variable").split():
+        kvp = var.split('=', 1)
+        environment.append(f'{[kvp[0]]}="{kvp[1]}"')
+
+    return environment
+
+
+def get_default_wine(config: Config = Config()) -> str:
+    runner = shutil.which(config.default_wine_runner)
+    if runner:
+        return runner
+
+    # fallback: iterate through all known variants in declaration order
+    for option in WINE_VARIANTS:
+        runner = shutil.which(option[0])
+        if runner:
+            return runner
+
+    # should never happen when get_default_wine is used after is_wine_installed returns true
+    return ""
+

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -80,7 +80,7 @@ class Test(TestCase):
         """[scenario: linux installer, unpack success]"""
         mock_is_file.return_value = True
         mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readlines.return_value = [b"\n"]
+        mock_subprocess().stdout.readlines.return_value = ["\n"]
         mock_listdir.return_value = ["object1", "object2"]
         game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
@@ -96,7 +96,7 @@ class Test(TestCase):
         """[scenario: linux installer, unpack failed]"""
         mock_is_file.return_value = True
         mock_subprocess().poll.return_value = 2
-        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         mock_listdir.return_value = ["object1", "object2"]
         game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
@@ -113,7 +113,7 @@ class Test(TestCase):
         """[scenario: innoextract, unpack success]"""
         mock_which.return_value = "path"
         mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         mock_config.lang = 'en'
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
@@ -128,7 +128,7 @@ class Test(TestCase):
     def test_extract_linux(self, mock_subprocess, mock_listdir, mock_is_file):
         mock_is_file.return_value = True
         mock_subprocess().poll.return_value = 1
-        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"(attempting to process anyway)"]
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "(attempting to process anyway)"]
         mock_listdir.return_value = ["object1", "object2"]
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1207658695"
@@ -141,7 +141,7 @@ class Test(TestCase):
     def test_extract_windows(self, mock_subprocess, mock_config):
         """[scenario: innoextract, unpack success]"""
         mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         mock_config.lang = 'en'
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
@@ -154,7 +154,7 @@ class Test(TestCase):
     def test1_extract_by_innoextract(self, mock_subprocess):
         """[scenario: success]"""
         mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
@@ -173,7 +173,7 @@ class Test(TestCase):
     def test3_extract_by_innoextract(self, mock_subprocess):
         """[scenario: unpack failed]"""
         mock_subprocess().poll.return_value = 1
-        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = "Innoextract extraction failed."
@@ -190,7 +190,7 @@ class Test(TestCase):
         wine_path.get_wine_path().return_value = '/bin/wine'
         mock_path_exists.return_value = True
         mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
@@ -207,7 +207,7 @@ class Test(TestCase):
         """[scenario: install failed]"""
         mock_path_exists.return_value = True
         mock_subprocess().poll.return_value = 1
-        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
@@ -220,7 +220,7 @@ class Test(TestCase):
     def test1_postinstaller(self, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = False
         mock_subprocess().poll.return_value = 1
-        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = ""
         obs = installer.postinstaller(game)
@@ -232,7 +232,7 @@ class Test(TestCase):
     def test2_postinstaller(self, mock_chmod, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = True
         mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = ""
         obs = installer.postinstaller(game)
@@ -244,7 +244,7 @@ class Test(TestCase):
     def test3_postinstaller(self, mock_chmod, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = True
         mock_subprocess().poll.return_value = 1
-        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = "Postinstallation script failed: /home/makson/GOG Games/Absolute Drift/support/postinst.sh"
         obs = installer.postinstaller(game)
@@ -308,7 +308,7 @@ class Test(TestCase):
 --------          -------  ---                            -------
 159236636         104883200  34%                            189 files
 """
-        mock_subprocess().communicate.return_value = [stdout, b"stderr"]
+        mock_subprocess().communicate.return_value = [stdout, "stderr"]
         installer_path = "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         exp = 159236636
         obs = installer.get_game_size_from_unzip(installer_path)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -203,9 +203,11 @@ class Test(TestCase):
     @mock.patch("os.path.exists")
     @mock.patch("os.unlink")
     @mock.patch("os.symlink")
+    #FIMXE: Make run again: problem is diagnostic install script written on failure
     def test2_extract_by_wine(self, mock_symlink, mock_unlink, mock_path_exists, mock_subprocess, mock_config):
         """[scenario: install failed]"""
         mock_path_exists.return_value = True
+        #side_effect = (True, True, False)
         mock_subprocess().poll.return_value = 1
         mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -314,23 +314,6 @@ class Test(TestCase):
         obs = installer.get_game_size_from_unzip(installer_path)
         self.assertEqual(exp, obs)
 
-    @mock.patch('shutil.which')
-    @mock.patch('os.listdir')
-    def test_get_exec_line(self, mock_list_dir, mock_which):
-        mock_which.return_value = True
-
-        game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
-        mock_list_dir.return_value = ["data", "docs", "scummvm", "support", "beneath.ini", "gameinfo", "start.sh"]
-
-        result1 = installer.get_exec_line(game1)
-        self.assertEqual(result1, "scummvm -c beneath.ini")
-
-        game2 = Game("Blocks That Matter", install_dir="/home/test/GOG Games/Blocks That Matter", platform="linux")
-        mock_list_dir.return_value = ["data", "docs", "support", "gameinfo", "start.sh"]
-
-        result2 = installer.get_exec_line(game2)
-        self.assertEqual(result2, "./start.sh")
-
     @mock.patch('os.path.getsize')
     @mock.patch('os.listdir')
     @mock.patch('os.path.isdir')

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,20 +1,39 @@
 import copy
+import shutil
+import os
 from unittest import TestCase, mock
 from unittest.mock import patch, mock_open, MagicMock
 
+from minigalaxy.paths import CONFIG_GAMES_DIR
 from minigalaxy.game import Game
 from minigalaxy import installer
 from minigalaxy.translation import _
 
 
 class Test(TestCase):
+
+    def setUp(self):
+        print('preparing config files for test')
+        if not os.path.exists(CONFIG_GAMES_DIR):
+            os.makedirs(CONFIG_GAMES_DIR, mode=0o755)
+        return super().setUp()
+
+    def tearDown(self):
+        print("removing config files changed during the test...")
+        shutil.rmtree(path=CONFIG_GAMES_DIR, ignore_errors=True)
+        return super().tearDown()
+
+    @mock.patch('minigalaxy.config')
     @mock.patch('shutil.which')
-    def test_install_game(self, mock_which):
+    def test_install_game(self, mock_which, mock_config):
         """[scenario: unhandled error]"""
         mock_which.side_effect = FileNotFoundError("Testing unhandled errors during install")
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         exp = "Unhandled error."
-        obs = installer.install_game(game, installer="", language="", install_dir="", keep_installers=False, create_desktop_file=True)
+        mock_config.keep_installers = False
+        mock_config.install_dir = ""
+        mock_config.create_desktop_file = True
+        obs = installer.install_game(game, installer="", config=mock_config)
         self.assertEqual(exp, obs)
 
     @mock.patch('os.path.exists')
@@ -60,8 +79,8 @@ class Test(TestCase):
     def test1_extract_installer(self, mock_subprocess, mock_listdir, mock_is_file):
         """[scenario: linux installer, unpack success]"""
         mock_is_file.return_value = True
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = [b"\n"]
         mock_listdir.return_value = ["object1", "object2"]
         game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
@@ -76,8 +95,8 @@ class Test(TestCase):
     def test2_extract_installer(self, mock_subprocess, mock_listdir, mock_is_file):
         """[scenario: linux installer, unpack failed]"""
         mock_is_file.return_value = True
-        mock_subprocess().returncode = 2
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 2
+        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
         mock_listdir.return_value = ["object1", "object2"]
         game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
@@ -86,18 +105,21 @@ class Test(TestCase):
         obs = installer.extract_installer(game, installer_path, temp_dir, "en", use_innoextract=False)
         self.assertEqual(exp, obs)
 
+    @mock.patch('minigalaxy.config')
     @mock.patch('subprocess.Popen')
     @mock.patch('shutil.which')
-    def test3_extract_installer(self, mock_which, mock_subprocess):
+    # FIXME: set_info in den tests speichert in datei, das ist ein problematischer side-effect
+    def test3_extract_installer(self, mock_which, mock_subprocess, mock_config):
         """[scenario: innoextract, unpack success]"""
-        mock_which.return_value = True
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_which.return_value = "path"
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_config.lang = 'en'
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
-        obs = installer.extract_installer(game, installer_path, temp_dir, "en", use_innoextract=True)
+        obs = installer.extract_installer(game, installer_path, temp_dir, mock_config, use_innoextract=True)
         self.assertEqual(exp, obs)
 
     @mock.patch('os.path.exists')
@@ -105,8 +127,8 @@ class Test(TestCase):
     @mock.patch('subprocess.Popen')
     def test_extract_linux(self, mock_subprocess, mock_listdir, mock_is_file):
         mock_is_file.return_value = True
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = [b"stdout", b"(attempting to process anyway)"]
+        mock_subprocess().poll.return_value = 1
+        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"(attempting to process anyway)"]
         mock_listdir.return_value = ["object1", "object2"]
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1207658695"
@@ -114,23 +136,25 @@ class Test(TestCase):
         obs = installer.extract_linux(installer_path, temp_dir)
         self.assertEqual(exp, obs)
 
+    @mock.patch('minigalaxy.config')
     @mock.patch('subprocess.Popen')
-    def test_extract_windows(self, mock_subprocess):
+    def test_extract_windows(self, mock_subprocess, mock_config):
         """[scenario: innoextract, unpack success]"""
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
+        mock_config.lang = 'en'
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
-        obs = installer.extract_windows(game, installer_path, temp_dir, "en", use_innoextract=True)
+        obs = installer.extract_windows(game, installer_path, temp_dir, mock_config, use_innoextract=True)
         self.assertEqual(exp, obs)
 
     @mock.patch('subprocess.Popen')
     def test1_extract_by_innoextract(self, mock_subprocess):
         """[scenario: success]"""
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
@@ -148,52 +172,55 @@ class Test(TestCase):
     @mock.patch('subprocess.Popen')
     def test3_extract_by_innoextract(self, mock_subprocess):
         """[scenario: unpack failed]"""
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 1
+        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = "Innoextract extraction failed."
         obs = installer.extract_by_innoextract(installer_path, temp_dir, "en", use_innoextract=True)
         self.assertEqual(exp, obs)
 
+    @mock.patch('minigalaxy.config')
     @mock.patch('subprocess.Popen')
     @mock.patch("os.path.exists")
-    @mock.patch("os.unlink")
+    @mock.patch("minigalaxy.wine_utils")
     @mock.patch("os.symlink")
-    def test1_extract_by_wine(self, mock_symlink, mock_unlink, mock_path_exists, mock_subprocess):
+    def test1_extract_by_wine(self, mock_symlink, wine_path, mock_path_exists, mock_subprocess, mock_config):
         """[scenario: success]"""
+        wine_path.get_wine_path().return_value = '/bin/wine'
         mock_path_exists.return_value = True
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
-        obs = installer.extract_by_wine(game, installer_path, temp_dir)
+        obs = installer.extract_by_wine(game, installer_path, temp_dir, mock_config)
         self.assertEqual(exp, obs)
 
+    @mock.patch('minigalaxy.config')
     @mock.patch('subprocess.Popen')
     @mock.patch("os.path.exists")
     @mock.patch("os.unlink")
     @mock.patch("os.symlink")
-    def test2_extract_by_wine(self, mock_symlink, mock_unlink, mock_path_exists, mock_subprocess):
+    def test2_extract_by_wine(self, mock_symlink, mock_unlink, mock_path_exists, mock_subprocess, mock_config):
         """[scenario: install failed]"""
         mock_path_exists.return_value = True
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 1
+        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = "Wine extraction failed."
-        obs = installer.extract_by_wine(game, installer_path, temp_dir)
+        obs = installer.extract_by_wine(game, installer_path, temp_dir, mock_config)
         self.assertEqual(exp, obs)
 
     @mock.patch('subprocess.Popen')
     @mock.patch("os.path.isfile")
     def test1_postinstaller(self, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = False
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 1
+        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = ""
         obs = installer.postinstaller(game)
@@ -204,8 +231,8 @@ class Test(TestCase):
     @mock.patch("os.chmod")
     def test2_postinstaller(self, mock_chmod, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = True
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = ""
         obs = installer.postinstaller(game)
@@ -216,8 +243,8 @@ class Test(TestCase):
     @mock.patch("os.chmod")
     def test3_postinstaller(self, mock_chmod, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = True
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 1
+        mock_subprocess().stdout.readlines.return_value = [b"stdout", b"stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = "Postinstallation script failed: /home/makson/GOG Games/Absolute Drift/support/postinst.sh"
         obs = installer.postinstaller(game)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,12 +1,27 @@
 import subprocess
+import os
+import shutil
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, mock_open
 
 from minigalaxy import launcher
 from minigalaxy.game import Game
+from minigalaxy.paths import CONFIG_GAMES_DIR
 
 
 class Test(TestCase):
+
+    def setUp(self):
+        print('preparing config files for test')
+        if not os.path.exists(CONFIG_GAMES_DIR):
+            os.makedirs(CONFIG_GAMES_DIR, mode=0o755)
+        return super().setUp()
+
+    def tearDown(self):
+        print("removing config files changed during the test...")
+        shutil.rmtree(path=CONFIG_GAMES_DIR, ignore_errors=True)
+        return super().tearDown()
+
     def test1_determine_launcher_type(self):
         files = ['thumbnail.jpg', 'docs', 'support', 'game', 'start.sh', 'minigalaxy-dlc.json', 'gameinfo']
         exp = "start_script"
@@ -41,18 +56,24 @@ class Test(TestCase):
         obs = launcher.determine_launcher_type(files)
         self.assertEqual(exp, obs)
 
+    @mock.patch('os.path.exists')
+    @mock.patch('shutil.which')
     @mock.patch('glob.glob')
-    def test1_get_windows_exe_cmd(self, mock_glob):
+    def test1_get_windows_exe_cmd(self, mock_glob, mock_which, mock_exists):
         mock_glob.return_value = ["/test/install/dir/start.exe", "/test/install/dir/unins000.exe"]
+        mock_which.return_value = '/bin/wine'
+        mock_exists.return_value = True
         files = ['thumbnail.jpg', 'docs', 'support', 'game', 'minigalaxy-dlc.json', 'start.exe', 'unins000.exe']
         game = Game("Test Game", install_dir="/test/install/dir")
-        exp = ["wine", "start.exe"]
+        exp = ['env', 'WINEDLLOVERRIDES=winemenubuilder.exe=d', 'WINEPREFIX=/test/install/dir/prefix', "/bin/wine", "start.exe"]
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 
+    @mock.patch('shutil.which')
+    @mock.patch('os.path.exists')
     @mock.patch('builtins.open', new_callable=mock_open, read_data="")
     @mock.patch('os.chdir')
-    def test2_get_windows_exe_cmd(self, mock_os_chdir, mo):
+    def test2_get_windows_exe_cmd(self, mock_os_chdir, mo, mock_exists, mock_which):
         goggame_1414471894_info_content = """{
         "buildId": "53350324452482937",
         "clientId": "53185732904249211",
@@ -99,18 +120,27 @@ class Test(TestCase):
         "rootGameId": "1407287452",
         "version": 1
         }"""
-        handlers = (mock_open(read_data=goggame_1414471894_info_content).return_value, mock_open(read_data=goggame_1407287452_info_content).return_value)
+        handlers = (
+            mock_open(read_data=goggame_1414471894_info_content).return_value,
+            mock_open(read_data=goggame_1407287452_info_content).return_value,
+            mock_open(read_data=goggame_1407287452_info_content).return_value,
+            mock_open(read_data=goggame_1407287452_info_content).return_value,
+            mock_open(read_data=goggame_1407287452_info_content).return_value)
         mo.side_effect = handlers
+        mock_exists.return_value = True
+        mock_which.return_value = 'wine'
         files = ['thumbnail.jpg', 'docs', 'support', 'game', 'minigalaxy-dlc.json', 'MetroExodus.exe', 'unins000.exe',
                  'goggame-1407287452.info', 'goggame-1414471894.info']
         game = Game("Test Game", install_dir="/test/install/dir")
-        exp = ['wine', 'start', '/b', '/wait', '/d', '.', 'MetroExodus.exe']
+        exp = ['env', 'WINEDLLOVERRIDES=winemenubuilder.exe=d', 'WINEPREFIX=/test/install/dir/prefix', 'wine', 'start', '/b', '/wait', '/d', 'c:\\game\\.', 'c:\\game\\MetroExodus.exe']
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 
+    @mock.patch('shutil.which')
+    @mock.patch('os.path.exists')
     @mock.patch('builtins.open', new_callable=mock_open, read_data="")
     @mock.patch('os.chdir')
-    def test3_get_windows_exe_cmd(self, mock_os_chdir, mo):
+    def test3_get_windows_exe_cmd(self, mock_os_chdir, mo, mock_exists, mock_which):
         goggame_1207658919_info_content = """{
         "buildId": "52095557858882770",
         "clientId": "49843178982252086",
@@ -176,7 +206,13 @@ class Test(TestCase):
         "rootGameId": "1207658919",
         "version": 1
         }"""
-        mo.side_effect = (mock_open(read_data=goggame_1207658919_info_content).return_value,)
+        handlers = (
+            mock_open(read_data=goggame_1207658919_info_content).return_value,
+            mock_open(read_data=goggame_1207658919_info_content).return_value,
+            mock_open(read_data=goggame_1207658919_info_content).return_value)
+        mo.side_effect = handlers
+        mock_exists.return_value = True
+        mock_which.return_value = 'wine'
         files = ['goggame-1207658919.script', 'DOSBOX', 'thumbnail.jpg', 'game.gog', 'unins000.dat', 'webcache.zip',
                  'EULA.txt', 'Music', 'dosboxRayman_single.conf', 'Rayman', 'unins000.exe', 'support.ico', 'prefix',
                  'goggame-1207658919.info', 'Manual.pdf', 'gog.ico', 'unins000.msg', 'goggame-1207658919.hashdb',
@@ -184,7 +220,8 @@ class Test(TestCase):
                  'goggame-1207658919.ico', 'goglog.ini', 'Launch Rayman Forever.lnk', 'cloud_saves',
                  'thumbnail_196.jpg']
         game = Game("Test Game", install_dir="/test/install/dir")
-        exp = ['wine', 'start', '/b', '/wait', '/d', 'DOSBOX', 'DOSBOX\\dosbox.exe', '-conf', '"..\\dosboxRayman.conf"',
+        exp = ['env', 'WINEDLLOVERRIDES=winemenubuilder.exe=d', 'WINEPREFIX=/test/install/dir/prefix',
+               'wine', 'start', '/b', '/wait', '/d', 'c:\\game\\DOSBOX', 'c:\\game\\DOSBOX\\dosbox.exe', '-conf', '"..\\dosboxRayman.conf"',
                '-conf', '"..\\dosboxRayman_single.conf"', '-noconsole', '-c', '"exit"']
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description
This code change introduces a dropdown in preference giving a choice between 'Wine' and 'UMU-Launcher' as windows game runner.
I've introduced a helper, wine_utils, to handle everything about wine: environment variables, locating the executable etc. There were quite a few other code changes/refactorings as well, partly for maintenance, partly to actually use the new utils.

I also started revising the entire install strategy for windows games as a lot of issues i can see here stem from the different ways to install and that they both seem to have issues.

I'm in favor of using the conventional install within wine over innoextract. 
The main reason is that innoextract is basically just like unzip, it doesn't perform any post-file-copy steps, nor does it execute the installer scripts. This leaves the 'installations' in a potentially undefined intermediate state where a lot of additional code is needed to 'make it work'. That's why i temporarily disabled innoextract hard-coded in my branch. Therefore the system installation won't matter. The revised installer does not utilize a temporary directory (with file moving around afterwards) anymore. instead it configures the installer to use a well-known pre-defined directory within the wineprefix.

If there is a desire to still keep innoextract even when the changed installation proves to be stable, i also have a few other changes in stock to make this an option, allowing to toggle between innoextract and regular install without having to remove inno from the system.

I'm putting this up as a draft PR here already (although it is in a bit of an early stage with lots of broken tests) because i need some help. I need information about games and 'constellations':

**1. Test of game installations, both with regular wine and umu**
I don't own too many windows games on GOG yet and my wallet is not infinite.
I'm mostly interested in the following things:
1. Does the installation itself work?
2. A file listing of the install directory in case of success, as well as the content of goggame-*.info file (if any). However, please try to only report if it is not the most trivial case imaginable (later more on that)
3. In case of failure, any console output, message dialog error etc is helpful.
4. In all cases: I configured the installer to write its setup configuration to `gamedirectory/prefix/drive_c/setup.inf`. I'm currently considering whether this file contains any reliable input usable to make workingdir and executable detection easier.

**2. Running games**
Installation should basically work for all games, since the working directories and installer executables are well known.
This does not apply when running a game, however. Even before my code changes, minigalaxy had quite some logic to try and detect the game's exe file.
There's some try to parse the goggame-*.info file (these appear to be optional), then a direct search for the first exe to found in the game's install dir (some games place their exe in a subdir like bin).
But all installers generate desktop shortcuts. It might be possible to leverage them instead.

That's why i need input on games that install, but don't launch. These are most likely not simple cases.

**3. Protonfixes**
Some games require winetricks etc.
The folks from UMU started to track this in a database [UMU-DB](https://github.com/Open-Wine-Components/umu-database/blob/main/umu-database.csv)
UMU-Launcher requires a variable named 'GAMEID', which can be arbitrary, but should correspond to value of UMU_ID for a game in that database (if it is there). I've implemented a lookup function and what i need to know is if it actually retrieves the right values for games with protonfixes. This requires a working internet connection. Without internet, the lookup will generate a reasonable default and try again the next time anything within that game's prefix is launched with umu.
I added a tempory dirty log statement to see the full wine launch commands on installation, including GAMEID= when umu is chosen as runner.
So, if anyone owns a game that appears in the database, under store gog, steam or none, please let me know if the value of GAMEID matches what is in that table for UMU_ID.

**4. Simple case**
A 'simple' case either:
* has only one executable (other than the unins000.exe) in it's root directory
* or several, but a parsable goggame-*.info file giving info about which one to use
* and does not require to step into any other working directory. Determining this is a bit harder. When there is a goggame-*.info file, but it does not contain any 'workingDir' property, it should be ok. Without this file, all we can do is try to start and check the output for errors.

**5. Savegames / home pollution**
This is something that i have not touched, but it is related to wine configuration.
Regular Wine normally tries to integrate windows applications as seamlessly as possible into the desktop environment. As such, it will link windows user folders like 'Documents' or 'Downloads' to those in /home/user. Depending on the game, it will start putting stuff there. I think it's arguable whether this is desired and this behavior can be changed. When this integration is disabled, the 'Documents' etc will just be regular folders nested somewhere deep within the game's wineprefix directories. The question here is, shall Minigalaxy provide a default configuration or leave it to the users to configure each and every game installation by themselves regarding that?
This is also roughly related to cloud saves or similar. But to achieve this, a uniform and well known save location is necessary which is very hard to do when running games from stone age vs brand new ones for more recent windows versions. But i'm not going on elaborating this here, since this is going off track.

The sandboxing/pollution issue might not apply the same way in UMU since it uses the isolated proton stuff. 

The changes to the installer potentially impact or fix:
#618, #605, #602, #512, #506
#289 - i did an adjustment to the /VERYSILENT argument in the wine installer. I found not having any visual feedback at all during a long-running installation makes me feel impatient or that there's something wrong. So i changed the flag to /SILENT which only shows the installation progress, but no configuration options dialog. Potential candidate to go into preferences.

The wine_env configuration might fix:
#117, #313 - i have disabled the winemenubuilder in all prefixes managed by minigalaxy, so shortcuts from within wine are not automatically added to the linux desktop. Only applies on new installations. If there already are shortcuts, they need to be removed manually.

The enhancement of preferences to pick a wine variant opens up the possibility to work on:
#288

## Checklist
 
 - [ ] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
