### PR TITLE
Rework installation of windows games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ debian/minigalaxy.substvars
 debian/minigalaxy.debhelper.log
 debian/minigalaxy.postinst.debhelper
 debian/minigalaxy.prerm.debhelper
+.vscode/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 **1.3.2**
-- Fix issue with windows install via wine on systems with optical drives (thanks to GB609)
+- Completely reworked windows wine installation. This should solve a lot of problems with failing game installs (thanks to GB609)
+- Variables and arguments in game settings can now contain blanks when quoted shell-style (thanks to GB609)
+- Minigalaxy will now create working Desktop Shortcuts for wine games (thanks to GB609)
 
 **1.3.1**
 - Fix Windows games with multiple parts not installing with wine

--- a/README.md
+++ b/README.md
@@ -26,15 +26,17 @@ In addition to that, Minigalaxy also allows you to:
 - Install Windows games using Wine
 
 ### Backwards compatibility
-Minigalaxy version 1.3.2 or higher changes some aspects of windows game installations through wine.
+Minigalaxy version 1.3.2 and higher change some aspects of windows game installations through wine.
 It will try to adapt already installed games to the new concept when launched through Minigalaxy.
+
 However, this will *likely break games* that save some directory paths in the *windows registry*.
 In that case, only a reinstallation will repair the game. 
+
 **Please make sure to backup any save games you might have within the game folder**
 
 The windows installer in wine uses a 2-step attempt to install games. 
 1. An unattended installer.
-2. In case this fails, the regular installation wizard will open. It is mandatory not to change the 
+2. In case this fails, the regular installation wizard will open. **Please do not change** the  
 install directory 'c:\game' given in the wizard as this an elementary part of the wine fix!
 
 ## Supported languages

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ In addition to that, Minigalaxy also allows you to:
 - Use the system's ScummVM or DOSBox installation
 - Install Windows games using Wine
 
+### Backwards compatibility
+Minigalaxy version 1.3.2 or higher changes some aspects of windows game installations through wine.
+It will try to adapt already installed games to the new concept when launched through Minigalaxy.
+However, this will *likely break games* that save some directory paths in the *windows registry*.
+In that case, only a reinstallation will repair the game. 
+**Please make sure to backup any save games you might have within the game folder**
+
+The windows installer in wine uses a 2-step attempt to install games. 
+1. An unattended installer.
+2. In case this fails, the regular installation wizard will open. It is mandatory not to change the 
+install directory 'c:\game' given in the wizard as this an elementary part of the wine fix!
+
 ## Supported languages
 
 Currently, Minigalaxy can be displayed in the following languages:

--- a/README.md
+++ b/README.md
@@ -29,15 +29,10 @@ In addition to that, Minigalaxy also allows you to:
 Minigalaxy version 1.3.2 and higher change some aspects of windows game installations through wine.
 It will try to adapt already installed games to the new concept when launched through Minigalaxy.
 
-However, this will *likely break games* that save some directory paths in the *windows registry*.
-In that case, only a reinstallation will repair the game. 
-
-**Please make sure to backup any save games you might have within the game folder**
-
-The windows installer in wine uses a 2-step attempt to install games. 
+The windows installer in wine now uses a 2-step attempt to install games. 
 1. An unattended installer.
 2. In case this fails, the regular installation wizard will open. **Please do not change** the  
-install directory 'c:\game' given in the wizard as this an elementary part of the wine fix!
+install directory 'c:\game' given in the wizard as this an elementary part of the wine fix.
 
 ## Supported languages
 

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -221,10 +221,11 @@ def extract_by_wine(game, installer, temp_dir, config=Config()):
         '/SILENT'
     ]
 
-    #first try full, unattended install
+    # first, try full unattended install
     success = try_wine_command(installer_cmd_basic + installer_args_full)
     if not success:
-        #some games will reject the /SILENT flag. Open normal installer as fallback and hope for the best
+        # some games will reject the /SILENT flag.
+        # Open normal installer as fallback and hope for the best
         print('Unattended install failed. Try install with wizard dialog.', file=sys.stderr)
         success = try_wine_command(installer_cmd_basic)
 
@@ -422,11 +423,9 @@ def _mv(source_dir, target_dir):
 def lang_install(installer: str, language: str):
     languages = []
     arg = ""
-    process = subprocess.Popen(["innoextract", installer, "--list-languages"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = process.communicate()
-    output = stdout.decode("utf-8")
+    stdout, stderr, ret_code = _exe_cmd(["innoextract", installer, "--list-languages"])
 
-    for line in output.split('\n'):
+    for line in stdout.split('\n'):
         if not line.startswith(' -'):
             continue
         languages.append(line[3:])

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -80,6 +80,7 @@ def get_execute_command(game) -> list:
         exe_cmd.insert(1, "--dlsym")
     exe_cmd = get_exe_cmd_with_var_command(game, exe_cmd)
     logger.info("Launch command for %s: %s", game.name, " ".join(exe_cmd))
+    print("Launch command for {}: {}".format(game.name, " ".join(exe_cmd)))
     return exe_cmd
 
 
@@ -115,7 +116,6 @@ def get_exe_cmd_with_var_command(game, exe_cmd):
 def get_windows_exe_cmd(game, files):
     exe_cmd = [""]
     prefix = os.path.join(game.install_dir, "prefix")
-    os.environ["WINEPREFIX"] = prefix
 
     # Find game executable file
     for file in files:
@@ -152,7 +152,7 @@ def get_windows_exe_cmd(game, files):
         os.makedirs(os.path.join(prefix, 'dosdevices', 'c:'))
         os.symlink('../..', gamelink)
 
-    return exe_cmd
+    return ['env', f'WINEPREFIX={prefix}'] + exe_cmd
 
 
 def get_dosbox_exe_cmd(game, files):

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -21,23 +21,17 @@ def get_wine_path(game):
 
 def config_game(game):
     prefix = os.path.join(game.install_dir, "prefix")
-
-    os.environ["WINEPREFIX"] = prefix
-    subprocess.Popen([get_wine_path(game), 'winecfg'])
+    subprocess.Popen(['env', f'WINEPREFIX={prefix}', get_wine_path(game), 'winecfg'])
 
 
 def regedit_game(game):
     prefix = os.path.join(game.install_dir, "prefix")
-
-    os.environ["WINEPREFIX"] = prefix
-    subprocess.Popen([get_wine_path(game), 'regedit'])
+    subprocess.Popen(['env', f'WINEPREFIX={prefix}', get_wine_path(game), 'regedit'])
 
 
 def winetricks_game(game):
     prefix = os.path.join(game.install_dir, "prefix")
-
-    os.environ["WINEPREFIX"] = prefix
-    subprocess.Popen(['winetricks'])
+    subprocess.Popen(['env', f'WINEPREFIX={prefix}', 'winetricks'])
 
 
 def start_game(game):
@@ -61,7 +55,7 @@ def get_execute_command(game) -> list:
     files = os.listdir(game.install_dir)
     launcher_type = determine_launcher_type(files)
     if launcher_type in ["start_script", "wine"]:
-        exe_cmd = get_start_script_exe_cmd()
+        exe_cmd = get_start_script_exe_cmd(game)
     elif launcher_type == "windows":
         exe_cmd = get_windows_exe_cmd(game, files)
     elif launcher_type == "dosbox":
@@ -80,7 +74,6 @@ def get_execute_command(game) -> list:
         exe_cmd.insert(1, "--dlsym")
     exe_cmd = get_exe_cmd_with_var_command(game, exe_cmd)
     logger.info("Launch command for %s: %s", game.name, " ".join(exe_cmd))
-    print("Launch command for {}: {}".format(game.name, " ".join(exe_cmd)))
     return exe_cmd
 
 
@@ -108,6 +101,8 @@ def get_exe_cmd_with_var_command(game, exe_cmd):
     if var_list:
         if var_list[0] not in ["env"]:
             var_list.insert(0, "env")
+        if 'env' == exe_cmd[0]:
+            exe_cmd = exe_cmd[1:]
 
     exe_cmd = var_list + exe_cmd + command_list
     return exe_cmd
@@ -177,8 +172,8 @@ def get_scummvm_exe_cmd(game, files):
     return ["scummvm", "-c", scummvm_config]
 
 
-def get_start_script_exe_cmd():
-    return ["./start.sh"]
+def get_start_script_exe_cmd(game):
+    return [os.path.join(game.install_dir, "start.sh")]
 
 
 def get_final_resort_exe_cmd(game, files):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -60,8 +60,8 @@ class Test(TestCase):
     def test1_extract_installer(self, mock_subprocess, mock_listdir, mock_is_file):
         """[scenario: linux installer, unpack success]"""
         mock_is_file.return_value = True
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = ["\n"]
         mock_listdir.return_value = ["object1", "object2"]
         game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
@@ -76,8 +76,8 @@ class Test(TestCase):
     def test2_extract_installer(self, mock_subprocess, mock_listdir, mock_is_file):
         """[scenario: linux installer, unpack failed]"""
         mock_is_file.return_value = True
-        mock_subprocess().returncode = 2
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 2
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         mock_listdir.return_value = ["object1", "object2"]
         game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
@@ -91,8 +91,8 @@ class Test(TestCase):
     def test3_extract_installer(self, mock_which, mock_subprocess):
         """[scenario: innoextract, unpack success]"""
         mock_which.return_value = True
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
@@ -105,8 +105,8 @@ class Test(TestCase):
     @mock.patch('subprocess.Popen')
     def test_extract_linux(self, mock_subprocess, mock_listdir, mock_is_file):
         mock_is_file.return_value = True
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = [b"stdout", b"(attempting to process anyway)"]
+        mock_subprocess().poll.return_value = 1
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "(attempting to process anyway)"]
         mock_listdir.return_value = ["object1", "object2"]
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1207658695"
@@ -117,8 +117,8 @@ class Test(TestCase):
     @mock.patch('subprocess.Popen')
     def test_extract_windows(self, mock_subprocess):
         """[scenario: innoextract, unpack success]"""
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
@@ -129,8 +129,8 @@ class Test(TestCase):
     @mock.patch('subprocess.Popen')
     def test1_extract_by_innoextract(self, mock_subprocess):
         """[scenario: success]"""
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
@@ -148,8 +148,8 @@ class Test(TestCase):
     @mock.patch('subprocess.Popen')
     def test3_extract_by_innoextract(self, mock_subprocess):
         """[scenario: unpack failed]"""
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 1
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = "Innoextract extraction failed."
@@ -158,13 +158,12 @@ class Test(TestCase):
 
     @mock.patch('subprocess.Popen')
     @mock.patch("os.path.exists")
-    @mock.patch("os.unlink")
     @mock.patch("os.symlink")
-    def test1_extract_by_wine(self, mock_symlink, mock_unlink, mock_path_exists, mock_subprocess):
+    def test1_extract_by_wine(self, mock_symlink, mock_path_exists, mock_subprocess):
         """[scenario: success]"""
         mock_path_exists.return_value = True
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
@@ -179,8 +178,8 @@ class Test(TestCase):
     def test2_extract_by_wine(self, mock_symlink, mock_unlink, mock_path_exists, mock_subprocess):
         """[scenario: install failed]"""
         mock_path_exists.return_value = True
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 1
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
@@ -192,8 +191,8 @@ class Test(TestCase):
     @mock.patch("os.path.isfile")
     def test1_postinstaller(self, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = False
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 1
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = ""
         obs = installer.postinstaller(game)
@@ -204,8 +203,8 @@ class Test(TestCase):
     @mock.patch("os.chmod")
     def test2_postinstaller(self, mock_chmod, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = True
-        mock_subprocess().returncode = 0
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 0
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = ""
         obs = installer.postinstaller(game)
@@ -216,8 +215,8 @@ class Test(TestCase):
     @mock.patch("os.chmod")
     def test3_postinstaller(self, mock_chmod, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = True
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = [b"stdout", b"stderr"]
+        mock_subprocess().poll.return_value = 1
+        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = "Postinstallation script failed: /home/makson/GOG Games/Absolute Drift/support/postinst.sh"
         obs = installer.postinstaller(game)
@@ -281,28 +280,11 @@ class Test(TestCase):
 --------          -------  ---                            -------
 159236636         104883200  34%                            189 files
 """
-        mock_subprocess().communicate.return_value = [stdout, b"stderr"]
+        mock_subprocess().communicate.return_value = [stdout, "stderr"]
         installer_path = "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         exp = 159236636
         obs = installer.get_game_size_from_unzip(installer_path)
         self.assertEqual(exp, obs)
-
-    @mock.patch('shutil.which')
-    @mock.patch('os.listdir')
-    def test_get_exec_line(self, mock_list_dir, mock_which):
-        mock_which.return_value = True
-
-        game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
-        mock_list_dir.return_value = ["data", "docs", "scummvm", "support", "beneath.ini", "gameinfo", "start.sh"]
-
-        result1 = installer.get_exec_line(game1)
-        self.assertEqual(result1, "scummvm -c beneath.ini")
-
-        game2 = Game("Blocks That Matter", install_dir="/home/test/GOG Games/Blocks That Matter", platform="linux")
-        mock_list_dir.return_value = ["data", "docs", "support", "gameinfo", "start.sh"]
-
-        result2 = installer.get_exec_line(game2)
-        self.assertEqual(result2, "./start.sh")
 
     @mock.patch('os.path.getsize')
     @mock.patch('os.listdir')

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -132,7 +132,6 @@ class Test(TestCase):
         mock_cmd.side_effect = [True, True]
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
-        temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = ""
         obs, uses_tmp = installer.extract_windows(game, installer_path, "en")
         self.assertEqual(exp, obs)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -192,7 +192,7 @@ class Test(TestCase):
         game = Game("Test Game", install_dir="/test/install/dir")
         exp = ['env', 'WINEPREFIX=/test/install/dir/prefix',
                'wine', 'start', '/b', '/wait', '/d', 'c:\\game\\DOSBOX', 'c:\\game\\DOSBOX\\dosbox.exe', '-conf', '..\\dosboxRayman.conf',
-               '-conf', '"..\\dosboxRayman_single.conf"', '-noconsole', '-c', 'exit']
+               '-conf', '..\\dosboxRayman_single.conf', '-noconsole', '-c', 'exit']
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -48,7 +48,7 @@ class Test(TestCase):
         mock_exists.return_value = True
         files = ['thumbnail.jpg', 'docs', 'support', 'game', 'minigalaxy-dlc.json', 'start.exe', 'unins000.exe']
         game = Game("Test Game", install_dir="/test/install/dir")
-        exp = ["wine", "start.exe"]
+        exp = ['env', 'WINEPREFIX=/test/install/dir/prefix', "wine", "start.exe"]
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 
@@ -108,7 +108,7 @@ class Test(TestCase):
         files = ['thumbnail.jpg', 'docs', 'support', 'game', 'minigalaxy-dlc.json', 'MetroExodus.exe', 'unins000.exe',
                  'goggame-1407287452.info', 'goggame-1414471894.info']
         game = Game("Test Game", install_dir="/test/install/dir")
-        exp = ['wine', 'start', '/b', '/wait', '/d', 'c:\\game\\.', 'c:\\game\\MetroExodus.exe']
+        exp = ['env', 'WINEPREFIX=/test/install/dir/prefix', 'wine', 'start', '/b', '/wait', '/d', 'c:\\game\\.', 'c:\\game\\MetroExodus.exe']
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 
@@ -190,8 +190,9 @@ class Test(TestCase):
                  'goggame-1207658919.ico', 'goglog.ini', 'Launch Rayman Forever.lnk', 'cloud_saves',
                  'thumbnail_196.jpg']
         game = Game("Test Game", install_dir="/test/install/dir")
-        exp = ['wine', 'start', '/b', '/wait', '/d', 'c:\\game\\DOSBOX', 'c:\\game\\DOSBOX\\dosbox.exe', '-conf', '"..\\dosboxRayman.conf"',
-               '-conf', '"..\\dosboxRayman_single.conf"', '-noconsole', '-c', '"exit"']
+        exp = ['env', 'WINEPREFIX=/test/install/dir/prefix',
+               'wine', 'start', '/b', '/wait', '/d', 'c:\\game\\DOSBOX', 'c:\\game\\DOSBOX\\dosbox.exe', '-conf', '..\\dosboxRayman.conf',
+               '-conf', '"..\\dosboxRayman_single.conf"', '-noconsole', '-c', 'exit']
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 
@@ -210,8 +211,9 @@ class Test(TestCase):
         self.assertEqual(exp, obs)
 
     def test_get_start_script_exe_cmd(self):
-        exp = ["./start.sh"]
-        obs = launcher.get_start_script_exe_cmd()
+        game = Game("Test Game", install_dir="/test/install/dir")
+        exp = ["/test/install/dir/start.sh"]
+        obs = launcher.get_start_script_exe_cmd(game)
         self.assertEqual(exp, obs)
 
     @mock.patch('os.getcwd')

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -41,18 +41,21 @@ class Test(TestCase):
         obs = launcher.determine_launcher_type(files)
         self.assertEqual(exp, obs)
 
+    @mock.patch('os.path.exists')
     @mock.patch('glob.glob')
-    def test1_get_windows_exe_cmd(self, mock_glob):
+    def test1_get_windows_exe_cmd(self, mock_glob, mock_exists):
         mock_glob.return_value = ["/test/install/dir/start.exe", "/test/install/dir/unins000.exe"]
+        mock_exists.return_value = True
         files = ['thumbnail.jpg', 'docs', 'support', 'game', 'minigalaxy-dlc.json', 'start.exe', 'unins000.exe']
         game = Game("Test Game", install_dir="/test/install/dir")
         exp = ["wine", "start.exe"]
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 
+    @mock.patch('os.path.exists')
     @mock.patch('builtins.open', new_callable=mock_open, read_data="")
     @mock.patch('os.chdir')
-    def test2_get_windows_exe_cmd(self, mock_os_chdir, mo):
+    def test2_get_windows_exe_cmd(self, mock_os_chdir, mo, mock_exists):
         goggame_1414471894_info_content = """{
         "buildId": "53350324452482937",
         "clientId": "53185732904249211",
@@ -101,16 +104,18 @@ class Test(TestCase):
         }"""
         handlers = (mock_open(read_data=goggame_1414471894_info_content).return_value, mock_open(read_data=goggame_1407287452_info_content).return_value)
         mo.side_effect = handlers
+        mock_exists.return_value = True
         files = ['thumbnail.jpg', 'docs', 'support', 'game', 'minigalaxy-dlc.json', 'MetroExodus.exe', 'unins000.exe',
                  'goggame-1407287452.info', 'goggame-1414471894.info']
         game = Game("Test Game", install_dir="/test/install/dir")
-        exp = ['wine', 'start', '/b', '/wait', '/d', '.', 'MetroExodus.exe']
+        exp = ['wine', 'start', '/b', '/wait', '/d', 'c:\\game\\.', 'c:\\game\\MetroExodus.exe']
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 
+    @mock.patch('os.path.exists')
     @mock.patch('builtins.open', new_callable=mock_open, read_data="")
     @mock.patch('os.chdir')
-    def test3_get_windows_exe_cmd(self, mock_os_chdir, mo):
+    def test3_get_windows_exe_cmd(self, mock_os_chdir, mo, mock_exists):
         goggame_1207658919_info_content = """{
         "buildId": "52095557858882770",
         "clientId": "49843178982252086",
@@ -177,6 +182,7 @@ class Test(TestCase):
         "version": 1
         }"""
         mo.side_effect = (mock_open(read_data=goggame_1207658919_info_content).return_value,)
+        mock_exists.return_value = True
         files = ['goggame-1207658919.script', 'DOSBOX', 'thumbnail.jpg', 'game.gog', 'unins000.dat', 'webcache.zip',
                  'EULA.txt', 'Music', 'dosboxRayman_single.conf', 'Rayman', 'unins000.exe', 'support.ico', 'prefix',
                  'goggame-1207658919.info', 'Manual.pdf', 'gog.ico', 'unins000.msg', 'goggame-1207658919.hashdb',
@@ -184,7 +190,7 @@ class Test(TestCase):
                  'goggame-1207658919.ico', 'goglog.ini', 'Launch Rayman Forever.lnk', 'cloud_saves',
                  'thumbnail_196.jpg']
         game = Game("Test Game", install_dir="/test/install/dir")
-        exp = ['wine', 'start', '/b', '/wait', '/d', 'DOSBOX', 'DOSBOX\\dosbox.exe', '-conf', '"..\\dosboxRayman.conf"',
+        exp = ['wine', 'start', '/b', '/wait', '/d', 'c:\\game\\DOSBOX', 'c:\\game\\DOSBOX\\dosbox.exe', '-conf', '"..\\dosboxRayman.conf"',
                '-conf', '"..\\dosboxRayman_single.conf"', '-noconsole', '-c', '"exit"']
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This PR offers a complete rework of the installer.py:extract_windows installation method for windows games.
1. There is no temporary directory involved anymore.
2. Thus, no linking of an additional dosdevice to temp, paths remain constant throughout the entire lifetime of the game install
3. The game installation path within the wine prefix will be set (and assumed to be) c:\game. Removing the temporary directory and using a fixed path will avoid any issues with registry keys created during installation.
4. The installer tries the windows installation with 2 sets of arguments. First fully unattended. When this fails, it will try to open the manual installation dialog, but preconfigured with c:\game as target dir. Potential TODO: Show an additional dialog in the fallback situation to ask users not to change the directory name. The fallback is necessary as some installer seem to reject the /SILENT argument. I've had this with 'Lethis - Path of progress' and 'Record of Agarest War'. Maybe there is a GOG Galaxy api we could use to get the required args and fix this for good without fallback.
6. During game installation, winemenubuilder is disabled to prevent wine from creating desktop shortcuts outside of Minigalaxy's control.
7. Shortcut creation done by Minigalaxy was changed to correctly include the command prefix 'env ...'. Commands placed in the Exec property are now correctly and fully shell-style quoted by shlex, instead of manual escaping.

The changes to the installer and how wine environment variables are handled made it also necessary to touch the launcher to correctly configure wine prefixes on launch.
Wherever necessary and possible, wine commands now use 'env' as prefix for configuration, Minigalaxy will not modify its own environment any longer.

I have also used shlex for parsing and command generation to improve handling of quotes and spaces. This makes it possible to use env variables or arguments containing spaces in the game properties (if quoted correctly).

installer.py:_exe_cmd was also reworked to use poll() and readline instead of communicate(). The reason for that is that wine can be very verbose with its stdout and i'm trying to prevent process buffers from filling up and thus effectively halting an installation. I think i've had this with a game that also installed directx afterwards  where using communicate would never return because the directx installation was apparently frozen.

The downside of these changes is that they are not entirely free of potentially breaking backwards compatibility. Games that save directory paths to registry and were installed through wine before this PR might break (although it is more likely they didn't work before).
I've tried to keep the effects as small as possible, by adding a few lines of code in launcher.py which try to restore the c:\game link on game launching. Desktop shortcuts are not regenerated and launching over shortcuts won't apply the fix.

But i've also added a note in the readme about this. If that is not the right place, just tell me where and what i shall add instead.

The initial change to the installation is also included in #622, but with some enhancements to also handle umu. The fallback solution is new to this branch.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))

Edit: Adding TODOs from discussion here for easier tracking:

[2516779478](https://github.com/sharkwouter/minigalaxy/pull/624#issuecomment-2516779478):
- [ ] install game with inno and test for working c:\game link 

[2516801895](https://github.com/sharkwouter/minigalaxy/pull/624#issuecomment-2516801895):
- [ ] manual test installation with inno success for temp_dir cleanup and NOT wine fallback
- [ ] manual test installation with inno extract ok but total failure, working wine fallback: temp_dir cleanup, usage of files from temp?

[2520299969](https://github.com/sharkwouter/minigalaxy/pull/624#issuecomment-2520299969)
- [ ] double-check wine installer language
- [ ] configure language in game launched in wine
