### PR TITLE
critical bug fix in installer

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -402,6 +402,17 @@ def _exe_cmd(cmd, print_output=False):
                 print(data, end='')
         time.sleep(0.01)
 
+    # there might some lines left in the buffer, get them all
+    data = process.stdout.readlines()
+    std_out += ''.join(data)
+    if print_output:
+        print(data, end='')
+
+    data = process.stderr.readlines()
+    std_err += ''.join(data)
+    if print_output:
+        print(data, end='')
+
     process.stdout.close()
     process.stderr.close()
 
@@ -425,20 +436,17 @@ def _mv(source_dir, target_dir):
 # "--list-languages" option returns "en-US", "fr-FR" etc... for these games.
 # Others installers return "French : Français" but disallow to choose game's language before installation
 def lang_install(installer: str, language: str):
-    languages = []
-    arg = ""
+    arg = "--language=en-US"
     stdout, stderr, ret_code = _exe_cmd(["innoextract", installer, "--list-languages"])
 
     for line in stdout.split('\n'):
         if not line.startswith(' -'):
             continue
-        languages.append(line[3:])
-    for lang in languages:
+
+        lang = line[3:]
         if "-" in lang:  # lang must be like "en-US" only.
             if language == lang[0:2]:
                 arg = "--language={}".format(lang)
                 break
-            else:
-                arg = "--language=en-US"
-                break
+
     return arg


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

My last pullrequest with the reworked wine installer contains a critical bug that prevents wine installations from working:

_exe_cmd might not consume all of the subprocess stdout because the loop exits as soon as the subprocess has a return code, but only 1 line per poll() check is consumed, so there might still be more lines in the buffer. These must also be consumed, especially when the output is required, as is the case for lang_install.

The output of innoextract --list-languages is very short and it returns quickly, so the first poll() might already return 0 and just 1 line will be consumed, which will be 'Inspecting "Game" ...', the actual lines listing languages come afterwards.

As lang_install is now used in extract_wine, there are situations where the return of lang_install will not be in the expected format '--language=langname', therefore the split operation fails with an error and the install aborts.

This happened because of my last-minute changes to lang_install and innoextract installation  introduced when fixing review comments.

This PR fixes this in 2 places:
1. Make _exe_cmd consume everything
2. make sure there will always be a default return from lang_install

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
