### PR TITLE
Wine: Installer language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 **1.3.2**
-- Completely reworked windows wine installation. This should solve a lot of problems with failing game installs (thanks to GB609)
+- Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)
 - Variables and arguments in game settings can now contain blanks when quoted shell-style (thanks to GB609)
 - Minigalaxy will now create working Desktop Shortcuts for wine games (thanks to GB609)
 

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -23,6 +23,31 @@ SUPPORTED_DOWNLOAD_LANGUAGES = [
     ["ro", _("Romanian")],
 ]
 
+# match locale ids to special language names used by some installers
+# mapping supports 1:n so we can add more than one per language if needed later
+GAME_LANGUAGE_IDS = {
+    "br": ["brazilian"],
+    "cn": ["chinese"],
+    "da": ["danish"],
+    "nl": ["dutch"],
+    "en": ["english"],
+    "fi": ["finnish"],
+    "fr": ["french"],
+    "de": ["german"],
+    "hu": ["hungarian"],
+    "it": ["italian"],
+    "jp": ["japanese"],
+    "ko": ["korean"],
+    "no": ["norwegian"],
+    "pl": ["polish"],
+    "pt": ["portuguese"],
+    "ru": ["russian"],
+    "es": ["spanish"],
+    "sv": ["swedish"],
+    "tr": ["turkish"],
+    "ro": ["romanian"]
+}
+
 SUPPORTED_LOCALES = [
     ["", _("System default")],
     ["pt_BR", _("Brazilian Portuguese")],

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -398,10 +398,10 @@ def _exe_cmd(cmd, print_output=False):
         # 1. a return code and
         # 2. nothing more to consume
         # this makes sure everything was read
+        time.sleep(0.02)
         return_code = process.poll()
         line_read = len(std_line) + len(err_line)
         done = return_code is not None and line_read == 0
-        time.sleep(0.02)
 
     process.stdout.close()
     process.stderr.close()

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -9,7 +9,7 @@ import time
 import re
 
 from minigalaxy.config import Config
-from minigalaxy.constants import SUPPORTED_DOWNLOAD_LANGUAGES, GAME_LANGUAGE_IDS
+from minigalaxy.constants import GAME_LANGUAGE_IDS
 from minigalaxy.game import Game
 from minigalaxy.logger import logger
 from minigalaxy.translation import _
@@ -53,8 +53,7 @@ def install_game(  # noqa: C901
         language: str,
         install_dir: str,
         keep_installers: bool,
-        create_desktop_file: bool,
-        use_innoextract: bool = True,  # not set externally as of yet
+        create_desktop_file: bool
 ):
     error_message = ""
     tmp_dir = ""
@@ -438,7 +437,9 @@ def match_game_lang_to_installer(installer: str, language: str, outputLogFile=No
         return "en-US"
 
     lang_keys = GAME_LANGUAGE_IDS.get(language, [])
-    lang_name_regex = re.compile(f'(\\w+)\\s*:\\s*.*')
+    # match lines like ' - french : French'
+    # gets the first lowercase word which is the key
+    lang_name_regex = re.compile('(\\w+)\\s*:\\s*.*')
 
     if outputLogFile is not None:
         logger.info('write setup language data: ', outputLogFile)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -115,13 +115,11 @@ class Test(TestCase):
         installer.extract_windows(game, installer_path, "en")
 
     @mock.patch('shutil.which')
-    @mock.patch('subprocess.Popen')
-    def test2_get_lang_with_innoextract(self, mock_subprocess, mock_which):
+    @mock.patch('minigalaxy.installer._exe_cmd')
+    def test2_get_lang_with_innoextract(self, mock_exe, mock_which):
         """[scenario: innoextract --list-languages returns locale ids]"""
-        lines = [" - fr-FR\n", " - jp-JP\n", " - en-US\n", " - ru-RU\n", ""]  # last is 'EOF'
-
-        mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readline.side_effect = lambda: lines.pop(0)
+        lines = [" - fr-FR\n", " - jp-JP\n", " - en-US\n", " - ru-RU"]
+        mock_exe.return_value = ''.join(lines), '', 0
         mock_which.return_value = '/bin/innoextract'
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         exp = "jp-JP"
@@ -129,12 +127,11 @@ class Test(TestCase):
         self.assertEqual(exp, obs)
 
     @mock.patch('shutil.which')
-    @mock.patch('subprocess.Popen')
-    def test3_get_lang_with_innoextract(self, mock_subprocess, mock_which):
+    @mock.patch('minigalaxy.installer._exe_cmd')
+    def test3_get_lang_with_innoextract(self, mock_exe, mock_which):
         """[scenario: innoextract --list-languages returns language names]"""
-        lines = [" - english: English\n", " - german: Deutsch\n", " - french: Français\n", ""]  # last is 'EOF'
-        mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readline.side_effect = lambda: lines.pop(0)
+        lines = [" - english: English\n", " - german: Deutsch\n", " - french: Français"]
+        mock_exe.return_value = ''.join(lines), '', 0
         mock_which.return_value = '/bin/innoextract'
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         exp = "french"
@@ -142,11 +139,10 @@ class Test(TestCase):
         self.assertEqual(exp, obs)
 
     @mock.patch('shutil.which')
-    @mock.patch('subprocess.Popen')
-    def test4_get_lang_with_innoextract(self, mock_subprocess, mock_which):
+    @mock.patch('minigalaxy.installer._exe_cmd')
+    def test4_get_lang_with_innoextract(self, mock_exe, mock_which):
         """[scenario: innoextract --list-languages can't be matched - default en-US is used]"""
-        mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readline.return_value = ""
+        mock_exe.return_value = '', '', 0
         mock_which.return_value = '/bin/innoextract'
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         exp = "en-US"


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This PR is a follow up on #624. Here, I'm doing the rest of the clean up and code rework related to innoextract.
Innoextract will now only be used for language detection during installation and the respective method has been reworked to have a clearer return value and more robust error handling.
I've also completely remove the old extract_by_innoextract install method since it is not used anymore.
Moreover, the new method match_game_lang_to_installer writes the output of innoextract into a log file (game.install_dir/minigalaxy_setup_languages.log).
With that, installing windows games now produces 3 small log files we can use for error reports and analysis:
* game.install._dir/minigalaxy_setup_languages.log - language list from installer (if supported)
* game.install_dir/prefix/drive_c/install.log - Log file of innosetup itself
* game.install_dir/prefix/drive_c/setup.inf - Setup data as per innosetup /SAVEINF

Coupled with everything that now also goes into minigalaxies default logging, there should be a lot of information to trace back errors on installations.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
