### PR TITLE
Desktop file creation

### DIFF
--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -296,6 +296,23 @@ class Test(TestCase):
         obs = installer.get_game_size_from_unzip(installer_path)
         self.assertEqual(exp, obs)
 
+    @mock.patch('shutil.which')
+    @mock.patch('os.listdir')
+    def test_get_exec_line(self, mock_list_dir, mock_which):
+        mock_which.return_value = True
+
+        game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
+        mock_list_dir.return_value = ["data", "docs", "scummvm", "support", "beneath.ini", "gameinfo", "start.sh"]
+
+        result1 = installer.get_exec_line(game1)
+        self.assertEqual("scummvm -c beneath.ini", result1)
+
+        game2 = Game("Blocks That Matter", install_dir="/home/test/GOG Games/Blocks That Matter", platform="linux")
+        mock_list_dir.return_value = ["data", "docs", "support", "gameinfo", "start.sh"]
+
+        result2 = installer.get_exec_line(game2)
+        self.assertEqual('"/home/test/GOG Games/Blocks That Matter/start.sh"', result2)
+
     @mock.patch('os.path.getsize')
     @mock.patch('os.listdir')
     @mock.patch('os.path.isdir')


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

While testing, I discovered that I've introduced a new error with my previous PR #624:
The change in how the value for the 'Exec' key in .desktop files is generated. 

I assumed that Exec uses quoting rules identical to shells. However, it does not. Only " can be used for quotes and there are less special characters. shlex.join quotes differently, it uses single quotes ' exclusively which is not compatible with how the Exec key is supposed to be quoted.

I restored the get_exec_line method in installer.py which i previously deleted, and enhanced it instead to conform to the quoting rules as described in [The Exec Key](https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html).

Sorry about this oversight on my part.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
