### PR TITLE
Fix Unreal Gold being unable to launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs (thanks to GB609)
 - Variables and arguments in game settings can now contain blanks when quoted shell-style (thanks to GB609)
 - Minigalaxy will now create working Desktop Shortcuts for wine games (thanks to GB609)
+- Make games Unreal Gold able to launch
 
 **1.3.1**
 - Fix Windows games with multiple parts not installing with wine

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -149,7 +149,7 @@ def get_windows_exe_cmd(game, files):
         executables.remove(os.path.join(game.install_dir, "unins000.exe"))
         if not executables:
             # Look one directory level deeper
-            executables = glob.glob(game.install_dir + '/**/*.exe')
+            executables = glob.glob(game.install_dir + '/*/*.exe')
         filename = os.path.relpath(executables[0], game.install_dir)
         exe_cmd = [get_wine_path(game), filename]
 

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -147,7 +147,10 @@ def get_windows_exe_cmd(game, files):
         # in case no goggame info file was found
         executables = glob.glob(game.install_dir + '/*.exe')
         executables.remove(os.path.join(game.install_dir, "unins000.exe"))
-        filename = os.path.splitext(os.path.basename(executables[0]))[0] + '.exe'
+        if not executables:
+            # Look one directory level deeper
+            executables = glob.glob(game.install_dir + '/**/*.exe')
+        filename = os.path.relpath(executables[0], game.install_dir)
         exe_cmd = [get_wine_path(game), filename]
 
     # Backwards compatibility with windows games installed before installer fixes.


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

<!-- Describe what was changed -->
Right now if the executable is one level deeper, the creation of shortcuts and launching the game will fail. This resolves this at least for Unreal Gold, but probably also for some other games

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
