### PR TITLE
adjust title of third-party login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Variables and arguments in game settings can now contain blanks when quoted shell-style (thanks to GB609)
 - Minigalaxy will now create working Desktop Shortcuts for wine games (thanks to GB609)
 - Make games Unreal Gold able to launch
+- Minor UI change in the dialog for third-party logins (thanks to GB609)
 
 **1.3.1**
 - Fix Windows games with multiple parts not installing with wine

--- a/minigalaxy/ui/login.py
+++ b/minigalaxy/ui/login.py
@@ -42,8 +42,9 @@ class Login(Gtk.Dialog):
 
     # Create any pop-up windows during authentication
     def on_create(self, widget, action):
-        popup = Gtk.Dialog(title=_("Facebook Login"), parent=self, flags=0, buttons=())
+        popup = Gtk.Dialog(title=_("Login"), parent=self, flags=0, buttons=())
         webview = WebKit2.WebView.new_with_related_view(widget)
+        webview.connect('notify::title', self.on_title_change)
         webview.load_uri(action.get_request().get_uri())
         webview.__dict__['popup'] = popup
         webview.connect('close', self.on_close_popup)
@@ -52,6 +53,10 @@ class Login(Gtk.Dialog):
         popup.set_modal(True)
         popup.show_all()
         return webview
+
+    def on_title_change(self, widget, property):
+        if 'popup' in widget.__dict__:
+            widget.__dict__['popup'].set_title(widget.get_title())
 
     # When a pop up is closed (by Javascript), close the Gtk window too
     def on_close_popup(self, widget):


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This is the fix for the issue in #637.

See the results with the following screenshots for german language:

![google-login](https://github.com/user-attachments/assets/8e41134b-8999-4b8c-be88-4a76c9e4d793)
![discord-login](https://github.com/user-attachments/assets/64a585bc-c6dc-4a5a-b293-c6176c2da58b)


## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
