### PR TITLE
Feature/updatable desktop shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Minigalaxy will now create working Desktop Shortcuts for wine games (thanks to GB609)
 - Make games Unreal Gold able to launch
 - Minor UI change in the dialog for third-party logins (thanks to GB609)
+- Desktop shortcuts created by Minigalaxy will now be updated with environment and launch argument changes from the game's property dialog when OK is clicked (thanks to GB609)
 
 **1.3.1**
 - Fix Windows games with multiple parts not installing with wine

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -273,7 +273,7 @@ def get_exec_line(game):
     return " ".join(exe_cmd_list)
 
 
-def create_applications_file(game):
+def create_applications_file(game, override=False):
     error_message = ""
     path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.get_stripped_name(to_path=True)))
     # Create desktop file definition
@@ -293,13 +293,19 @@ def create_applications_file(game):
         Name={game_name}
         Icon={game_icon_path}
         Categories=Game""".format(**desktop_context)
-    if not os.path.isfile(path_to_shortcut):
-        try:
-            with open(path_to_shortcut, 'w+') as desktop_file:
-                desktop_file.writelines(textwrap.dedent(desktop_definition))
-        except Exception as e:
+
+    file_exists = os.path.isfile(path_to_shortcut)
+    try:
+        if file_exists and override:
             os.remove(path_to_shortcut)
-            error_message = e
+        elif file_exists:
+            return error_message
+
+        with open(path_to_shortcut, 'w+') as desktop_file:
+            desktop_file.writelines(textwrap.dedent(desktop_definition))
+    except Exception as e:
+        os.remove(path_to_shortcut)
+        error_message = e
     return error_message
 
 

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -135,7 +135,7 @@ class GameTile(Gtk.Box):
 
     @Gtk.Template.Callback("on_menu_button_properties_clicked")
     def show_properties(self, button):
-        properties_window = Properties(self, self.game, self.api)
+        properties_window = Properties(self, self.game, self.config, self.api)
         properties_window.run()
         properties_window.destroy()
 

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -141,7 +141,7 @@ class GameTileList(Gtk.Box):
 
     @Gtk.Template.Callback("on_menu_button_properties_clicked")
     def show_properties(self, button):
-        properties_window = Properties(self, self.game, self.api)
+        properties_window = Properties(self, self.game, self.config, self.api)
         properties_window.run()
         properties_window.destroy()
 


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This is a small one, but important on the long run nonetheless:
Changes in the game properties to the environment or launch arguments will now also cause the desktop shortcut file to be recreated (if create_application_file is enabled in preferences).

I've added an 'override' flag to installer/create_application_file. When true, any existing file will be deleted first (before, it just skipped over file creation if it existed).
The call to create_application_file forim properties.py sets override to true. It is false by default otherwise.

Depending on feedback and various use cases, we might consider to make this overriding behaviour itself also a preference changeable by users (or check existing files for some kind of flag that disables overriding), because there might be power users that want to manually customize the precreated shortcut files. In that case, minigalaxy would eventually overwrite these changes again.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
