### PR TITLE
remove duplicate code step 1 - locale setting in GameTile(List)

### DIFF
--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -1,22 +1,20 @@
-import shutil
-import locale
 import os
+import shutil
 import threading
 import time
 import urllib.parse
 
+from minigalaxy.api import NoDownloadLinkFound, Api
 from minigalaxy.config import Config
-from minigalaxy.entity.state import State
-from minigalaxy.game import Game
-from minigalaxy.logger import logger
-from minigalaxy.translation import _
-from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, ICON_DIR, UI_DIR, DOWNLOAD_DIR
 from minigalaxy.download import Download, DownloadType
 from minigalaxy.download_manager import DownloadManager
-from minigalaxy.launcher import start_game
+from minigalaxy.entity.state import State
+from minigalaxy.game import Game
 from minigalaxy.installer import uninstall_game, install_game, check_diskspace
-from minigalaxy.paths import ICON_WINE_PATH
-from minigalaxy.api import NoDownloadLinkFound, Api
+from minigalaxy.launcher import start_game
+from minigalaxy.logger import logger
+from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, ICON_DIR, UI_DIR, DOWNLOAD_DIR, ICON_WINE_PATH
+from minigalaxy.translation import _
 from minigalaxy.ui.gtk import Gtk, GLib, Notify
 from minigalaxy.ui.information import Information
 from minigalaxy.ui.properties import Properties
@@ -40,24 +38,16 @@ class GameTile(Gtk.Box):
     menu_button_properties = Gtk.Template.Child()
     progress_bar = Gtk.Template.Child()
 
-    def __init__(self, parent, game: Game, config: Config, api: Api, download_manager: DownloadManager):
+    def __init__(self, parent_library, game: Game, config: Config, api: Api, download_manager: DownloadManager):
         self.config = config
-        current_locale = self.config.locale
-        default_locale = locale.getdefaultlocale()[0]
-        if current_locale == '':
-            locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
-        else:
-            try:
-                locale.setlocale(locale.LC_ALL, (current_locale, 'UTF-8'))
-            except NameError:
-                locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
+
         Gtk.Frame.__init__(self)
 
-        self.parent = parent
+        self.parent = parent_library
         self.game = game
         self.api = api
         self.download_manager = download_manager
-        self.offline = parent.offline
+        self.offline = parent_library.offline
         self.thumbnail_set = False
         self.download_list = []
         self.dlc_dict = {}

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -1,23 +1,21 @@
-import shutil
-import locale
 import os
+import shutil
 import threading
 import time
 import urllib.parse
 
+from minigalaxy.api import NoDownloadLinkFound, Api
 from minigalaxy.config import Config
-from minigalaxy.entity.state import State
-from minigalaxy.game import Game
-from minigalaxy.logger import logger
-from minigalaxy.translation import _
-from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, ICON_DIR, UI_DIR, DOWNLOAD_DIR
+from minigalaxy.css import CSS_PROVIDER
 from minigalaxy.download import Download, DownloadType
 from minigalaxy.download_manager import DownloadManager
-from minigalaxy.launcher import start_game
+from minigalaxy.entity.state import State
+from minigalaxy.game import Game
 from minigalaxy.installer import uninstall_game, install_game, check_diskspace
-from minigalaxy.css import CSS_PROVIDER
-from minigalaxy.paths import ICON_WINE_PATH
-from minigalaxy.api import NoDownloadLinkFound, Api
+from minigalaxy.launcher import start_game
+from minigalaxy.logger import logger
+from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, ICON_DIR, UI_DIR, DOWNLOAD_DIR, ICON_WINE_PATH
+from minigalaxy.translation import _
 from minigalaxy.ui.gtk import Gtk, GLib, Notify
 from minigalaxy.ui.information import Information
 from minigalaxy.ui.properties import Properties
@@ -41,26 +39,18 @@ class GameTileList(Gtk.Box):
     menu_button_properties = Gtk.Template.Child()
     game_label = Gtk.Template.Child()
 
-    def __init__(self, parent, game: Game, config: Config, api: Api, download_manager: DownloadManager):
+    def __init__(self, parent_library, game: Game, config: Config, api: Api, download_manager: DownloadManager):
         self.config = config
-        current_locale = self.config.locale
-        default_locale = locale.getdefaultlocale()[0]
-        if current_locale == '':
-            locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
-        else:
-            try:
-                locale.setlocale(locale.LC_ALL, (current_locale, 'UTF-8'))
-            except NameError:
-                locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
+
         Gtk.Frame.__init__(self)
         Gtk.StyleContext.add_provider(self.button.get_style_context(),
                                       CSS_PROVIDER,
                                       Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-        self.parent = parent
+        self.parent = parent_library
         self.game = game
         self.api = api
         self.download_manager = download_manager
-        self.offline = parent.offline
+        self.offline = parent_library.offline
         self.progress_bar = None
         self.thumbnail_set = False
         self.download_list = []

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -1,21 +1,23 @@
+import json
+import locale
 import os
 import re
-import json
 import threading
-from typing import List
 
+from minigalaxy.api import Api
+from minigalaxy.config import Config
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.entity.state import State
+from minigalaxy.game import Game
 from minigalaxy.logger import logger
 from minigalaxy.paths import UI_DIR, CATEGORIES_FILE_PATH
-from minigalaxy.api import Api
-from minigalaxy.game import Game
+from minigalaxy.translation import _
 from minigalaxy.ui.categoryfilters import CategoryFilters
 from minigalaxy.ui.gametile import GameTile
 from minigalaxy.ui.gametilelist import GameTileList
 from minigalaxy.ui.gtk import Gtk, GLib
-from minigalaxy.config import Config
-from minigalaxy.translation import _
+
+from typing import List
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "library.ui"))
@@ -24,10 +26,22 @@ class Library(Gtk.Viewport):
 
     flowbox = Gtk.Template.Child()
 
-    def __init__(self, parent, config: Config, api: Api, download_manager: DownloadManager):
+    def __init__(self, parent_window, config: Config, api: Api, download_manager: DownloadManager):
         Gtk.Viewport.__init__(self)
-        self.parent = parent
+
+        self.parent = parent_window
         self.config = config
+
+        current_locale = self.config.locale
+        default_locale = locale.getdefaultlocale()[0]
+        if current_locale == '':
+            locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
+        else:
+            try:
+                locale.setlocale(locale.LC_ALL, (current_locale, 'UTF-8'))
+            except NameError:
+                locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
+
         self.api = api
         self.download_manager = download_manager
         self.show_installed_only = self.config.installed_filter

--- a/tests/test_ui_library.py
+++ b/tests/test_ui_library.py
@@ -79,6 +79,10 @@ API_GAMES = {"Neverwinter Nights: Enhanced Edition": "1097893768", "Beneath a St
 
 
 class TestLibrary(TestCase):
+
+    mock_config = MagicMock()
+    mock_config.locale = "en"
+
     def test1_add_games_from_api(self):
         self_games = []
         for game in SELF_GAMES:
@@ -87,10 +91,9 @@ class TestLibrary(TestCase):
         for game in API_GAMES:
             api_games.append(Game(name=game, game_id=int(API_GAMES[game]),))
         err_msg = ""
-        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), config, api_mock, MagicMock())
+        test_library = Library(MagicMock(), self.mock_config, api_mock, MagicMock())
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = len(API_GAMES)
@@ -105,10 +108,9 @@ class TestLibrary(TestCase):
         for game in API_GAMES:
             api_games.append(Game(name=game, game_id=int(API_GAMES[game]),))
         err_msg = ""
-        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), config, api_mock, MagicMock())
+        test_library = Library(MagicMock(), self.mock_config, api_mock, MagicMock())
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = True
@@ -126,10 +128,9 @@ class TestLibrary(TestCase):
         api_gmae_with_id = Game(name="Game without ID", game_id=1234567890)
         api_games.append(api_gmae_with_id)
         err_msg = ""
-        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), config, api_mock, MagicMock())
+        test_library = Library(MagicMock(), self.mock_config, api_mock, MagicMock())
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = True
@@ -149,10 +150,9 @@ class TestLibrary(TestCase):
             api_games.append(Game(name=game, game_id=int(API_GAMES[game]), url="http://test_url{}".format(str(url_nr))))
             url_nr += 1
         err_msg = ""
-        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), config, api_mock, MagicMock())
+        test_library = Library(MagicMock(), self.mock_config, api_mock, MagicMock())
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = "http://test_url1"
@@ -167,10 +167,9 @@ class TestLibrary(TestCase):
         for game in API_GAMES:
             api_games.append(Game(name=game, game_id=int(API_GAMES[game])))
         err_msg = ""
-        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), config, api_mock, MagicMock())
+        test_library = Library(MagicMock(), self.mock_config, api_mock, MagicMock())
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = "Neverwinter Nights: Enhanced Edition"
@@ -181,10 +180,9 @@ class TestLibrary(TestCase):
         self_games = [Game(name="Torchlight 2", game_id=0, install_dir="/home/user/GoG Games/Torchlight II")]
         api_games = [Game(name="Torchlight II", game_id=1958228073)]
         err_msg = ""
-        config = MagicMock()
         api_mock = MagicMock()
         api_mock.get_library.return_value = api_games, err_msg
-        test_library = Library(MagicMock(), config, api_mock, MagicMock())
+        test_library = Library(MagicMock(), self.mock_config, api_mock, MagicMock())
         test_library.games = self_games
         test_library._Library__add_games_from_api()
         exp = 1


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

I'm planning to rework the code around GameTile and GameTileList.
To be more precise, i want to get rid of as much of the duplication as possible because that makes most of the logic very hard to maintain.
There's few open issues and feature requests that would benefit greatly if we wouldn't need to implement and maintain them twice.

There is a lot of code to touch overall because those classes are very large, so i'm trying to split it up as much as somehow possible while not creating a commit that breaks the application.
This is part 1 of X (number to come unknown) and still a small little change, comprising of the following:

1. I've sorted the imports in library, gametile and gametileview alphabetically. This is just an editorial, but it already helped me to find a duplicated import
2. A little renaming of one argument passed to the constructors of Library, GameTile and GameTileList to make its expected type clear (`parent` => `parent_window` or `parent_library`). Maybe we can/should also rename the variable bound to self. Reason: When reading through the ui code, i've stumbled over lines like `self.parent.parent.parent` in multiple places. It is very hard to follow and understand what _exactly_ which parent is.
3. There was some locale get-set code in the constructors of both GameTile and GameTileView, which only uses Config and locale. Given that Config and locale are more or less 'singletons', there is no need to run this repeatedly in a loop for each game added to the library window. I've moved that to the constructor of Library (and adjusted the tests accordingly). And i think it doesn't even belong there but should be taken care of right after the start of the application. But that's a separate issue.

-----------------------------------------
### Here's a rough overall outline of what and how i'm planning to change stuff here:

1. When directly comparing gametile and gametilelist, one can see that they are mostly identical, so i want to extract this out into a dedicated class. I can basically just copy GameTile and call it something else like e.g. LibraryEntry.
2. Both can then inherit this class, additionally to the Gtk.Box.
4. Because i'm not sure about how the gtk annotations for the buttons behave when placed superclasses, anything strictly related to ui elements remains in the subclasses.
5. The differences in behaviour can mostly be eliminated because they are few and minor.

The differences are:
1. Some translatable labels, but only in the first letter, e.g. `Updating...` vs. `updating...`. Merge strategy: Pick one of both to streamline, then the code using it can go into the superclass and we could possibly also drop the other variant from the po files because it's might not be needed anymore.
2. `__install` and `__install_game` in both classes open the "installation success" popup at slightly different points in time. This is only a matter of 2-3 logical lines in the code flow. Pick one, both are likely correct and not that different.
3. Some ui elements are different. For that i would introduce a new method, `init_ui_elements`, in the parent classes with the common parts and override them in the subclass (where they do additions + call super). This method can then be called at the end of the subclasses constructors. One cavaet currently: Because the UI elements are generated based on annotations and factories in the subclasses, i likely can't include their definition in the parent, so it's kind of an 'implicit' contract whereever the parent class uses a reference/variable name it doesn't declare by itself. But its easily noticable and an undefined variable will immediately lead to crashes while starting up.
4. The handling of progress_bar. In GameTile it is an inherent part of the ui template and just gets hidden when not needed. GameTileList destroys and recreates the bar in the code all the time depending on the current state. I think it should be enough to create it once in setup, then the show/hide logical used in GameTile (or superclass) can apply to both.
6. The state handling of the ui elements. There is a big common part. However, because GameTile implementations might also use different elements, differences must also be handled. For that, i moved the initialisation of `STATE_UPDATE_HANDLERS` to the parent class constructor and made it an instance variable. But i had to rename the `__state_something` methods to `state_something` or the superclass wouldn't pick up the right ones (because of the name mangling). With that, ui state handling takes places in the superclass, but state change can also be re-implemented or enhanced in subclasses.

I've actually started with a rough draft branch already, although i'm not done with eliminating all possible duplications and the test are not running yet. Feel free to check it out https://github.com/GB609/minigalaxy/tree/deduplicate_ui_code.

## Checklist
Note: Changelog will be updated at the end, there is no point in adding a line for each intermediate step 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
