### PR TITLE
remove duplicate code step 2 - rename self.parent vars for more clarity

### DIFF
--- a/minigalaxy/ui/information.py
+++ b/minigalaxy/ui/information.py
@@ -1,13 +1,13 @@
-import urllib
 import os
+import urllib
 import webbrowser
 
 from minigalaxy.api import Api
-from minigalaxy.paths import UI_DIR, THUMBNAIL_DIR, COVER_DIR
-from minigalaxy.translation import _
 from minigalaxy.config import Config
 from minigalaxy.download import Download
 from minigalaxy.download_manager import DownloadManager
+from minigalaxy.paths import UI_DIR, THUMBNAIL_DIR, COVER_DIR
+from minigalaxy.translation import _
 from minigalaxy.ui.gtk import Gtk, GLib, Gio, GdkPixbuf
 
 
@@ -25,10 +25,10 @@ class Information(Gtk.Dialog):
     button_information_pcgamingwiki = Gtk.Template.Child()
     label_game_description = Gtk.Template.Child()
 
-    def __init__(self, parent, game, config: Config, api: Api, download_manager: DownloadManager):
-        Gtk.Dialog.__init__(self, title=_("Information about {}").format(game.name), parent=parent.parent.parent,
+    def __init__(self, parent_window, game, config: Config, api: Api, download_manager: DownloadManager):
+        Gtk.Dialog.__init__(self, title=_("Information about {}").format(game.name), parent=parent_window,
                             modal=True)
-        self.parent = parent
+        self.parent_window = parent_window
         self.game = game
         self.config = config
         self.api = api
@@ -51,7 +51,7 @@ class Information(Gtk.Dialog):
         try:
             webbrowser.open(self.api.get_info(self.game)['links']['support'], new=2)
         except webbrowser.Error:
-            self.parent.parent.show_error(
+            self.parent_window.show_error(
                 _("Couldn't open support page"),
                 _("Please check your internet connection")
             )
@@ -61,7 +61,7 @@ class Information(Gtk.Dialog):
         try:
             webbrowser.open(self.gogBaseUrl + self.game.url)
         except webbrowser.Error:
-            self.parent.parent.show_error(
+            self.parent_window.show_error(
                 _("Couldn't open store page"),
                 _("Please check your internet connection")
             )
@@ -71,7 +71,7 @@ class Information(Gtk.Dialog):
         try:
             webbrowser.open(self.api.get_info(self.game)['links']['forum'], new=2)
         except webbrowser.Error:
-            self.parent.parent.show_error(
+            self.parent_window.show_error(
                 _("Couldn't open forum page"),
                 _("Please check your internet connection")
             )
@@ -81,7 +81,7 @@ class Information(Gtk.Dialog):
         try:
             webbrowser.open("https://www.gogdb.org/product/{}".format(self.game.id))
         except webbrowser.Error:
-            self.parent.parent.show_error(
+            self.parent_window.show_error(
                 _("Couldn't open GOG Database page"),
                 _("Please check your internet connection")
             )
@@ -91,7 +91,7 @@ class Information(Gtk.Dialog):
         try:
             webbrowser.open("https://pcgamingwiki.com/api/gog.php?page={}".format(self.game.id))
         except webbrowser.Error:
-            self.parent.parent.show_error(
+            self.parent_window.show_error(
                 _("Couldn't open PCGamingWiki page"),
                 _("Please check your internet connection")
             )

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -32,10 +32,11 @@ class Properties(Gtk.Dialog):
     button_properties_ok = Gtk.Template.Child()
     label_wine_custom = Gtk.Template.Child()
 
-    def __init__(self, parent, game, config: Config, api):
-        Gtk.Dialog.__init__(self, title=_("Properties of {}").format(game.name), parent=parent.parent.parent,
+    def __init__(self, parent_library, game, config: Config, api):
+        Gtk.Dialog.__init__(self, title=_("Properties of {}").format(game.name), parent=parent_library.parent_window,
                             modal=True)
-        self.parent = parent
+        self.parent_library = parent_library
+        self.parent_window = parent_library.parent_window
         self.game = game
         self.config = config
         self.api = api
@@ -83,12 +84,12 @@ class Properties(Gtk.Dialog):
             self.game.set_info("check_for_updates", self.switch_properties_check_for_updates.get_active())
             self.game.set_info("show_fps", self.switch_properties_show_fps.get_active())
             if self.switch_properties_use_gamemode.get_active() and not shutil.which("gamemoderun"):
-                self.parent.parent.parent.show_error(_("GameMode wasn't found. Using GameMode cannot be enabled."))
+                self.parent_window.show_error(_("GameMode wasn't found. Using GameMode cannot be enabled."))
                 self.game.set_info("use_gamemode", False)
             else:
                 self.game.set_info("use_gamemode", self.switch_properties_use_gamemode.get_active())
             if self.switch_properties_use_mangohud.get_active() and not shutil.which("mangohud"):
-                self.parent.parent.parent.show_error(_("MangoHud wasn't found. Using MangoHud cannot be enabled."))
+                self.parent_window.show_error(_("MangoHud wasn't found. Using MangoHud cannot be enabled."))
                 self.game.set_info("use_mangohud", False)
             else:
                 self.game.set_info("use_mangohud", self.switch_properties_use_mangohud.get_active())
@@ -96,7 +97,7 @@ class Properties(Gtk.Dialog):
             self.game.set_info("command", str(self.entry_properties_command.get_text()))
         self.game.set_info("hide_game", self.switch_properties_hide_game.get_active())
         self.game.set_info("custom_wine", str(self.button_properties_wine.get_filename()))
-        self.parent.parent.filter_library()
+        self.parent_library.filter_library()
 
         if game_installed and self.config.create_applications_file:
             create_applications_file(game=self.game, override=True)
@@ -118,7 +119,7 @@ class Properties(Gtk.Dialog):
     @Gtk.Template.Callback("on_button_properties_winetricks_clicked")
     def on_menu_button_winetricks(self, widget):
         if not shutil.which("winetricks"):
-            self.parent.parent.parent.show_error(_("Winetricks wasn't found and cannot be used."))
+            self.parent_window.show_error(_("Winetricks wasn't found and cannot be used."))
         else:
             winetricks_game(self.game)
 


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

Step 2 of the refactoring i started with #642.
Some of this could already be considered to be 'double work' because i'm changing code both in GameTile and GameTileList, which i could also do in a superclass once only.
Still, it's not that much and it helps reduce the differences per PR to manageable chunks.

I renamed some of the `self.parent` variables to `self.parent_library` or `self.parent_window` to improve readability and clarity.
In some places i've also 'unwrapped' them to disjunct variables so that frequently used deep dot-style navigation isn't necessary.

Then there's some code shifting around between GameTile(List) and Library.
Oh, and a little performance improvement for large libraries:
Every added game puts 2 actions on the worker queue for GTK: 
```python
self._debounce(self.sort_library)
self._debounce(self.flowbox.show_all)
```
Even if they were executed immediately, it would mean that for e.g. 100 added games, the bubble sort in the library would run 100 times, each time with a list one element longer than before. All of that in a loop while more games still are added. And that doesn't even include the show_all which likely involves a lot of layout and rendering work by GTK.
I've moved both calls from `Library.__add_gametile` to the calling method `Library.__create_gametiles` so that they are executed once, after the adding loop has finished.