### PR TITLE
remove duplicate code step 3 - introduce barebones LibraryEntry

### DIFF
--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -4,10 +4,8 @@ import threading
 import time
 import urllib.parse
 
-from minigalaxy.api import NoDownloadLinkFound, Api
-from minigalaxy.config import Config
+from minigalaxy.api import NoDownloadLinkFound
 from minigalaxy.download import Download, DownloadType
-from minigalaxy.download_manager import DownloadManager
 from minigalaxy.entity.state import State
 from minigalaxy.game import Game
 from minigalaxy.installer import uninstall_game, install_game, check_diskspace
@@ -16,12 +14,11 @@ from minigalaxy.logger import logger
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, ICON_DIR, UI_DIR, DOWNLOAD_DIR, ICON_WINE_PATH
 from minigalaxy.translation import _
 from minigalaxy.ui.gtk import Gtk, GLib, Notify
-from minigalaxy.ui.information import Information
-from minigalaxy.ui.properties import Properties
+from minigalaxy.ui.library_entry import LibraryEntry
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "gametile.ui"))
-class GameTile(Gtk.Box):
+class GameTile(LibraryEntry, Gtk.Box):
     __gtype_name__ = "GameTile"
 
     image = Gtk.Template.Child()
@@ -38,16 +35,10 @@ class GameTile(Gtk.Box):
     menu_button_properties = Gtk.Template.Child()
     progress_bar = Gtk.Template.Child()
 
-    def __init__(self, parent_library, game: Game, config: Config, api: Api, download_manager: DownloadManager):
-        self.config = config
-
+    def __init__(self, parent_library, game: Game):
+        super().__init__(parent_library, game)
         Gtk.Frame.__init__(self)
 
-        self.parent_library = parent_library
-        self.parent_window = parent_library.parent_window
-        self.game = game
-        self.api = api
-        self.download_manager = download_manager
         self.offline = parent_library.offline
         self.thumbnail_set = False
         self.download_list = []
@@ -117,15 +108,11 @@ class GameTile(Gtk.Box):
 
     @Gtk.Template.Callback("on_menu_button_information_clicked")
     def show_information(self, button):
-        information_window = Information(self.parent_window, self.game, self.config, self.api, self.download_manager)
-        information_window.run()
-        information_window.destroy()
+        super().show_information(button)
 
     @Gtk.Template.Callback("on_menu_button_properties_clicked")
     def show_properties(self, button):
-        properties_window = Properties(self.parent_library, self.game, self.config, self.api)
-        properties_window.run()
-        properties_window.destroy()
+        super().show_properties(button)
 
     @Gtk.Template.Callback("on_button_cancel_clicked")
     def on_button_cancel(self, widget):

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -4,11 +4,9 @@ import threading
 import time
 import urllib.parse
 
-from minigalaxy.api import NoDownloadLinkFound, Api
-from minigalaxy.config import Config
+from minigalaxy.api import NoDownloadLinkFound
 from minigalaxy.css import CSS_PROVIDER
 from minigalaxy.download import Download, DownloadType
-from minigalaxy.download_manager import DownloadManager
 from minigalaxy.entity.state import State
 from minigalaxy.game import Game
 from minigalaxy.installer import uninstall_game, install_game, check_diskspace
@@ -17,12 +15,11 @@ from minigalaxy.logger import logger
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, ICON_DIR, UI_DIR, DOWNLOAD_DIR, ICON_WINE_PATH
 from minigalaxy.translation import _
 from minigalaxy.ui.gtk import Gtk, GLib, Notify
-from minigalaxy.ui.information import Information
-from minigalaxy.ui.properties import Properties
+from minigalaxy.ui.library_entry import LibraryEntry
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "gametilelist.ui"))
-class GameTileList(Gtk.Box):
+class GameTileList(LibraryEntry, Gtk.Box):
     __gtype_name__ = "GameTileList"
 
     image = Gtk.Template.Child()
@@ -39,18 +36,14 @@ class GameTileList(Gtk.Box):
     menu_button_properties = Gtk.Template.Child()
     game_label = Gtk.Template.Child()
 
-    def __init__(self, parent_library, game: Game, config: Config, api: Api, download_manager: DownloadManager):
-        self.config = config
+    def __init__(self, parent_library, game: Game):
+        super().__init__(parent_library, game)
 
         Gtk.Frame.__init__(self)
         Gtk.StyleContext.add_provider(self.button.get_style_context(),
                                       CSS_PROVIDER,
                                       Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-        self.parent_library = parent_library
-        self.parent_window = parent_library.parent_window
-        self.game = game
-        self.api = api
-        self.download_manager = download_manager
+
         self.offline = parent_library.offline
         self.progress_bar = None
         self.thumbnail_set = False
@@ -123,15 +116,11 @@ class GameTileList(Gtk.Box):
 
     @Gtk.Template.Callback("on_menu_button_information_clicked")
     def show_information(self, button):
-        information_window = Information(self.parent_window, self.game, self.config, self.api, self.download_manager)
-        information_window.run()
-        information_window.destroy()
+        super().show_information(button)
 
     @Gtk.Template.Callback("on_menu_button_properties_clicked")
     def show_properties(self, button):
-        properties_window = Properties(self.parent_library, self.game, self.config, self.api)
-        properties_window.run()
-        properties_window.destroy()
+        super().show_properties(button)
 
     @Gtk.Template.Callback("on_button_cancel_clicked")
     def on_button_cancel(self, widget):

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -51,6 +51,7 @@ class Library(Gtk.Viewport):
         self.owned_products_ids = []
         self._queue = []
         self.category_filters = []
+        self.configure_library_sort()
 
     def _debounce(self, thunk):
         if thunk not in self._queue:
@@ -119,7 +120,7 @@ class Library(Gtk.Viewport):
 
         return True
 
-    def sort_library(self):
+    def configure_library_sort(self):
         self.flowbox.set_sort_func(self.__sort_library_func)
 
     def __sort_library_func(self, child1, child2):
@@ -141,15 +142,14 @@ class Library(Gtk.Viewport):
                 new_tiles_added = True
 
         if new_tiles_added:
-            self._debounce(self.sort_library)
             self._debounce(self.flowbox.show_all)
 
     def __add_gametile(self, game):
         view = self.config.view
         if view == "grid":
-            game_tile = GameTile(self, game, self.config, self.api, self.download_manager)
+            game_tile = GameTile(self, game)
         elif view == "list":
-            game_tile = GameTileList(self, game, self.config, self.api, self.download_manager)
+            game_tile = GameTileList(self, game)
 
         # Start download if Minigalaxy was closed while downloading this game
         game_tile.resume_download_if_expected()

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -1,0 +1,26 @@
+from minigalaxy.game import Game
+from minigalaxy.ui.information import Information
+from minigalaxy.ui.properties import Properties
+
+
+class LibraryEntry:
+    '''encapsulates all actions that can be taken for an individual game'''
+
+    def __init__(self, parent_library, game: Game):
+        self.parent_library = parent_library
+        self.parent_window = parent_library.parent_window
+
+        self.api = parent_library.api
+        self.config = parent_library.config
+        self.download_manager = parent_library.download_manager
+        self.game = game
+
+    def show_information(self, button):
+        information_window = Information(self.parent_window, self.game, self.config, self.api, self.download_manager)
+        information_window.run()
+        information_window.destroy()
+
+    def show_properties(self, button):
+        properties_window = Properties(self.parent_library, self.game, self.config, self.api)
+        properties_window.run()
+        properties_window.destroy()


### PR DESCRIPTION
Step 3 of the refactoring i started with #642.

This more or less marks the beginning of the big changes for real. There likely won't be coming many more small PRs, but I'll try to see what i can do. And the last one for now (this morning).

@sharkwouter Sorry if i'm flooding you with too many PRs in quick sucession. Just take your time, i don't want to rush you. 

Changes:
1. A skeleton superclass for GameTile(List). It already contains 2 methods from the subclasses that didn't need any of the private instance attributes. And it also shows how i plan to manage interaction between GTK -> subclasses -> common code in places where annotations are involved.
2. Reduced constructor arguments - there is no need to pass around stuff like config and api as individual arguments if they are part of the parent object that also gets passed in anyway.
3. Above changes also lead to some moving around of imports.

I've also had another look at the sort. There are small misunderstandings:
1. on the way it is used in general in the current code
2. and my interpretation of the impact on performance

The sort isn't manually retrigged all the time, instead the GTK api that configures a sort function for the list is used. The rest is completely up to GTK everytime the list is manipulated. It does this automatically and the to only way to interfere would be to temporarily disable sort or unset/change the sort function.
And it's currently only done when adding games, there are no preferences or options to change the sort order.
Therefore, it is enough to call 'sort_library' once during Library construction and drop all repeated calls otherwise. This still means that some unnecessary items on the queue can be avoided.
However, the impact on performance likely is much less severe as i thought initially, at least for the sorting aspect.

Sorry about the confusion.