### PR TITLE
remove duplicate code step 4 - eliminate differences in GameTile(List)

### DIFF
--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -135,14 +135,9 @@ class Library(Gtk.Viewport):
             if tile.game in self.games:
                 games_with_tiles.append(tile.game)
 
-        new_tiles_added = False
         for game in self.games:
             if game not in games_with_tiles:
                 self.__add_gametile(game)
-                new_tiles_added = True
-
-        if new_tiles_added:
-            self._debounce(self.flowbox.show_all)
 
     def __add_gametile(self, game):
         view = self.config.view
@@ -154,6 +149,11 @@ class Library(Gtk.Viewport):
         # Start download if Minigalaxy was closed while downloading this game
         game_tile.resume_download_if_expected()
         self.flowbox.add(game_tile)
+        '''
+        using flowbox.show_all at this point would overrule any state-based
+        hide() statements in game_tile (progress_bar in GameTileList)
+        '''
+        game_tile.show()
 
     def __get_installed_games(self) -> List[Game]:
         # Make sure the install directory exists

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -1,4 +1,8 @@
+import os
+
+from minigalaxy.entity.state import State
 from minigalaxy.game import Game
+from minigalaxy.paths import CACHE_DIR, DOWNLOAD_DIR
 from minigalaxy.ui.information import Information
 from minigalaxy.ui.properties import Properties
 
@@ -14,6 +18,21 @@ class LibraryEntry:
         self.config = parent_library.config
         self.download_manager = parent_library.download_manager
         self.game = game
+
+        self.offline = parent_library.offline
+        self.thumbnail_set = False
+        self.download_list = []
+        self.dlc_dict = {}
+        self.current_state = State.DOWNLOADABLE
+
+        # Set folder for download installer
+        self.download_dir = os.path.join(DOWNLOAD_DIR, self.game.get_install_directory_name())
+
+        # Set folder if user wants to keep installer (disabled by default)
+        self.keep_dir = os.path.join(self.config.install_dir, "installer")
+        self.keep_path = os.path.join(self.keep_dir, self.game.get_install_directory_name())
+        if not os.path.exists(CACHE_DIR):
+            os.makedirs(CACHE_DIR, mode=0o755)
 
     def show_information(self, button):
         information_window = Information(self.parent_window, self.game, self.config, self.api, self.download_manager)


### PR DESCRIPTION
Step 4 of the refactoring i started with #642.

1. Common variable setup is moved to `LibraryEntry.__init__`
2. Prepared a method `init_ui_elements` in subclasses. This already contains a lot of common code for both. Will move the common part up in one of the next steps
3. progress_bar in GameTileList is now created once only. With that, the repeated 'if progress_bar: destroy or create' lines can be replaced by a simple `progress_bar.hide()` or `progress_bar.show()` which is identical to GameTile.
4. Use the same ui labels for GameTileList as they are used by GameTile ('updating...' -> 'Updating...')
5. Small change to how the library calls `show` on newly added game widget. `show_all` overrules the `progress_bar.hide()` statements from GameTileList, so it can't be used.