### PR TITLE
Provide a UI for active downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Various improvements to the download manager, including a pause function (not usable from the UI yet) (thanks to GB609)
 - Speed up creation of wine prefixes during installations (thanks to GB609)
 - Use regedit to more permanently disable useless shortcut creation by wine from within a prefix (thanks to GB609)
+- Introduce a UI to show all active, stopped or failed downloads. Also allows to permanently pause a download (thanks to GB609)
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 **1.4.0**
-- Various improvements to the download manager, including a pause function (not usable from the UI yet) (thanks to GB609)
+- Various improvements to the download manager, including a pause function (thanks to GB609)
 - Speed up creation of wine prefixes during installations (thanks to GB609)
 - Use regedit to more permanently disable useless shortcut creation by wine from within a prefix (thanks to GB609)
 - Introduce a UI to show all active, stopped or failed downloads. Also allows to permanently pause a download (thanks to GB609)

--- a/data/po/cs_CZ.po
+++ b/data/po/cs_CZ.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2022-09-24 10:17+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -29,10 +29,15 @@ msgid "About"
 msgstr "O aplikaci"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "O aplikaci"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -50,7 +55,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Opravdu chcete zrušit stahování {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Opravdu se chcete odhlásit z GOG?"
 
@@ -77,7 +82,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -138,22 +143,42 @@ msgstr "Stažitelný obsah (DLC)"
 msgid "Danish"
 msgstr "Dánština"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Stáhnout"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Zobrazit pouze nainstalované hry"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Chyba stahování"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Stahování…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -183,7 +208,7 @@ msgstr ""
 "Nepodařilo se změnit jazyk aplikace. Ujistěte se, že je na Vašem systému "
 "vygenerováno příslušné locale."
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Instalace {} se nezdařila"
 
@@ -195,7 +220,12 @@ msgstr "Knihovnu se nepodařilo získat"
 msgid "Failed to start {}:"
 msgstr "{} se nezdařilo spustit:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -249,7 +279,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Maďarština"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "Ve frontě…"
 
@@ -261,11 +291,11 @@ msgstr "Informace"
 msgid "Information about {}"
 msgstr "Informace o {}"
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Nainstalovat"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Nainstalované"
@@ -277,12 +307,12 @@ msgid "Installation path: "
 msgstr "Cesta pro instalaci: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Nainstalované"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Instalace…"
 
@@ -318,7 +348,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Jazyk: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -331,10 +361,22 @@ msgid "Login"
 msgstr "Přihlášení"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Odhlásit"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
@@ -376,6 +418,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Otevřít soubory"
@@ -385,12 +432,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Hrát"
 
@@ -413,7 +480,7 @@ msgid "Preferences"
 msgstr "Možnosti"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Možnosti"
@@ -433,7 +500,7 @@ msgid "Properties of {}"
 msgstr "Možnosti {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Obnovit seznam her"
@@ -441,6 +508,11 @@ msgstr "Obnovit seznam her"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -454,6 +526,16 @@ msgstr "Obnovit cestu k wine"
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
 msgstr "Obnovit cestu k wine"
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
+msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
 msgid "Romanian"
@@ -470,7 +552,7 @@ msgid "Save"
 msgstr "Uložit"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -495,7 +577,7 @@ msgstr "Zobrazit hry pro Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -506,7 +588,7 @@ msgid "Show hidden games: "
 msgstr "Zobrazit skryté hry: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Zobrazit pouze nainstalované hry"
@@ -528,6 +610,11 @@ msgstr "Španělština (Španělsko)"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Zapamatovat přihlášení:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -598,15 +685,19 @@ msgstr "Chyba stahování"
 msgid "Uninstall"
 msgstr "Odinstalovat"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Odinstalace…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Aktualizovat"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Aktualizace…"
 
@@ -669,7 +760,7 @@ msgstr "Určuje zdali se mají vytvářet zástupci pro nově nainstalované hry
 msgid "Wine executable:"
 msgstr "Cesta k wine:"
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Rozbalení Wine se nezdařilo."
 
@@ -681,7 +772,7 @@ msgstr "Wine nebyl nalezen. Zobrazení her pro Windows nemůže být zapnuto."
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Rozbalení Wine se nezdařilo."

--- a/data/po/de.po
+++ b/data/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: minigalaxy 0.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2025-02-26 13:03+0000\n"
 "Last-Translator: Akin Yildiz <akin.yildiz@protonmail.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/minigalaxy/"
@@ -30,10 +30,15 @@ msgid "About"
 msgstr "Info"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Info"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -51,7 +56,7 @@ msgstr "Anwenden"
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Bist du sicher, dass du den Download von {} abbrechen möchtest?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Bist du sicher, dass du dich von GOG abmelden möchtest?"
 
@@ -78,7 +83,7 @@ msgid "Category Filters"
 msgstr "Kategorienfilter"
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr "Kategorienfilter"
@@ -137,21 +142,41 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "Dänisch"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Herunterladen"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 msgid "Download and install the game"
 msgstr "Spiel herunterladen und installieren"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Download-Fehler"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Wird heruntergeladen…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -184,7 +209,7 @@ msgid ""
 "system."
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Fehler beim Installieren von {}"
 
@@ -196,7 +221,12 @@ msgstr "Fehler beim Abrufen der Bibliothek"
 msgid "Failed to start {}:"
 msgstr "Fehler beim Starten von {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -253,7 +283,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Ungarisch"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "In der warteschlange…"
 
@@ -265,11 +295,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Installieren"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Installiert"
@@ -281,12 +311,12 @@ msgid "Installation path: "
 msgstr "Installationspfad: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Installiert"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Wird installiert…"
 
@@ -322,7 +352,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Sprache: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -335,10 +365,22 @@ msgid "Login"
 msgstr "Anmelden"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Abmelden"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
@@ -383,6 +425,11 @@ msgstr "Winecfg für dieses Spiel öffnen"
 msgid "Open Winetricks for this game"
 msgstr "Winetricks für dieses Spiel öffnen"
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Dateien öffnen"
@@ -392,12 +439,32 @@ msgid "Open game install folder"
 msgstr "Spieleinstallationsordner öffnen"
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr "Optionsmenü"
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Spielen"
 
@@ -420,7 +487,7 @@ msgid "Preferences"
 msgstr "Einstellungen"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Einstellungen"
@@ -440,7 +507,7 @@ msgid "Properties of {}"
 msgstr "Eigenschaften von {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Spieleliste aktualisieren"
@@ -448,6 +515,11 @@ msgstr "Spieleliste aktualisieren"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -459,6 +531,16 @@ msgstr "Wine Ausführungsdatei für dieses Spiel zurücksetzen"
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -476,7 +558,7 @@ msgid "Save"
 msgstr "Speichern"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -500,7 +582,7 @@ msgstr "Windows-Spiele anzeigen: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -511,7 +593,7 @@ msgid "Show hidden games: "
 msgstr "Versteckte Spiele anzeigen: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Nur installierte Spiele anzeigen"
@@ -534,6 +616,11 @@ msgstr "Spanisch"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Angemeldet bleiben:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -605,15 +692,19 @@ msgstr "Download-Fehler"
 msgid "Uninstall"
 msgstr "Deinstallieren"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Wird deinstalliert…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Wird aktualisiert…"
 
@@ -678,7 +769,7 @@ msgstr ""
 msgid "Wine executable:"
 msgstr "Entpacken mit Wine fehlgeschlagen."
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Entpacken mit Wine fehlgeschlagen."
 
@@ -692,7 +783,7 @@ msgstr ""
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Entpacken mit Wine fehlgeschlagen."

--- a/data/po/el.po
+++ b/data/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2024-04-01 03:37+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -29,10 +29,15 @@ msgid "About"
 msgstr "Περί"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Περί"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -54,7 +59,7 @@ msgstr "Εφαρμογή"
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Είστε σίγουρος/η ότι θέλετε να ακυρώσετε την εγκατάσταση του {};"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Είστε σίγουρος/η ότι θέλετε να αποσυνδεθείτε από το GOG;"
 
@@ -81,7 +86,7 @@ msgid "Category Filters"
 msgstr "Φίλτρα Κατηγορίας"
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr "Φίλτρα κατηγορίας"
@@ -140,21 +145,41 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "Δανέζικα"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Λήψη"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 msgid "Download and install the game"
 msgstr "Λήψη και εγκατάσταση του παιχνιδιού"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Σφάλμα κατα την διαρκεια κατεβασματος"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Ενυμέρωση…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -189,7 +214,7 @@ msgstr ""
 "Αδυναμία αλλαγής γλωσσάς προγράμματος.Βεβαιωθείτε ότι έχει δημιουργηθεί η "
 "καταχώρηση τοπικότητας στο σύστημα σας."
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Αδυναμία εγκατάστασης {}"
 
@@ -201,7 +226,12 @@ msgstr "Αδυναμία εύρεσης βιβλιοθήκης"
 msgid "Failed to start {}:"
 msgstr "Αδυναμία έναρξης {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr "Ολοκληρώθηκε η λήψη και εγκατάσταση {}"
 
@@ -257,7 +287,7 @@ msgstr "Αποκρύπτει το παιχνίδι από τη λίστα παι
 msgid "Hungarian"
 msgstr "Ουγγαρέζικα"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "Σε αναμονή…"
 
@@ -269,11 +299,11 @@ msgstr "Πληροφορίες"
 msgid "Information about {}"
 msgstr "Πληροφορίες περί {}"
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Εγκατάστασή"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 msgid "Install the game"
 msgstr "Εγκατάσταση του παιχνιδιού"
 
@@ -284,12 +314,12 @@ msgid "Installation path: "
 msgstr "Προορισμός εγκατάστασης: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Εγκατεστημένα"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Εγκαθίσταται…"
 
@@ -325,7 +355,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Γλώσσα: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr "Εκτελέσει του παιχνιδιού"
 
@@ -338,10 +368,22 @@ msgid "Login"
 msgstr "Σύνδεση"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Αποσύνδεση"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
@@ -387,6 +429,11 @@ msgstr "Άνοιγμα του Winecfg για αυτό το παιχνίδι"
 msgid "Open Winetricks for this game"
 msgstr "Άνοιγμα Winetricks για αυτό το παιχνίδι"
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Άνοιγμα αρχείων"
@@ -396,12 +443,32 @@ msgid "Open game install folder"
 msgstr "Άνοιγμα του φακέλου εγκατάστασης του παιχνιδιού"
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr "Μενού επιλογών"
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Παίξε"
 
@@ -424,7 +491,7 @@ msgid "Preferences"
 msgstr "Προτιμήσεις"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Προτιμήσεις"
@@ -444,7 +511,7 @@ msgid "Properties of {}"
 msgstr "Ιδιότητες του {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Ανανέωση λίστας παιχνιδιών"
@@ -452,6 +519,11 @@ msgstr "Ανανέωση λίστας παιχνιδιών"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Επεξεργασία μητρώου wine"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -464,6 +536,16 @@ msgstr "Επαναφορά του εκτελέσιμου αρχείου wine γ�
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
 msgstr "Επαναφορά εκτελέσιμου wine"
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
+msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
 msgid "Romanian"
@@ -480,7 +562,7 @@ msgid "Save"
 msgstr "Αποθήκευση"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 msgctxt "search"
 msgid "Search games list"
 msgstr "Αναζήτηση λίστας παιχνιδιών"
@@ -503,7 +585,7 @@ msgstr "Προβολή παιχνιδιών Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr "Εμφάνιση ενός μετρητή FPS (καρέ ανά δευτερόλεπτο) στο παιχνίδι"
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr "Εμφάνιση του μενού επιλογών παιχνιδιού"
 
@@ -514,7 +596,7 @@ msgid "Show hidden games: "
 msgstr "Προβολή κρυφών παιχνιδιών: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Προβολή μόνο εγκατεστημένων παιχνιδιών"
@@ -536,6 +618,11 @@ msgstr "Ισπανικά (Ισπανίας)"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Διατήρηση Σύνδεσης:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -603,15 +690,19 @@ msgstr "Μη διαχειρίσιμο σφάλμα."
 msgid "Uninstall"
 msgstr "Απεγκατάσταση"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Απ εγκαθίσταται…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Ενημέρωση"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Ενημερώνεται…"
 
@@ -679,7 +770,7 @@ msgstr ""
 msgid "Wine executable:"
 msgstr "Εκτελέσιμο wine:"
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Αποτυχία αποσυμπίεσης wine."
 
@@ -693,7 +784,7 @@ msgstr ""
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 msgid "Wineprefix creation failed."
 msgstr "Απέτυχε η δημιουργία wineprefix."
 

--- a/data/po/es_AR.po
+++ b/data/po/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2021-10-07 18:22+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -29,10 +29,15 @@ msgid "About"
 msgstr "Acerca de"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Acerca de"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -50,7 +55,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "¿Estás seguro que deseas cancelar la descarga de {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "¿Estás seguro que quieres cerrar la sesión de GOG?"
 
@@ -78,7 +83,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -141,23 +146,43 @@ msgstr ""
 msgid "Danish"
 msgstr "Danés"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Descarga"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Mostrar solo los juegos instalados"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 #, fuzzy
 msgid "Download error"
 msgstr "Error en la descarga"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Descargando…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -187,7 +212,7 @@ msgstr ""
 "Fallo al cambiar el idioma del programa. Asegúrate de que el local se "
 "hagenerado en tu sistema"
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "No se pudo instalar {}"
 
@@ -199,7 +224,12 @@ msgstr "No se pudo recuperar la biblioteca"
 msgid "Failed to start {}:"
 msgstr "No se pudo iniciar {}"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -255,7 +285,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "En cola…"
 
@@ -267,11 +297,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Instalar"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Instalados"
@@ -283,12 +313,12 @@ msgid "Installation path: "
 msgstr "Ruta de instalación: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Instalados"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Instalando…"
 
@@ -324,7 +354,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Idioma: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -337,10 +367,22 @@ msgid "Login"
 msgstr "Iniciar sesión"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Cerrar sesión"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -388,6 +430,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Abrir Archivos"
@@ -397,12 +444,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Jugar"
 
@@ -425,7 +492,7 @@ msgid "Preferences"
 msgstr "Preferencias"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Preferencias"
@@ -445,13 +512,18 @@ msgid "Properties of {}"
 msgstr "Propiedades de {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Refrescar lista de juegos"
 
 #: data/ui/properties.ui:48
 msgid "Regedit"
+msgstr ""
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
 msgstr ""
 
 #: data/ui/categoryfilters.ui:44
@@ -464,6 +536,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -481,7 +563,7 @@ msgid "Save"
 msgstr "Guardar"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -506,7 +588,7 @@ msgstr "Mostrar los juegos para Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -518,7 +600,7 @@ msgid "Show hidden games: "
 msgstr "Mostrar los juegos ocultos: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Mostrar solo los juegos instalados"
@@ -541,6 +623,11 @@ msgstr "Español"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Permanecer conectado:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 #, fuzzy
@@ -616,15 +703,19 @@ msgstr "Error en la descarga"
 msgid "Uninstall"
 msgstr "Desinstalar"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Desinstalando…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Actualizar"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Descargando…"
 
@@ -689,7 +780,7 @@ msgstr "Si los atajos son creados al instalar nuevos juegos o no"
 msgid "Wine executable:"
 msgstr "La extracción de Wine fallo."
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "La extracción de Wine fallo."
 
@@ -702,7 +793,7 @@ msgstr ""
 msgid "Winecfg"
 msgstr ""
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "La extracción de Wine fallo."

--- a/data/po/es_ES.po
+++ b/data/po/es_ES.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2023-02-21 13:26-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -29,10 +29,15 @@ msgid "About"
 msgstr "Acerca de"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Acerca de"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -50,7 +55,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "¿Estás seguro de que quieres cancelar la descarga de {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "¿Estás seguro de que quieres cerrar la sesión de GOG?"
 
@@ -77,7 +82,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -136,22 +141,42 @@ msgstr "Contenido descargable"
 msgid "Danish"
 msgstr "Danés"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Descargar"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Mostrar solo los juegos instalados"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Error en la descarga"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Descargando…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -181,7 +206,7 @@ msgstr ""
 "Fallo al cambiar el idioma del programa. Asegúrate de que el local se ha "
 "generado en tu sistema."
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "No se ha podido instalar {}"
 
@@ -193,7 +218,12 @@ msgstr "No se ha podido recuperar la biblioteca"
 msgid "Failed to start {}:"
 msgstr "No se ha podido iniciar {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -248,7 +278,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "En cola…"
 
@@ -260,11 +290,11 @@ msgstr "Información"
 msgid "Information about {}"
 msgstr "Información sobre {}"
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Instalar"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Instalados"
@@ -276,12 +306,12 @@ msgid "Installation path: "
 msgstr "Ruta de instalación: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Instalados"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Instalando…"
 
@@ -317,7 +347,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Idioma: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -330,10 +360,22 @@ msgid "Login"
 msgstr "Iniciar sesión"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Cerrar sesión"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
@@ -378,6 +420,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Abrir archivos"
@@ -387,12 +434,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Jugar"
 
@@ -415,7 +482,7 @@ msgid "Preferences"
 msgstr "Preferencias"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Preferencias"
@@ -435,7 +502,7 @@ msgid "Properties of {}"
 msgstr "Propiedades de {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Refrescar lista de juegos"
@@ -443,6 +510,11 @@ msgstr "Refrescar lista de juegos"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -456,6 +528,16 @@ msgstr "Restablecer ejecutable de wine"
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
 msgstr "Restablecer ejecutable de wine"
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
+msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
 msgid "Romanian"
@@ -472,7 +554,7 @@ msgid "Save"
 msgstr "Guardar"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -497,7 +579,7 @@ msgstr "Mostrar los juegos para Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -508,7 +590,7 @@ msgid "Show hidden games: "
 msgstr "Mostrar los juegos ocultos: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Mostrar solo los juegos instalados"
@@ -530,6 +612,11 @@ msgstr "Español (España)"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Permanecer conectado:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -600,15 +687,19 @@ msgstr "Error en la descarga"
 msgid "Uninstall"
 msgstr "Desinstalar"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Desinstalando…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Actualizar"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Actualizando…"
 
@@ -671,7 +762,7 @@ msgstr "Si los atajos son creados al instalar nuevos juegos o no"
 msgid "Wine executable:"
 msgstr "Ejecutable de Wine:"
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Ha fallado la extracción de Wine."
 
@@ -685,7 +776,7 @@ msgstr ""
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Ha fallado la extracción de Wine."

--- a/data/po/fi.po
+++ b/data/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2021-09-30 12:59+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -30,10 +30,15 @@ msgid "About"
 msgstr "Tietoja"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Tietoja"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Oletko varma että haluat keskeyttää latauksen {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Oletko varma että halua kirjautua ulos palvelusta GOG?"
 
@@ -78,7 +83,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -140,22 +145,42 @@ msgstr "DLC-lisäosa"
 msgid "Danish"
 msgstr "Tanska"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Lataa"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Näytä ainoastaan asennetut pelit"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Latausvirhe"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Ladataan…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -183,7 +208,7 @@ msgid ""
 "system."
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "{} asentaminen epäonnistui"
 
@@ -195,7 +220,12 @@ msgstr "Kirjaston noutaminen epäonnistui"
 msgid "Failed to start {}:"
 msgstr "Kohteen {} käynnistäminen epäonnistui:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -251,7 +281,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Unkari"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "Jonossa…"
 
@@ -263,11 +293,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Asenna"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Asennetut"
@@ -279,12 +309,12 @@ msgid "Installation path: "
 msgstr "Asennuspolku: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Asennetut"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Asennetaan…"
 
@@ -320,7 +350,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Kieli: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -333,10 +363,22 @@ msgid "Login"
 msgstr "Kirjaudu sisään"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Kirjaudu ulos"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -381,6 +423,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Avaa tiedostot"
@@ -390,12 +437,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Pelaa"
 
@@ -418,7 +485,7 @@ msgid "Preferences"
 msgstr "Asetukset"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Asetukset"
@@ -438,7 +505,7 @@ msgid "Properties of {}"
 msgstr "Ominaisuudet kohteelle {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Virkistä peliluettelo"
@@ -446,6 +513,11 @@ msgstr "Virkistä peliluettelo"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit-muokkaus"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -457,6 +529,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -474,7 +556,7 @@ msgid "Save"
 msgstr "Tallenna"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -498,7 +580,7 @@ msgstr "Näytä Windows-pelit: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -509,7 +591,7 @@ msgid "Show hidden games: "
 msgstr "Näytä piilotetut pelit: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Näytä ainoastaan asennetut pelit"
@@ -532,6 +614,11 @@ msgstr "Espanja"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Pysy kirjautuneena:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -603,15 +690,19 @@ msgstr "Latausvirhe"
 msgid "Uninstall"
 msgstr "Poista asennus"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Poistetaan asennusta…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Päivitä"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Päivitetään…"
 
@@ -675,7 +766,7 @@ msgstr "Luodaanko uusille peleille pikakuvakkeet vaiko ei"
 msgid "Wine executable:"
 msgstr "Wine-purku epäonnistui."
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Wine-purku epäonnistui."
 
@@ -688,7 +779,7 @@ msgstr ""
 msgid "Winecfg"
 msgstr "Winecfg-asetukset"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Wine-purku epäonnistui."

--- a/data/po/fr.po
+++ b/data/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2021-10-23 16:33+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -29,10 +29,15 @@ msgid "About"
 msgstr "À propos"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "À propos"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -50,7 +55,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Êtes-vous sûr de vouloir annuler le téléchargement {} ?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Êtes-vous sûr de vouloir vous déconnecter de GOG ?"
 
@@ -77,7 +82,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -139,22 +144,42 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "Danois"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Télécharger"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Afficher uniquement les jeux installés"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Erreur de téléchargement"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Téléchargement…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -182,7 +207,7 @@ msgid ""
 "system."
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Impossible de démarrer {} :"
 
@@ -194,7 +219,12 @@ msgstr "Impossible de récupérer la bibliothèque"
 msgid "Failed to start {}:"
 msgstr "Impossible de démarrer {} :"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -251,7 +281,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Hongrois"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "Dans la file d'attente…"
 
@@ -263,11 +293,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Installer"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Installé"
@@ -279,12 +309,12 @@ msgid "Installation path: "
 msgstr "Chemin d'installation : "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Installé"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Installation…"
 
@@ -320,7 +350,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Langue : "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -333,10 +363,22 @@ msgid "Login"
 msgstr "Connexion"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Déconnexion"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -381,6 +423,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Ouvrir le dossier"
@@ -390,12 +437,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Jouer"
 
@@ -418,7 +485,7 @@ msgid "Preferences"
 msgstr "Préférences"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Préférences"
@@ -438,7 +505,7 @@ msgid "Properties of {}"
 msgstr "Propriétés de {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Rafraîchir la liste de jeux"
@@ -446,6 +513,11 @@ msgstr "Rafraîchir la liste de jeux"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -457,6 +529,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -474,7 +556,7 @@ msgid "Save"
 msgstr "Sauvegarder"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -498,7 +580,7 @@ msgstr "Montrer les jeux Windows : "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -509,7 +591,7 @@ msgid "Show hidden games: "
 msgstr "Montrer les jeux cachés : "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Afficher uniquement les jeux installés"
@@ -532,6 +614,11 @@ msgstr "Espagnol"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Rester connecté :"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -603,15 +690,19 @@ msgstr "Erreur de téléchargement"
 msgid "Uninstall"
 msgstr "Désinstaller"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Désinstallation…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Mise à jour"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Mise à jour…"
 
@@ -676,7 +767,7 @@ msgstr ""
 msgid "Wine executable:"
 msgstr "L'extraction de Wine a échoué."
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "L'extraction de Wine a échoué."
 
@@ -690,7 +781,7 @@ msgstr ""
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "L'extraction de Wine a échoué."

--- a/data/po/it_IT.po
+++ b/data/po/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2025-02-27 17:02+0000\n"
 "Last-Translator: nexal <driftlock@proton.me>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/minigalaxy/"
@@ -30,10 +30,15 @@ msgid "About"
 msgstr "Informazioni"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Informazioni"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -51,7 +56,7 @@ msgstr "Applica"
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Sei sicuro di voler annullare lo scaricamento di {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr ""
 
@@ -78,7 +83,7 @@ msgid "Category Filters"
 msgstr "Filtri di categoria"
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -142,21 +147,41 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "Danese"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Scarica"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 msgid "Download and install the game"
 msgstr "Scarica e installa il gioco"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Errore di download"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Scaricando…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -184,7 +209,7 @@ msgid ""
 "system."
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Installazione di {} fallita"
 
@@ -196,7 +221,12 @@ msgstr "Recupero della libreria fallito"
 msgid "Failed to start {}:"
 msgstr "Apertura di {} fallita:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -253,7 +283,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "In coda…"
 
@@ -265,11 +295,11 @@ msgstr "Informazioni"
 msgid "Information about {}"
 msgstr "Informazioni su {}"
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Installa"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 msgid "Install the game"
 msgstr "Installa il gioco"
 
@@ -280,12 +310,12 @@ msgid "Installation path: "
 msgstr "Percorso di installazione: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Installati"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Installando…"
 
@@ -321,7 +351,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Lingua: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr "Inizia il gioco"
 
@@ -334,10 +364,22 @@ msgid "Login"
 msgstr "Accedi"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Disconnettiti"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -382,6 +424,11 @@ msgstr "Apri Winecfg per questo gioco"
 msgid "Open Winetricks for this game"
 msgstr "Apri Winetricks per questo gioco"
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Apri cartella"
@@ -391,12 +438,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr "Menu di opzioni"
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Gioca"
 
@@ -419,7 +486,7 @@ msgid "Preferences"
 msgstr "Impostazioni"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Impostazioni"
@@ -439,7 +506,7 @@ msgid "Properties of {}"
 msgstr "Proprietà di {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Aggiorna lista dei giochi"
@@ -447,6 +514,11 @@ msgstr "Aggiorna lista dei giochi"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -458,6 +530,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -475,7 +557,7 @@ msgid "Save"
 msgstr "Salva"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 msgctxt "search"
 msgid "Search games list"
 msgstr "Cerca lista dei giochi"
@@ -498,7 +580,7 @@ msgstr "Visualizza giochi di Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -509,7 +591,7 @@ msgid "Show hidden games: "
 msgstr "Visualizza giochi nascosti: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Visualizza solo i giochi installati"
@@ -531,6 +613,11 @@ msgstr "Spagnolo (Spagna)"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Mantieni l'accesso:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -601,15 +688,19 @@ msgstr "Errore di download"
 msgid "Uninstall"
 msgstr "Disinstalla"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Disinstallando…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Aggiorna"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Aggiornando…"
 
@@ -674,7 +765,7 @@ msgstr ""
 msgid "Wine executable:"
 msgstr "L'eseguibile di Wine:"
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr ""
 
@@ -688,7 +779,7 @@ msgstr ""
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 msgid "Wineprefix creation failed."
 msgstr ""
 

--- a/data/po/minigalaxy.pot
+++ b/data/po/minigalaxy.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,9 +28,14 @@ msgid "About"
 msgstr ""
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
+msgstr ""
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
 msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
@@ -49,7 +54,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr ""
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr ""
 
@@ -76,7 +81,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -135,20 +140,40 @@ msgstr ""
 msgid "Danish"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 msgid "Download and install the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
+msgstr ""
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
 msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
@@ -177,7 +202,7 @@ msgid ""
 "system."
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr ""
 
@@ -189,7 +214,12 @@ msgstr ""
 msgid "Failed to start {}:"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -243,7 +273,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr ""
 
@@ -255,11 +285,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 msgid "Install the game"
 msgstr ""
 
@@ -270,12 +300,12 @@ msgid "Installation path: "
 msgstr ""
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr ""
 
@@ -309,7 +339,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -322,9 +352,21 @@ msgid "Login"
 msgstr ""
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
+msgstr ""
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
 msgstr ""
 
 #: minigalaxy/ui/properties.py:92
@@ -367,6 +409,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr ""
@@ -376,12 +423,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr ""
 
@@ -404,7 +471,7 @@ msgid "Preferences"
 msgstr ""
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr ""
@@ -424,13 +491,18 @@ msgid "Properties of {}"
 msgstr ""
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr ""
 
 #: data/ui/properties.ui:48
 msgid "Regedit"
+msgstr ""
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
 msgstr ""
 
 #: data/ui/categoryfilters.ui:44
@@ -443,6 +515,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -460,7 +542,7 @@ msgid "Save"
 msgstr ""
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 msgctxt "search"
 msgid "Search games list"
 msgstr ""
@@ -483,7 +565,7 @@ msgstr ""
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -494,7 +576,7 @@ msgid "Show hidden games: "
 msgstr ""
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr ""
@@ -515,6 +597,11 @@ msgstr ""
 #: data/ui/preferences.ui:196
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
+msgstr ""
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
 msgstr ""
 
 #: data/ui/information.ui:76
@@ -583,15 +670,19 @@ msgstr ""
 msgid "Uninstall"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
+msgstr ""
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
 msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr ""
 
@@ -652,7 +743,7 @@ msgstr ""
 msgid "Wine executable:"
 msgstr ""
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr ""
 
@@ -664,7 +755,7 @@ msgstr ""
 msgid "Winecfg"
 msgstr ""
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 msgid "Wineprefix creation failed."
 msgstr ""
 

--- a/data/po/nb_NO.po
+++ b/data/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2021-11-10 14:20+0100\n"
 "Last-Translator: Kim Malmo <berencamlost@msn.com>\n"
 "Language-Team: \n"
@@ -29,10 +29,15 @@ msgid "About"
 msgstr "Om"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Om"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -50,7 +55,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Er du sikker på at du vil avbryte nedlastingen av {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Er du sikker på at du vil logge ut av GOG?"
 
@@ -77,7 +82,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -138,22 +143,42 @@ msgstr "Tillegg"
 msgid "Danish"
 msgstr "Dansk"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Last ned"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Vis kun installerte spill"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Feil ved nedlasting"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Laster ned…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -183,7 +208,7 @@ msgstr ""
 "Kunne ikke forandre språk for programmet. Sørg for at lokasjonsdata er "
 "generert på systemet ditt."
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Kunne ikke installere {}:"
 
@@ -195,7 +220,12 @@ msgstr "Kunne ikke hente bibliotek"
 msgid "Failed to start {}:"
 msgstr "Kunne ikke starte {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -249,7 +279,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "I kø…"
 
@@ -261,11 +291,11 @@ msgstr "Informasjon"
 msgid "Information about {}"
 msgstr "Informasjon om {}"
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Installer"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Installert"
@@ -277,12 +307,12 @@ msgid "Installation path: "
 msgstr "Installasjonssti: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Installert"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Installerer…"
 
@@ -318,7 +348,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Språk: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -331,10 +361,22 @@ msgid "Login"
 msgstr "Innlogging"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Logg ut"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
@@ -376,6 +418,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Åpne filer"
@@ -385,12 +432,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Spill"
 
@@ -413,7 +480,7 @@ msgid "Preferences"
 msgstr "Brukervalg"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Brukervalg"
@@ -433,13 +500,18 @@ msgid "Properties of {}"
 msgstr "Egenskaper for {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Oppdater spillisten"
 
 #: data/ui/properties.ui:48
 msgid "Regedit"
+msgstr ""
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
 msgstr ""
 
 #: data/ui/categoryfilters.ui:44
@@ -452,6 +524,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -469,7 +551,7 @@ msgid "Save"
 msgstr "Lagre"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -494,7 +576,7 @@ msgstr "Vis Windows spill: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -505,7 +587,7 @@ msgid "Show hidden games: "
 msgstr "Vis skjulte spill: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Vis kun installerte spill"
@@ -527,6 +609,11 @@ msgstr "Spansk (Spania)"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Forbli pålogget:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -597,15 +684,19 @@ msgstr "Feil ved nedlasting"
 msgid "Uninstall"
 msgstr "Avinstaller"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Avinstallerer…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Oppdater"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Oppdaterer…"
 
@@ -667,7 +758,7 @@ msgstr "Om snarveier blir opprettet for nylig innstallerte spill eller ikke"
 msgid "Wine executable:"
 msgstr "Kjørbar fil for Wine:"
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Utpakking av Wine feilet."
 
@@ -679,7 +770,7 @@ msgstr "Wine ble ikke funnet. Visning av Windows spill kan ikke aktiveres."
 msgid "Winecfg"
 msgstr ""
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Utpakking av Wine feilet."

--- a/data/po/nl.po
+++ b/data/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: minigalaxy 0.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2025-02-26 11:02+0000\n"
 "Last-Translator: Wouter Wijsman <wwijsman@live.nl>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/minigalaxy/"
@@ -30,10 +30,15 @@ msgid "About"
 msgstr "Over Minigalaxy"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Over Minigalaxy"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -53,7 +58,7 @@ msgstr "Toepassen"
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Weet je zeker dat je de {} download wilt stoppen?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Weet je zeker dat je uit wilt loggen?"
 
@@ -80,7 +85,7 @@ msgid "Category Filters"
 msgstr "Categorie Filters"
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -142,22 +147,42 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "Deens"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Download"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Laat alleen geïnstalleerde games zien"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Downloadfout"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Downloaden…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -185,7 +210,7 @@ msgid ""
 "system."
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Kon {} niet geïnstalleerd worden:"
 
@@ -197,7 +222,12 @@ msgstr "De lijst me games kon niet opgehaald worden"
 msgid "Failed to start {}:"
 msgstr "Kon {} niet starten:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -254,7 +284,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Hongaars"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "In de wachtrij…"
 
@@ -266,11 +296,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Installeren"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Geïnstalleerd"
@@ -282,12 +312,12 @@ msgid "Installation path: "
 msgstr "Installatiepad: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Geïnstalleerd"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Installeren…"
 
@@ -323,7 +353,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Taal: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -336,10 +366,22 @@ msgid "Login"
 msgstr "Log in"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Uitloggen"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -384,6 +426,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Bestanden openen"
@@ -393,12 +440,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Spelen"
 
@@ -421,7 +488,7 @@ msgid "Preferences"
 msgstr "Voorkeuren"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Voorkeuren"
@@ -441,7 +508,7 @@ msgid "Properties of {}"
 msgstr "Instellingen van {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Haal gamelijst opnieuw op"
@@ -449,6 +516,11 @@ msgstr "Haal gamelijst opnieuw op"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -460,6 +532,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -477,7 +559,7 @@ msgid "Save"
 msgstr "Opslaan"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -501,7 +583,7 @@ msgstr "Toon games voor Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -512,7 +594,7 @@ msgid "Show hidden games: "
 msgstr "Toon verborgen games: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Laat alleen geïnstalleerde games zien"
@@ -535,6 +617,11 @@ msgstr "Spaans"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Blijf ingelogd:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -606,15 +693,19 @@ msgstr "Downloadfout"
 msgid "Uninstall"
 msgstr "Verwijderen"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Verwijderen…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Update"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Updaten…"
 
@@ -680,7 +771,7 @@ msgstr ""
 msgid "Wine executable:"
 msgstr "Het uitpakken met wine is mislukt."
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Het uitpakken met wine is mislukt."
 
@@ -694,7 +785,7 @@ msgstr ""
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Het uitpakken met wine is mislukt."

--- a/data/po/nn_NO.po
+++ b/data/po/nn_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2021-10-04 11:33+0200\n"
 "Last-Translator: Jan Kjetil Myklebust\n"
 "Language-Team: \n"
@@ -29,10 +29,15 @@ msgid "About"
 msgstr "Om"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Om"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -50,7 +55,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Er du sikker på at du vil avbryte nedlastinga av {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Er du sikker på at du vil logge ut av GOG?"
 
@@ -77,7 +82,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -139,22 +144,42 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "Dansk"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Last ned"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Vis berre installerte spel"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Nedlastingsfeil"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Lastar ned…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -182,7 +207,7 @@ msgid ""
 "system."
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Klarte ikkje å installere {}"
 
@@ -194,7 +219,12 @@ msgstr "Klarte ikkje å hente bibliotek"
 msgid "Failed to start {}:"
 msgstr "Klarte ikkje å starte {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -249,7 +279,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "I kø…"
 
@@ -261,11 +291,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Installer"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Installert"
@@ -277,12 +307,12 @@ msgid "Installation path: "
 msgstr "Installasjonssti: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Installert"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Installerar…"
 
@@ -318,7 +348,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Språk: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -331,10 +361,22 @@ msgid "Login"
 msgstr "Inlogging"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Logg ut"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -377,6 +419,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Opne filer"
@@ -386,12 +433,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Spel"
 
@@ -414,7 +481,7 @@ msgid "Preferences"
 msgstr "Brukarval"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Brukarval"
@@ -434,7 +501,7 @@ msgid "Properties of {}"
 msgstr "Eigenskapar for {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Oppdater spelelista"
@@ -442,6 +509,11 @@ msgstr "Oppdater spelelista"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -453,6 +525,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -470,7 +552,7 @@ msgid "Save"
 msgstr "Lagre"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -494,7 +576,7 @@ msgstr "Vis spel for Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -505,7 +587,7 @@ msgid "Show hidden games: "
 msgstr "Vis spel for Windows: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Vis berre installerte spel"
@@ -528,6 +610,11 @@ msgstr "Spansk"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Bli verande pålogga:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -599,15 +686,19 @@ msgstr "Nedlastingsfeil"
 msgid "Uninstall"
 msgstr "Avinstaller"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Avinstallerar…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Oppdater"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Oppdaterar…"
 
@@ -670,7 +761,7 @@ msgstr "Om snarvegar blir oppretta for nyinstallerte spel eller ikkje"
 msgid "Wine executable:"
 msgstr "Wine utpakking feila."
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Wine utpakking feila."
 
@@ -682,7 +773,7 @@ msgstr "Fann ikkje Wine. Kan ikkje skru på vising av Windows-spel."
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Wine utpakking feila."

--- a/data/po/pl.po
+++ b/data/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2025-02-27 17:02+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/minigalaxy/"
@@ -31,10 +31,15 @@ msgid "About"
 msgstr "O programie"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "O programie"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -52,7 +57,7 @@ msgstr "Zastosuj"
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Czy na pewno chcesz anulować pobieranie {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Czy na pewno chcesz wylogować się z GOG?"
 
@@ -79,7 +84,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -141,22 +146,42 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "Duński"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Pobierz"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Pokaż tylko zainstalowane gry"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Błąd pobierania"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Pobieranie…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -184,7 +209,7 @@ msgid ""
 "system."
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Instalacja {} nie powiodła się"
 
@@ -196,7 +221,12 @@ msgstr "Nie można pobrać biblioteki"
 msgid "Failed to start {}:"
 msgstr "Nie można uruchomić {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -253,7 +283,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Węgierski"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "W kolejce…"
 
@@ -265,11 +295,11 @@ msgstr "Informacje"
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Zainstaluj"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Zainstalowane"
@@ -281,12 +311,12 @@ msgid "Installation path: "
 msgstr "Ścieżka instalacji: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Zainstalowane"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Instalowanie…"
 
@@ -322,7 +352,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Język: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -335,10 +365,22 @@ msgid "Login"
 msgstr "Zaloguj się"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Wyloguj"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -383,6 +425,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Otwórz pliki"
@@ -392,12 +439,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Graj"
 
@@ -420,7 +487,7 @@ msgid "Preferences"
 msgstr "Ustawienia"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Ustawienia"
@@ -440,7 +507,7 @@ msgid "Properties of {}"
 msgstr "Właściwości {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Odśwież listę gier"
@@ -448,6 +515,11 @@ msgstr "Odśwież listę gier"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -459,6 +531,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -476,7 +558,7 @@ msgid "Save"
 msgstr "Zapis"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -500,7 +582,7 @@ msgstr "Wyświetl gry dla Systemu Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -511,7 +593,7 @@ msgid "Show hidden games: "
 msgstr "Pokaż ukryte gry: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Pokaż tylko zainstalowane gry"
@@ -533,6 +615,11 @@ msgstr "Hiszpański (Hiszpania)"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Pozostań zalogowany:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -604,15 +691,19 @@ msgstr "Błąd pobierania"
 msgid "Uninstall"
 msgstr "Odinstaluj"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Odinstalowywanie…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Aktualizuj"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Aktualizowanie..."
 
@@ -677,7 +768,7 @@ msgstr "Czy skróty mają być tworzone dla nowo zainstalowanych gier, czy nie"
 msgid "Wine executable:"
 msgstr "Plik wykonywalny Wine:"
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Ekstrakcja Wine nie powiodła się."
 
@@ -691,7 +782,7 @@ msgstr ""
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Ekstrakcja Wine nie powiodła się."

--- a/data/po/pt_BR.po
+++ b/data/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2020-11-17 03:06-0300\n"
 "Last-Translator: Esdras Tarsis <esdrastarsis@gmail.com>\n"
 "Language-Team: \n"
@@ -29,10 +29,15 @@ msgid "About"
 msgstr "Sobre"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Sobre"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -50,7 +55,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Tem certeza de que deseja cancelar o download do game {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr ""
 
@@ -78,7 +83,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -141,22 +146,42 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Baixar"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Mostrar apenas jogos instalados"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Erro ao baixar"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Baixando…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -184,7 +209,7 @@ msgid ""
 "system."
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Falha ao instalar {}"
 
@@ -196,7 +221,12 @@ msgstr "Falha ao recuperar a biblioteca"
 msgid "Failed to start {}:"
 msgstr "Falha ao iniciar {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -250,7 +280,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "Na fila…"
 
@@ -262,11 +292,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Instalar"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Instalados"
@@ -278,12 +308,12 @@ msgid "Installation path: "
 msgstr "Caminho de instalação: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Instalados"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Instalando…"
 
@@ -319,7 +349,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -332,10 +362,22 @@ msgid "Login"
 msgstr "Login"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Logout"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
@@ -379,6 +421,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Abrir arquivos"
@@ -388,12 +435,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Jogar"
 
@@ -416,7 +483,7 @@ msgid "Preferences"
 msgstr "Preferências"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Preferências"
@@ -436,13 +503,18 @@ msgid "Properties of {}"
 msgstr ""
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Recarregar lista de jogos"
 
 #: data/ui/properties.ui:48
 msgid "Regedit"
+msgstr ""
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
 msgstr ""
 
 #: data/ui/categoryfilters.ui:44
@@ -455,6 +527,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -472,7 +554,7 @@ msgid "Save"
 msgstr "Salvar"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -497,7 +579,7 @@ msgstr "Mostrar jogos para Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -509,7 +591,7 @@ msgid "Show hidden games: "
 msgstr "Mostrar jogos para Windows: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Mostrar apenas jogos instalados"
@@ -532,6 +614,11 @@ msgstr "Espanhol"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Permanecer conectado:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 #, fuzzy
@@ -607,16 +694,20 @@ msgstr "Erro ao baixar"
 msgid "Uninstall"
 msgstr "Desinstalar"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Desinstalando…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 #, fuzzy
 msgid "Update"
 msgstr "Atualizar"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Atualizando…"
 
@@ -680,7 +771,7 @@ msgstr ""
 msgid "Wine executable:"
 msgstr ""
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr ""
 
@@ -692,7 +783,7 @@ msgstr ""
 msgid "Winecfg"
 msgstr ""
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 msgid "Wineprefix creation failed."
 msgstr ""
 

--- a/data/po/pt_PT.po
+++ b/data/po/pt_PT.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2024-08-28 12:44+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -23,10 +23,15 @@ msgid "About"
 msgstr "Sobre"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Sobre"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -44,7 +49,7 @@ msgstr "Aplicar"
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Pretende cancelar o descarregamento {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Pretende desligar-se do GOG?"
 
@@ -71,7 +76,7 @@ msgid "Category Filters"
 msgstr "Filtros de Categoria"
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr "Filtros de Categoria"
@@ -130,21 +135,41 @@ msgstr "DLC (Conteúdo Descarregável)"
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Descarregar"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 msgid "Download and install the game"
 msgstr "Descarregar e instalar o jogo"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Erro ao descarregar"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "A descarregar…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -172,7 +197,7 @@ msgid ""
 "system."
 msgstr "Falha ao alterar o idioma do programa."
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Falha ao instalar {}"
 
@@ -184,7 +209,12 @@ msgstr "Falha ao descarregar biblioteca"
 msgid "Failed to start {}:"
 msgstr "Falha ao iniciar {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr "Terminou o descarregamento e instalação de {}"
 
@@ -238,7 +268,7 @@ msgstr "Oculta o jogo da lista"
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "Na fila…"
 
@@ -250,11 +280,11 @@ msgstr "Informação"
 msgid "Information about {}"
 msgstr "Informação sobre {}"
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Instalar"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 msgid "Install the game"
 msgstr "Instalar o jogo"
 
@@ -265,12 +295,12 @@ msgid "Installation path: "
 msgstr "Caminho da instalação:"
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Instalado"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "A instalar…"
 
@@ -306,7 +336,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Idioma:"
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr "Abrir o jogo"
 
@@ -319,10 +349,22 @@ msgid "Login"
 msgstr "Entrar"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Sair"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
@@ -366,6 +408,11 @@ msgstr "Abrir Winecfg para este jogo"
 msgid "Open Winetricks for this game"
 msgstr "Abrir Winetricks para este jogo"
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Abrir ficheiros"
@@ -375,12 +422,32 @@ msgid "Open game install folder"
 msgstr "Abrir pasta de instalação do jogo"
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr "Menu de Opções"
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Jogar"
 
@@ -403,7 +470,7 @@ msgid "Preferences"
 msgstr "Preferências"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Preferências"
@@ -423,13 +490,18 @@ msgid "Properties of {}"
 msgstr "Propriedades de {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Atualizar lista de jogos"
 
 #: data/ui/properties.ui:48
 msgid "Regedit"
+msgstr ""
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
 msgstr ""
 
 #: data/ui/categoryfilters.ui:44
@@ -443,6 +515,16 @@ msgstr "Reiniciar o executável Wine deste jogo"
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
 msgstr "Reiniciar o executável Wine"
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
+msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
 msgid "Romanian"
@@ -459,7 +541,7 @@ msgid "Save"
 msgstr "Guardar"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 msgctxt "search"
 msgid "Search games list"
 msgstr "Procurar na lista de jogos"
@@ -482,7 +564,7 @@ msgstr "Mostrar jogos Windows:"
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr "Mostrar contador de FPS (frames por segundo) no jogo"
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr "Mostrar menu de opções do jogo"
 
@@ -493,7 +575,7 @@ msgid "Show hidden games: "
 msgstr "Mostrar jogos ocultos: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Mostrar apenas jogos instalados"
@@ -515,6 +597,11 @@ msgstr "Espanhol (Espanha)"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Manter-se ligado:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -584,15 +671,19 @@ msgstr ""
 msgid "Uninstall"
 msgstr "Desinstalar"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "A desinstalar…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Atualização"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "A atualizar…"
 
@@ -654,7 +745,7 @@ msgstr "Se serão criados atalos para jogos recentemente instalados ou não"
 msgid "Wine executable:"
 msgstr "Executável Wine:"
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Extração de Wine falhou."
 
@@ -666,7 +757,7 @@ msgstr "Wine não foi encontrado. Não é possível mostrar jogos Windows."
 msgid "Winecfg"
 msgstr ""
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 msgid "Wineprefix creation failed."
 msgstr "Criação de Wineprefix falhou."
 

--- a/data/po/ro.po
+++ b/data/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2021-09-29 19:02+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -30,10 +30,15 @@ msgid "About"
 msgstr "Despre"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Despre"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Ești sigur că vrei să oprești descărcarea jocului {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Ești sigur că vrei să te deconectezi din GOG?"
 
@@ -78,7 +83,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -140,22 +145,42 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "Danez"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Descarcă"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Arată doar jocurile instalate"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Eroare de descărcare"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Se descarcă…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -185,7 +210,7 @@ msgstr ""
 "Nu s-a putut schimba limba programului. Asigură-te că locale-ul este "
 "generatîn sistemul tău"
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Nu s-a putut instala {}"
 
@@ -197,7 +222,12 @@ msgstr "Nu s-a putut descărca libraria"
 msgid "Failed to start {}:"
 msgstr "Nu s-a putut porni {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -252,7 +282,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Maghiară"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "În coadă…"
 
@@ -264,11 +294,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Instalează"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Instalat"
@@ -280,12 +310,12 @@ msgid "Installation path: "
 msgstr "Locație instalare: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Instalat"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Se instalează…"
 
@@ -321,7 +351,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Limbă: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -334,10 +364,22 @@ msgid "Login"
 msgstr "Autentificare"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Deconectare"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -381,6 +423,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Deschide fișiere"
@@ -390,12 +437,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Joacă"
 
@@ -418,7 +485,7 @@ msgid "Preferences"
 msgstr "Preferințe"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Preferințe"
@@ -438,7 +505,7 @@ msgid "Properties of {}"
 msgstr "Proprietățile {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Reîmprospătează listă jocuri"
@@ -446,6 +513,11 @@ msgstr "Reîmprospătează listă jocuri"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -457,6 +529,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -474,7 +556,7 @@ msgid "Save"
 msgstr "Salvează"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -498,7 +580,7 @@ msgstr "Arată jocuri Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -509,7 +591,7 @@ msgid "Show hidden games: "
 msgstr "Arată jocuri ascunse: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Arată doar jocurile instalate"
@@ -532,6 +614,11 @@ msgstr "Spaniolă"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Rămâi conectat:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -603,15 +690,19 @@ msgstr "Eroare de descărcare"
 msgid "Uninstall"
 msgstr "Dezinstalează"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Se dezinstalează…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Actualizează"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Se actualizează…"
 
@@ -675,7 +766,7 @@ msgstr "Dacă scurtăturile sunt create pentru jocuri nou-instalate sau nu"
 msgid "Wine executable:"
 msgstr "Extragerea Wine a eșuat."
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Extragerea Wine a eșuat."
 
@@ -687,7 +778,7 @@ msgstr "Wine nu a fost găsit. Arătarea jocurilor Windows nu poate fi pornită.
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Extragerea Wine a eșuat."

--- a/data/po/ru_RU.po
+++ b/data/po/ru_RU.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2025-03-04 14:02+0000\n"
 "Last-Translator: AnanaSeek4Jam <furryananasik@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/minigalaxy/"
@@ -32,10 +32,15 @@ msgid "About"
 msgstr "О Minigalaxy"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "О Minigalaxy"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -53,7 +58,7 @@ msgstr "Применить"
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Вы уверены, что хотите отменить загрузку {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Вы уверены, что хотите выйти из GOG?"
 
@@ -81,7 +86,7 @@ msgid "Category Filters"
 msgstr "Фильтры категорий"
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 #, fuzzy
 msgctxt "category_filter"
 msgid "Category filters"
@@ -142,22 +147,42 @@ msgstr "Дополнения"
 msgid "Danish"
 msgstr "Датский"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Загрузить"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 msgid "Download and install the game"
 msgstr "Скачать и установить игру"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Ошибка загрузки"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 #, fuzzy
 msgid "Downloading…"
 msgstr "Скачивание…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -192,7 +217,7 @@ msgstr ""
 "Не удалось изменить язык программы. Убедитесь, что на вашей системе "
 "сгенерирована локаль."
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Не удалось установить {}"
 
@@ -204,7 +229,12 @@ msgstr "Не удалось получить библиотеку"
 msgid "Failed to start {}:"
 msgstr "Не удалось запустить {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr "Скачивание и загрузка завершена {}"
 
@@ -259,7 +289,7 @@ msgstr "Скрывает игру в списке"
 msgid "Hungarian"
 msgstr "Венгерский"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "В очереди…"
 
@@ -271,11 +301,11 @@ msgstr "Информация"
 msgid "Information about {}"
 msgstr "Информация о {}"
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Установить"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 msgid "Install the game"
 msgstr "Установить игру"
 
@@ -286,12 +316,12 @@ msgid "Installation path: "
 msgstr "Путь установки: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Установленные"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Установка…"
 
@@ -327,7 +357,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Язык: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr "Запустить игру"
 
@@ -340,10 +370,22 @@ msgid "Login"
 msgstr "Войти"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Выйти"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
@@ -385,6 +427,11 @@ msgstr "Открыть Winecfg для этой игры"
 msgid "Open Winetricks for this game"
 msgstr "Открыть Winetricks для этой игры"
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Открыть файлы"
@@ -394,12 +441,32 @@ msgid "Open game install folder"
 msgstr "Открыть папку установки игры"
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr "Меню настроек"
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Играть"
 
@@ -422,7 +489,7 @@ msgid "Preferences"
 msgstr "Настройки"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Настройки"
@@ -442,7 +509,7 @@ msgid "Properties of {}"
 msgstr "Свойства {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Обновить список игр"
@@ -450,6 +517,11 @@ msgstr "Обновить список игр"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -463,6 +535,16 @@ msgstr "Сбросить запускаемый файл wine для этой и
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
 msgstr "Сбросить запускаемый файл wine"
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
+msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
 msgid "Romanian"
@@ -479,7 +561,7 @@ msgid "Save"
 msgstr "Сохранить"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -503,7 +585,7 @@ msgstr "Показывать игры для Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr "Показывать FPS (кол-во кадров в секунду) в игре"
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 #, fuzzy
 msgid "Show game options menu"
 msgstr "Показывать меню настроек игры"
@@ -515,7 +597,7 @@ msgid "Show hidden games: "
 msgstr "Показывать скрытые игры: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Показывать только установленные игры"
@@ -537,6 +619,11 @@ msgstr "Испанский (Испания)"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Не выходить из системы:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -607,15 +694,19 @@ msgstr "Ошибка."
 msgid "Uninstall"
 msgstr "Удалить"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Удаление…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Обновить"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Обновление…"
 
@@ -678,7 +769,7 @@ msgstr "Создавать ярлыки для недавно установле
 msgid "Wine executable:"
 msgstr "Запускаемый файл wine:"
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Не удалось извлечь игру с помощью Wine."
 
@@ -690,7 +781,7 @@ msgstr "Wine не найден. Отображение игр для Windows н�
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 msgid "Wineprefix creation failed."
 msgstr "Не удалось создать Wineprefix."
 

--- a/data/po/sv_SE.po
+++ b/data/po/sv_SE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2021-10-01 12:46+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -29,10 +29,15 @@ msgid "About"
 msgstr "Om"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Om"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -50,7 +55,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Är du säker på att du vill avbryta nedladdningen av {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Är du säker på att du vill logga ut från GOG?"
 
@@ -77,7 +82,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -139,22 +144,42 @@ msgstr "Nedladdningsbart innehåll"
 msgid "Danish"
 msgstr "Danska"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Ladda ner"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Visa endast installerade spel"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Nedladdningsfel"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Laddar ner…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -182,7 +207,7 @@ msgid ""
 "system."
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Misslyckades att installera {}"
 
@@ -194,7 +219,12 @@ msgstr "Misslyckades att hämta bibliotek"
 msgid "Failed to start {}:"
 msgstr "Misslyckades att starta {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -249,7 +279,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Ungerska"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "I kö…"
 
@@ -261,11 +291,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Installera"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Installerade"
@@ -277,12 +307,12 @@ msgid "Installation path: "
 msgstr "Installationssökväg: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Installerade"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Installerar…"
 
@@ -318,7 +348,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Språk: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -331,10 +361,22 @@ msgid "Login"
 msgstr "Inloggning"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Logga ut"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -380,6 +422,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Öppna filer"
@@ -389,12 +436,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Spela"
 
@@ -417,7 +484,7 @@ msgid "Preferences"
 msgstr "Inställningar"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Inställningar"
@@ -437,7 +504,7 @@ msgid "Properties of {}"
 msgstr "Egenskaper för {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Uppdatera spellistan"
@@ -445,6 +512,11 @@ msgstr "Uppdatera spellistan"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -456,6 +528,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -473,7 +555,7 @@ msgid "Save"
 msgstr "Spara"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -497,7 +579,7 @@ msgstr "Visa Windowsspel: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -508,7 +590,7 @@ msgid "Show hidden games: "
 msgstr "Visa gömda spel: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Visa endast installerade spel"
@@ -531,6 +613,11 @@ msgstr "Spanska"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Håll mig inloggad:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -602,15 +689,19 @@ msgstr "Nedladdningsfel"
 msgid "Uninstall"
 msgstr "Avinstallera"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Avinstallerar…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Uppdatera"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Uppdaterar…"
 
@@ -674,7 +765,7 @@ msgstr "Om genvägar ska skapas för nyinstallerade spel eller inte"
 msgid "Wine executable:"
 msgstr "Extrahering av Wine misslyckades."
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Extrahering av Wine misslyckades."
 
@@ -686,7 +777,7 @@ msgstr "Wine kunde inte hittas. Visning av Windowsspel kan inte slås på."
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Extrahering av Wine misslyckades."

--- a/data/po/tr.po
+++ b/data/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2021-09-30 11:22+0300\n"
 "Last-Translator: Hüseyin Fahri Uzun <mail@fahriuzun.com>\n"
 "Language-Team: \n"
@@ -29,10 +29,15 @@ msgid "About"
 msgstr "Hakkında"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Hakkında"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -50,7 +55,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "{} indirmesini iptal etmek istediğine emin misin?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "GOG üzerinden çıkış yapmak istediğinize emin misiniz?"
 
@@ -77,7 +82,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -139,22 +144,42 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "Danimarka Dili"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Indir"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "Sadece yüklü oyunları göster"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "İndirme hatası"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Indirliyor…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -182,7 +207,7 @@ msgid ""
 "system."
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "{} yüklenemedi:"
 
@@ -194,7 +219,12 @@ msgstr "Kütüphane alınamadı"
 msgid "Failed to start {}:"
 msgstr "{} başlatılamadı:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -249,7 +279,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Macarca"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "Sırada…"
 
@@ -261,11 +291,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Yükle"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "Yüklendi"
@@ -277,12 +307,12 @@ msgid "Installation path: "
 msgstr "Yükleme klasör yolu: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Yüklendi"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Yükleniyor…"
 
@@ -318,7 +348,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Dil:  "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -331,10 +361,22 @@ msgid "Login"
 msgstr "Giriş Yap"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Çıkış Yap"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -377,6 +419,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Dosyaları Aç"
@@ -386,12 +433,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Oyna"
 
@@ -414,7 +481,7 @@ msgid "Preferences"
 msgstr "Ayarlar"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Ayarlar"
@@ -434,7 +501,7 @@ msgid "Properties of {}"
 msgstr "{} Seçenekleri"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Oyun listesini güncelle"
@@ -442,6 +509,11 @@ msgstr "Oyun listesini güncelle"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -453,6 +525,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -470,7 +552,7 @@ msgid "Save"
 msgstr "Kaydet"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -494,7 +576,7 @@ msgstr "Windows oyunlarını göster: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -505,7 +587,7 @@ msgid "Show hidden games: "
 msgstr "Gizli oyunları göster: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Sadece yüklü oyunları göster"
@@ -528,6 +610,11 @@ msgstr "İspanyolca"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Çevrimci tut:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -597,15 +684,19 @@ msgstr "İndirme hatası"
 msgid "Uninstall"
 msgstr "Kaldır"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Siliniyor…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Güncelle"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Güncelleniyor…"
 
@@ -667,7 +758,7 @@ msgstr "Yeni yüklenen oyunların kısa yol oluşturup oluşturmayacağı"
 msgid "Wine executable:"
 msgstr "Wine dışarı aktarım başarısız."
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Wine dışarı aktarım başarısız."
 
@@ -679,7 +770,7 @@ msgstr "Wine bulunamadı. Windows oyunlarının gösterimi etkinleştirilemez."
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Wine dışarı aktarım başarısız."

--- a/data/po/uk.po
+++ b/data/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2025-02-27 17:02+0000\n"
 "Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/minigalaxy/"
@@ -31,10 +31,15 @@ msgid "About"
 msgstr "Про MiniGalaxy"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "Про MiniGalaxy"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -52,7 +57,7 @@ msgstr "Застосувати"
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "Ви впевнені, що хочете скасувати завантаження {}?"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "Ви дійсно хочете вийти з GOG?"
 
@@ -79,7 +84,7 @@ msgid "Category Filters"
 msgstr "Фільтри категорій"
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr "Фільтри категорій"
@@ -138,21 +143,41 @@ msgstr "Доповнення"
 msgid "Danish"
 msgstr "Датська"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "Завантажити"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 msgid "Download and install the game"
 msgstr "Завантажити та встановити гру"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "Помилка при завантаженні"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "Завантаження…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -186,7 +211,7 @@ msgstr ""
 "Не вдалося змінити мову застосунку. Переконайтеся, що у вашій системі є ця "
 "мова."
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "Не вдалося встановити {}"
 
@@ -198,7 +223,12 @@ msgstr "Не вдалося отримати бібліотеку"
 msgid "Failed to start {}:"
 msgstr "Не вдалося запустити {}:"
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr "Завершено завантаження та встановлення {}"
 
@@ -252,7 +282,7 @@ msgstr "Приховує гру зі списку ігор"
 msgid "Hungarian"
 msgstr "Угорська"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "В черзі…"
 
@@ -264,11 +294,11 @@ msgstr "Інформація"
 msgid "Information about {}"
 msgstr "Інформація про {}"
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "Встановити"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 msgid "Install the game"
 msgstr "Встановити гру"
 
@@ -279,12 +309,12 @@ msgid "Installation path: "
 msgstr "Шлях установлення: "
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "Встановлено"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "Встановлення…"
 
@@ -320,7 +350,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "Мова: "
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr "Запустити гру"
 
@@ -333,10 +363,22 @@ msgid "Login"
 msgstr "Увійти"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "Вийти"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
@@ -378,6 +420,11 @@ msgstr "Відкрити Winecfg для цієї гри"
 msgid "Open Winetricks for this game"
 msgstr "Відкрити Winetricks для цієї гри"
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "Відкрити файли"
@@ -387,12 +434,32 @@ msgid "Open game install folder"
 msgstr "Відкрити теку встановлення гри"
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr "Меню налаштувань"
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "Грати"
 
@@ -415,7 +482,7 @@ msgid "Preferences"
 msgstr "Налаштування"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "Налаштування"
@@ -435,7 +502,7 @@ msgid "Properties of {}"
 msgstr "Властивості {}"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "Оновити список ігор"
@@ -443,6 +510,11 @@ msgstr "Оновити список ігор"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "Regedit"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -455,6 +527,16 @@ msgstr "Скинути виконуваний файл Wine для цієї гр
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
 msgstr "Скинути виконуваний файл Wine"
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
+msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
 msgid "Romanian"
@@ -471,7 +553,7 @@ msgid "Save"
 msgstr "Зберегти"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 msgctxt "search"
 msgid "Search games list"
 msgstr "Шукати в списку ігор"
@@ -494,7 +576,7 @@ msgstr "Показати ігри для Windows: "
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr "Показувати лічильник к / с (кадрів в секунду), накладений у грі"
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr "Показати меню налаштувань гри"
 
@@ -505,7 +587,7 @@ msgid "Show hidden games: "
 msgstr "Показати приховані ігри: "
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "Показати лише встановлені ігри"
@@ -527,6 +609,11 @@ msgstr "Іспанська (Іспанія)"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "Залишатися в системі:"
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -596,15 +683,19 @@ msgstr "Невиправлена помилка."
 msgid "Uninstall"
 msgstr "Видалити"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "Видалення…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "Оновити"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "Оновлення…"
 
@@ -668,7 +759,7 @@ msgstr ""
 msgid "Wine executable:"
 msgstr "Виконуваний файл Wine:"
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Помилка вилучення Wine."
 
@@ -680,7 +771,7 @@ msgstr "Wine не знайдено. Показ ігор Windows не може б
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 msgid "Wineprefix creation failed."
 msgstr "Не вдалося створити Wineprefix."
 

--- a/data/po/zh_CN.po
+++ b/data/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2021-11-06 23:37+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -29,10 +29,15 @@ msgid "About"
 msgstr "关于"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "关于"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -50,7 +55,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "确定要取消下载 {} 吗？"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "确定要登出GOG吗？"
 
@@ -77,7 +82,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -139,22 +144,42 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "丹麦语"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "下载"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "只显示已安装的游戏"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "下载错误"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "正在下载…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -182,7 +207,7 @@ msgid ""
 "system."
 msgstr "更改软件语言失败。请确保已生成locale。"
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "安装 {} 失败"
 
@@ -194,7 +219,12 @@ msgstr "获取游戏库失败"
 msgid "Failed to start {}:"
 msgstr "启动 {} 失败："
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -249,7 +279,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "队列中…"
 
@@ -261,11 +291,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "安装"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "仅显示已安装的游戏"
@@ -277,12 +307,12 @@ msgid "Installation path: "
 msgstr "安装路径："
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "仅显示已安装的游戏"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "正在安装…"
 
@@ -316,7 +346,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "语言"
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -329,10 +359,22 @@ msgid "Login"
 msgstr "登录"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "退出登录"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -375,6 +417,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "打开文件"
@@ -384,12 +431,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "开始游戏"
 
@@ -412,7 +479,7 @@ msgid "Preferences"
 msgstr "偏好设置"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "偏好设置"
@@ -432,7 +499,7 @@ msgid "Properties of {}"
 msgstr "{} 的属性"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "刷新游戏列表"
@@ -440,6 +507,11 @@ msgstr "刷新游戏列表"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "注册表"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -451,6 +523,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -468,7 +550,7 @@ msgid "Save"
 msgstr "保存"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -492,7 +574,7 @@ msgstr "显示 Windows 游戏："
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -503,7 +585,7 @@ msgid "Show hidden games: "
 msgstr "显示隐藏的游戏："
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "只显示已安装的游戏"
@@ -526,6 +608,11 @@ msgstr "西班牙语"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "保持登录："
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -597,15 +684,19 @@ msgstr "下载错误"
 msgid "Uninstall"
 msgstr "卸载"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "正在卸载…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "更新"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "正在更新…"
 
@@ -667,7 +758,7 @@ msgstr "游戏安装完成后是否创建快捷方式"
 msgid "Wine executable:"
 msgstr "Wine 提取失败"
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Wine 提取失败"
 
@@ -679,7 +770,7 @@ msgstr "未找到 Wine。无法启用显示 Windows 游戏"
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Wine 提取失败"

--- a/data/po/zh_TW.po
+++ b/data/po/zh_TW.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-25 11:05+0100\n"
+"POT-Creation-Date: 2025-03-04 20:22+0100\n"
 "PO-Revision-Date: 2023-03-19 20:48+0800\n"
 "Last-Translator: Jeff Huang <s8321414@gmail.com>\n"
 "Language-Team: Chinese <zh-l10n@linux.org.tw>\n"
@@ -28,10 +28,15 @@ msgid "About"
 msgstr "關於"
 
 #. Opens about dialog
-#: data/ui/application.ui:58
+#: data/ui/application.ui:64
 msgctxt "about"
 msgid "About"
 msgstr "關於"
+
+#: data/ui/download_list.ui:23
+msgctxt "download_group"
+msgid "Active Downloads:"
+msgstr ""
 
 #: data/ui/properties.ui:269 data/ui/properties.ui:281
 msgid "Added at the end of the command used to launch the game"
@@ -49,7 +54,7 @@ msgstr ""
 msgid "Are you sure you want to cancel downloading {}?"
 msgstr "您確定您想要取消下載 {} 嗎？"
 
-#: minigalaxy/ui/window.py:117
+#: minigalaxy/ui/window.py:121
 msgid "Are you sure you want to log out of GOG?"
 msgstr "您確定要登出 GOG？"
 
@@ -76,7 +81,7 @@ msgid "Category Filters"
 msgstr ""
 
 #. Tooltip for category filter button
-#: data/ui/application.ui:149
+#: data/ui/application.ui:144
 msgctxt "category_filter"
 msgid "Category filters"
 msgstr ""
@@ -138,22 +143,42 @@ msgstr "DLC"
 msgid "Danish"
 msgstr "丹麥文"
 
-#: minigalaxy/ui/library_entry.py:462
+#. Tooltip of icon button to delete a downloaded file
+#: minigalaxy/ui/download_list.py:250
+msgid "Delete file"
+msgstr ""
+
+#: data/ui/download_list.ui:116
+msgctxt "download_group"
+msgid "Done:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:476
 msgid "Download"
 msgstr "下載"
 
-#: minigalaxy/ui/library_entry.py:463
+#: minigalaxy/ui/library_entry.py:477
 #, fuzzy
 msgid "Download and install the game"
 msgstr "僅顯示已安裝的遊戲"
 
-#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:247
+#: minigalaxy/ui/library_entry.py:150 minigalaxy/ui/library_entry.py:255
 msgid "Download error"
 msgstr "下載錯誤"
 
-#: minigalaxy/ui/library_entry.py:504
+#: minigalaxy/ui/library_entry.py:518
 msgid "Downloading…"
 msgstr "正在下載…"
+
+#: data/ui/download_list.ui:115
+msgctxt "download_group"
+msgid "Downloads that completed, failed or were stopped."
+msgstr ""
+
+#: data/ui/download_list.ui:53
+msgctxt "download_group"
+msgid "Downloads waiting for a free worker slot."
+msgstr ""
 
 #: minigalaxy/constants.py:7 minigalaxy/constants.py:55
 msgid "Dutch"
@@ -181,7 +206,7 @@ msgid ""
 "system."
 msgstr "變更程式語言失敗。請確定您的系統上以產生對應的語系檔。"
 
-#: minigalaxy/ui/library_entry.py:343
+#: minigalaxy/ui/library_entry.py:352
 msgid "Failed to install {}"
 msgstr "安裝 {} 失敗"
 
@@ -193,7 +218,12 @@ msgstr "擷取收藏庫失敗"
 msgid "Failed to start {}:"
 msgstr "啟動 {} 失敗："
 
-#: minigalaxy/ui/library_entry.py:295
+#: data/ui/download_list.ui:22
+msgctxt "download_group"
+msgid "Files being actively downloaded."
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:303
 msgid "Finished downloading and installing {}"
 msgstr ""
 
@@ -248,7 +278,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr "匈牙利文"
 
-#: minigalaxy/ui/library_entry.py:495
+#: minigalaxy/ui/library_entry.py:509
 msgid "In queue…"
 msgstr "在佇列中…"
 
@@ -260,11 +290,11 @@ msgstr ""
 msgid "Information about {}"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:480
+#: minigalaxy/ui/library_entry.py:494
 msgid "Install"
 msgstr "安裝"
 
-#: minigalaxy/ui/library_entry.py:481
+#: minigalaxy/ui/library_entry.py:495
 #, fuzzy
 msgid "Install the game"
 msgstr "已安裝"
@@ -276,12 +306,12 @@ msgid "Installation path: "
 msgstr "安裝路徑："
 
 #. Used next to a checkbox which switches between showing all games and only installed ones
-#: data/ui/application.ui:116
+#: data/ui/application.ui:175
 msgctxt "installed"
 msgid "Installed"
 msgstr "已安裝"
 
-#: minigalaxy/ui/library_entry.py:513
+#: minigalaxy/ui/library_entry.py:527
 msgid "Installing…"
 msgstr "正在安裝…"
 
@@ -317,7 +347,7 @@ msgctxt "language"
 msgid "Language: "
 msgstr "語言："
 
-#: minigalaxy/ui/library_entry.py:526
+#: minigalaxy/ui/library_entry.py:540
 msgid "Launch the game"
 msgstr ""
 
@@ -330,10 +360,22 @@ msgid "Login"
 msgstr "登入"
 
 #. Logs the users gog account out and returns to login page
-#: data/ui/application.ui:17
+#: data/ui/application.ui:23
 msgctxt "logout"
 msgid "Logout"
 msgstr "登出"
+
+#. Tooltip of the 'show downloads' button in the application main window
+#: data/ui/application.ui:201
+msgctxt "game_download_management"
+msgid "Manage downloads"
+msgstr ""
+
+#. Klick on button will open file explorer to manage downloaded installers
+#: data/ui/download_list.ui:173
+msgctxt "game_download_management"
+msgid "Manage installers"
+msgstr ""
 
 #: minigalaxy/ui/properties.py:92
 #, fuzzy
@@ -376,6 +418,11 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
+#: data/ui/download_list.ui:147
+msgctxt "game_download_management"
+msgid "Open file manager at location where installers are saved"
+msgstr ""
+
 #: data/ui/properties.ui:76
 msgid "Open files"
 msgstr "開啟檔案"
@@ -385,12 +432,32 @@ msgid "Open game install folder"
 msgstr ""
 
 #. Tooltip for header menu button
-#: data/ui/application.ui:130
+#: data/ui/application.ui:122
 msgctxt "menu"
 msgid "Options menu"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:525 minigalaxy/ui/library_entry.py:554
+#. Tooltip of icon button to pause a download
+#: minigalaxy/ui/download_list.py:241
+msgid "Pause"
+msgstr ""
+
+#: data/ui/download_list.ui:84
+msgctxt "download_group"
+msgid "Paused downlods will not automatically resume."
+msgstr ""
+
+#: data/ui/download_list.ui:85
+msgctxt "download_group"
+msgid "Paused:"
+msgstr ""
+
+#: data/ui/download_list.ui:54
+msgctxt "download_group"
+msgid "Pending:"
+msgstr ""
+
+#: minigalaxy/ui/library_entry.py:539 minigalaxy/ui/library_entry.py:568
 msgid "Play"
 msgstr "遊玩"
 
@@ -413,7 +480,7 @@ msgid "Preferences"
 msgstr "偏好設定"
 
 #. Opens preferences dialog
-#: data/ui/application.ui:32
+#: data/ui/application.ui:38
 msgctxt "preferences"
 msgid "Preferences"
 msgstr "偏好設定"
@@ -433,7 +500,7 @@ msgid "Properties of {}"
 msgstr "{} 的屬性"
 
 #. Tooltip for refresh button
-#: data/ui/application.ui:89
+#: data/ui/application.ui:105
 msgctxt "refresh"
 msgid "Refresh game list"
 msgstr "重新整理遊戲清單"
@@ -441,6 +508,11 @@ msgstr "重新整理遊戲清單"
 #: data/ui/properties.ui:48
 msgid "Regedit"
 msgstr "登錄檔編輯"
+
+#. Tooltip of icon button which removes a download from the ui list of downloads
+#: minigalaxy/ui/download_list.py:253
+msgid "Remove from list"
+msgstr ""
 
 #: data/ui/categoryfilters.ui:44
 msgid "Reset"
@@ -452,6 +524,16 @@ msgstr ""
 
 #: data/ui/properties.ui:291
 msgid "Reset wine executable"
+msgstr ""
+
+#. Tooltip of icon button for download (re)start
+#: minigalaxy/ui/download_list.py:238
+msgid "Resume"
+msgstr ""
+
+#. Tooltip of icon button to retry a failed or canceled download
+#: minigalaxy/ui/download_list.py:244
+msgid "Retry"
 msgstr ""
 
 #: minigalaxy/constants.py:23 minigalaxy/constants.py:74
@@ -469,7 +551,7 @@ msgid "Save"
 msgstr "儲存"
 
 #. Tooltip for search field
-#: data/ui/application.ui:172
+#: data/ui/application.ui:185
 #, fuzzy
 msgctxt "search"
 msgid "Search games list"
@@ -493,7 +575,7 @@ msgstr "顯示 Windows 遊戲："
 msgid "Show an FPS (frames per second) counter overlaid in the game"
 msgstr ""
 
-#: minigalaxy/ui/library_entry.py:470 minigalaxy/ui/library_entry.py:530
+#: minigalaxy/ui/library_entry.py:484 minigalaxy/ui/library_entry.py:544
 msgid "Show game options menu"
 msgstr ""
 
@@ -504,7 +586,7 @@ msgid "Show hidden games: "
 msgstr "顯示隱藏的遊戲："
 
 #. Tooltip for the switch which allows only showing installed games or all games
-#: data/ui/application.ui:105
+#: data/ui/application.ui:164
 msgctxt "tooltip_installed"
 msgid "Show only installed games"
 msgstr "僅顯示已安裝的遊戲"
@@ -527,6 +609,11 @@ msgstr "西班牙文"
 msgctxt "stay_logged_in"
 msgid "Stay logged in:"
 msgstr "保持登入："
+
+#. Tooltip of icon button to stop an active or queued download
+#: minigalaxy/ui/download_list.py:247
+msgid "Stop"
+msgstr ""
 
 #: data/ui/information.ui:76
 msgid "Store"
@@ -598,15 +685,19 @@ msgstr "下載錯誤"
 msgid "Uninstall"
 msgstr "解除安裝"
 
-#: minigalaxy/ui/library_entry.py:541
+#: minigalaxy/ui/library_entry.py:555
 msgid "Uninstalling…"
 msgstr "正在解除安裝…"
+
+#: minigalaxy/ui/download_list.py:87
+msgid "Unknown error"
+msgstr ""
 
 #: data/ui/gametilelist.ui:209 data/ui/gametile.ui:182
 msgid "Update"
 msgstr "更新"
 
-#: minigalaxy/ui/library_entry.py:563
+#: minigalaxy/ui/library_entry.py:577
 msgid "Updating…"
 msgstr "正在更新…"
 
@@ -668,7 +759,7 @@ msgstr "新安裝的遊戲是否應建立捷徑"
 msgid "Wine executable:"
 msgstr "Wine 解壓縮失敗。"
 
-#: minigalaxy/installer.py:205
+#: minigalaxy/installer.py:210
 msgid "Wine extraction failed."
 msgstr "Wine 解壓縮失敗。"
 
@@ -680,7 +771,7 @@ msgstr "找不到 Wine。無法啟用顯示 Windows 遊戲。"
 msgid "Winecfg"
 msgstr "Winecfg"
 
-#: minigalaxy/installer.py:173
+#: minigalaxy/installer.py:178
 #, fuzzy
 msgid "Wineprefix creation failed."
 msgstr "Wine 解壓縮失敗。"

--- a/data/ui/application.ui
+++ b/data/ui/application.ui
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface domain="minigalaxy">
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkPopover" id="download_list">
+    <property name="can-focus">False</property>
+    <child>
+      <placeholder/>
+    </child>
+  </object>
   <object class="GtkPopover" id="menu">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkModelButton" id="menu_logout">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
             <property name="text" translatable="yes" context="logout" comments="Logs the users gog account out and returns to login page">Logout</property>
             <property name="centered">True</property>
             <signal name="clicked" handler="on_menu_logout_clicked" swapped="no"/>
@@ -27,8 +33,8 @@
         <child>
           <object class="GtkModelButton" id="menu_preferences">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
             <property name="text" translatable="yes" context="preferences" comments="Opens preferences dialog">Preferences</property>
             <property name="centered">True</property>
             <signal name="clicked" handler="on_menu_preferences_clicked" swapped="no"/>
@@ -42,7 +48,7 @@
         <child>
           <object class="GtkSeparator">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -53,8 +59,8 @@
         <child>
           <object class="GtkModelButton" id="menu_about">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
             <property name="text" translatable="yes" context="about" comments="Opens about dialog">About</property>
             <property name="centered">True</property>
             <signal name="clicked" handler="on_menu_about_clicked" swapped="no"/>
@@ -69,40 +75,93 @@
     </child>
   </object>
   <template class="Window" parent="GtkApplicationWindow">
-    <property name="can_focus">False</property>
-    <property name="window_position">center</property>
-    <property name="default_width">1400</property>
-    <property name="default_height">800</property>
+    <property name="can-focus">False</property>
+    <property name="window-position">center</property>
+    <property name="default-width">1400</property>
+    <property name="default-height">800</property>
     <signal name="window-state-event" handler="on_window_state_event" swapped="no"/>
+    <child>
+      <object class="GtkScrolledWindow" id="window_library">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="shadow-type">in</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="HeaderBar">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="vexpand">False</property>
-        <property name="has_subtitle">False</property>
-        <property name="show_close_button">True</property>
+        <property name="has-subtitle">False</property>
+        <property name="show-close-button">True</property>
         <child>
           <object class="GtkButton" id="header_sync">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes" context="refresh" comments="Tooltip for refresh button">Refresh game list</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="tooltip-text" translatable="yes" context="refresh" comments="Tooltip for refresh button">Refresh game list</property>
             <property name="valign">center</property>
             <signal name="clicked" handler="on_header_sync_clicked" swapped="no"/>
             <child>
               <object class="GtkImage">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">view-refresh-symbolic</property>
+                <property name="can-focus">False</property>
+                <property name="icon-name">view-refresh-symbolic</property>
               </object>
             </child>
           </object>
         </child>
         <child>
+          <object class="GtkMenuButton" id="header_menu">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="tooltip-text" translatable="yes" context="menu" comments="Tooltip for header menu button">Options menu</property>
+            <property name="valign">center</property>
+            <property name="use-popover">False</property>
+            <property name="popover">menu</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="icon-name">open-menu-symbolic</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="pack-type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="category_filter_button">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="tooltip-text" translatable="yes" context="category_filter" comments="Tooltip for category filter button">Category filters</property>
+            <property name="valign">center</property>
+            <signal name="clicked" handler="on_menu_category_filter_clicked" swapped="no"/>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="icon-name">view-conceal-symbolic</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="pack-type">end</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkSwitch" id="header_installed">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="tooltip_text" translatable="yes" context="tooltip_installed" comments="Tooltip for the switch which allows only showing installed games or all games">Show only installed games</property>
+            <property name="can-focus">True</property>
+            <property name="tooltip-text" translatable="yes" context="tooltip_installed" comments="Tooltip for the switch which allows only showing installed games or all games">Show only installed games</property>
             <signal name="state-set" handler="filter_library" swapped="no"/>
           </object>
           <packing>
@@ -112,7 +171,7 @@
         <child>
           <object class="GtkLabel" id="header_installed_label">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="label" translatable="yes" context="installed" comments="Used next to a checkbox which switches between showing all games and only installed ones">Installed</property>
           </object>
           <packing>
@@ -120,72 +179,40 @@
           </packing>
         </child>
         <child>
-          <object class="GtkMenuButton" id="header_menu">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="valign">center</property>
-            <property name="use_popover">False</property>
-            <property name="popover">menu</property>
-            <property name="tooltip_text" translatable="yes" context="menu" comments="Tooltip for header menu button">Options menu</property>
-            <child>
-              <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">open-menu-symbolic</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="category_filter_button">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes" context="category_filter" comments="Tooltip for category filter button">Category filters</property>
-            <property name="valign">center</property>
-            <signal name="clicked" handler="on_menu_category_filter_clicked" swapped="no"/>
-            <child>
-              <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">view-conceal-symbolic</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="pack_type">end</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkSearchEntry" id="header_search">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="primary_icon_name">edit-find-symbolic</property>
-            <property name="primary_icon_activatable">False</property>
-            <property name="primary_icon_sensitive">False</property>
-            <property name="tooltip_text" translatable="yes" context="search" comments="Tooltip for search field">Search games list</property>
+            <property name="can-focus">True</property>
+            <property name="tooltip-text" translatable="yes" context="search" comments="Tooltip for search field">Search games list</property>
+            <property name="primary-icon-name">edit-find-symbolic</property>
+            <property name="primary-icon-activatable">False</property>
+            <property name="primary-icon-sensitive">False</property>
             <signal name="search-changed" handler="filter_library" swapped="no"/>
           </object>
           <packing>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">3</property>
           </packing>
         </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkScrolledWindow" id="window_library">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="shadow_type">in</property>
         <child>
-          <placeholder/>
+          <object class="GtkMenuButton" id="download_list_button">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="valign">center</property>
+            <property name="popover">download_list</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Show downloads</property>
+                <property name="icon-name">folder-download-symbolic</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="pack-type">end</property>
+            <property name="position">6</property>
+          </packing>
         </child>
       </object>
     </child>

--- a/data/ui/application.ui
+++ b/data/ui/application.ui
@@ -198,14 +198,13 @@
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
-            <property name="tooltip-text" translatable="yes">Manage downloads</property>
+            <property name="tooltip-text" translatable="yes" context="game_download_management" comments="Tooltip of the 'show downloads' button in the application main window">Manage downloads</property>
             <property name="valign">center</property>
             <property name="popover">download_list</property>
             <child>
               <object class="GtkImage">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes">Show downloads</property>
                 <property name="icon-name">folder-download-symbolic</property>
                 <style>
                   <class name="icon-dropshadow"/>

--- a/data/ui/application.ui
+++ b/data/ui/application.ui
@@ -198,6 +198,7 @@
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
+            <property name="tooltip-text" translatable="yes">Manage downloads</property>
             <property name="valign">center</property>
             <property name="popover">download_list</property>
             <child>
@@ -206,6 +207,9 @@
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Show downloads</property>
                 <property name="icon-name">folder-download-symbolic</property>
+                <style>
+                  <class name="icon-dropshadow"/>
+                </style>
               </object>
             </child>
           </object>

--- a/data/ui/download_action_buttons.ui
+++ b/data/ui/download_action_buttons.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk+" version="3.20"/>
   <template class="DownloadActionButtons" parent="GtkBox">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -49,7 +49,7 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="valign">center</property>
-            <property name="icon-name">dialog-cancel</property>
+            <property name="icon-name">media-playback-stop</property>
             <property name="icon_size">3</property>
           </object>
         </child>

--- a/data/ui/download_action_buttons.ui
+++ b/data/ui/download_action_buttons.ui
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <template class="DownloadActionButtons" parent="GtkBox">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="margin-start">3</property>
+    <property name="margin-end">3</property>
+    <property name="margin-top">3</property>
+    <property name="margin-bottom">3</property>
+    <property name="homogeneous">True</property>
+    <child>
+      <object class="GtkButton">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="relief">none</property>
+        <signal name="clicked" handler="on_primary_button" swapped="no"/>
+        <child>
+          <object class="GtkImage" id="image_primary_action">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="valign">center</property>
+            <property name="icon-name">media-playback-pause</property>
+            <property name="icon_size">3</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkButton">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="relief">none</property>
+        <signal name="clicked" handler="on_secondary_button" swapped="no"/>
+        <child>
+          <object class="GtkImage" id="image_secondary_action">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="valign">center</property>
+            <property name="icon-name">dialog-cancel</property>
+            <property name="icon_size">3</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </template>
+</interface>

--- a/data/ui/download_list.ui
+++ b/data/ui/download_list.ui
@@ -19,7 +19,7 @@
         <child>
           <object class="GtkLabel" id="label_active">
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Files being actively downloaded</property>
+            <property name="tooltip-text" translatable="yes" context="download_group">Files being actively downloaded.</property>
             <property name="label" translatable="yes" context="download_group">Active Downloads:</property>
             <property name="xalign">0.05000000074505806</property>
           </object>
@@ -50,7 +50,7 @@
         <child>
           <object class="GtkLabel" id="label_queued">
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Waiting for a free download worker slot</property>
+            <property name="tooltip-text" translatable="yes" context="download_group">Downloads waiting for a free worker slot.</property>
             <property name="label" translatable="yes" context="download_group">Pending:</property>
             <property name="xalign">0.05000000074505806</property>
           </object>
@@ -81,7 +81,7 @@
         <child>
           <object class="GtkLabel" id="label_paused">
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Will not automatically resume on restart</property>
+            <property name="tooltip-text" translatable="yes" context="download_group">Paused downlods will not automatically resume.</property>
             <property name="label" translatable="yes" context="download_group">Paused:</property>
             <property name="xalign">0.05000000074505806</property>
           </object>
@@ -112,7 +112,7 @@
         <child>
           <object class="GtkLabel" id="label_done">
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Downloads that completed, failed or were stopped.</property>
+            <property name="tooltip-text" translatable="yes" context="download_group">Downloads that completed, failed or were stopped.</property>
             <property name="label" translatable="yes" context="download_group">Done:</property>
             <property name="xalign">0.05000000074505806</property>
           </object>
@@ -144,6 +144,7 @@
           <object class="GtkButton" id="button_manage_installers">
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
+            <property name="tooltip-text" translatable="yes" context="game_download_management">Open file manager at location where installers are saved</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
             <property name="always-show-image">True</property>
@@ -169,7 +170,7 @@
                   <object class="GtkLabel" id="label_manage_installers">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes" context="game download management" comments="Klick on button should open file explorer to manage downloaded installers">Manage...</property>
+                    <property name="label" translatable="yes" context="game_download_management" comments="Klick on button will open file explorer to manage downloaded installers">Manage installers</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/data/ui/download_list.ui
+++ b/data/ui/download_list.ui
@@ -6,6 +6,7 @@
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="shadow-type">none</property>
+    <signal name="map" handler="manage_button_visibility" swapped="no"/>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
@@ -141,6 +142,52 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">7</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button_manage_installers">
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <property name="always-show-image">True</property>
+            <signal name="clicked" handler="on_manage_button" swapped="no"/>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkImage" id="icon-harddisk">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="icon-name">drive-harddisk</property>
+                    <property name="icon_size">3</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label_manage_installers">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes" context="game download management" comments="Klick on button should open file explorer to manage downloaded installers">Manage...</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">8</property>
           </packing>
         </child>
       </object>

--- a/data/ui/download_list.ui
+++ b/data/ui/download_list.ui
@@ -32,7 +32,6 @@
         <child>
           <object class="GtkFlowBox" id="flowbox_active">
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Active Downloads</property>
             <property name="valign">start</property>
             <property name="border-width">10</property>
             <property name="homogeneous">True</property>
@@ -64,7 +63,6 @@
         <child>
           <object class="GtkFlowBox" id="flowbox_queued">
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Queued Downloads</property>
             <property name="valign">start</property>
             <property name="border-width">10</property>
             <property name="homogeneous">True</property>
@@ -96,7 +94,6 @@
         <child>
           <object class="GtkFlowBox" id="flowbox_paused">
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Paused Downloads</property>
             <property name="valign">start</property>
             <property name="border-width">10</property>
             <property name="homogeneous">True</property>
@@ -128,7 +125,6 @@
         <child>
           <object class="GtkFlowBox" id="flowbox_done">
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">All Terminated Downloads</property>
             <property name="valign">start</property>
             <property name="border-width">10</property>
             <property name="homogeneous">True</property>

--- a/data/ui/download_list.ui
+++ b/data/ui/download_list.ui
@@ -18,7 +18,8 @@
         <child>
           <object class="GtkLabel" id="label_active">
             <property name="can-focus">False</property>
-            <property name="label" translatable="yes">Active downloads:</property>
+            <property name="tooltip-text" translatable="yes">Files being actively downloaded</property>
+            <property name="label" translatable="yes" context="download_group">Active Downloads:</property>
             <property name="xalign">0.05000000074505806</property>
           </object>
           <packing>
@@ -30,7 +31,7 @@
         <child>
           <object class="GtkFlowBox" id="flowbox_active">
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">active</property>
+            <property name="tooltip-text" translatable="yes">Active Downloads</property>
             <property name="valign">start</property>
             <property name="border-width">10</property>
             <property name="homogeneous">True</property>
@@ -49,7 +50,8 @@
         <child>
           <object class="GtkLabel" id="label_queued">
             <property name="can-focus">False</property>
-            <property name="label" translatable="yes">Pending:</property>
+            <property name="tooltip-text" translatable="yes">Waiting for a free download worker slot</property>
+            <property name="label" translatable="yes" context="download_group">Pending:</property>
             <property name="xalign">0.05000000074505806</property>
           </object>
           <packing>
@@ -61,7 +63,7 @@
         <child>
           <object class="GtkFlowBox" id="flowbox_queued">
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">queued</property>
+            <property name="tooltip-text" translatable="yes">Queued Downloads</property>
             <property name="valign">start</property>
             <property name="border-width">10</property>
             <property name="homogeneous">True</property>
@@ -78,9 +80,10 @@
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="label_done">
+          <object class="GtkLabel" id="label_paused">
             <property name="can-focus">False</property>
-            <property name="label" translatable="yes">Done:</property>
+            <property name="tooltip-text" translatable="yes">Will not automatically resume on restart</property>
+            <property name="label" translatable="yes" context="download_group">Paused:</property>
             <property name="xalign">0.05000000074505806</property>
           </object>
           <packing>
@@ -90,9 +93,9 @@
           </packing>
         </child>
         <child>
-          <object class="GtkFlowBox" id="flowbox_done">
+          <object class="GtkFlowBox" id="flowbox_paused">
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">done</property>
+            <property name="tooltip-text" translatable="yes">Paused Downloads</property>
             <property name="valign">start</property>
             <property name="border-width">10</property>
             <property name="homogeneous">True</property>
@@ -106,6 +109,38 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label_done">
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Downloads that completed, failed or were stopped.</property>
+            <property name="label" translatable="yes" context="download_group">Done:</property>
+            <property name="xalign">0.05000000074505806</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFlowBox" id="flowbox_done">
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">All Terminated Downloads</property>
+            <property name="valign">start</property>
+            <property name="border-width">10</property>
+            <property name="homogeneous">True</property>
+            <property name="column-spacing">15</property>
+            <property name="row-spacing">10</property>
+            <property name="max-children-per-line">1</property>
+            <property name="selection-mode">none</property>
+            <property name="activate-on-single-click">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">7</property>
           </packing>
         </child>
       </object>

--- a/data/ui/download_list.ui
+++ b/data/ui/download_list.ui
@@ -13,7 +13,6 @@
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkLabel" id="label_active">
-            <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="label" translatable="yes">Active downloads:</property>
             <property name="xalign">0.05000000074505806</property>
@@ -26,7 +25,6 @@
         </child>
         <child>
           <object class="GtkFlowBox" id="flowbox_active">
-            <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">active</property>
             <property name="valign">start</property>
@@ -46,7 +44,6 @@
         </child>
         <child>
           <object class="GtkLabel" id="label_queued">
-            <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="label" translatable="yes">Pending:</property>
             <property name="xalign">0.05000000074505806</property>
@@ -59,7 +56,6 @@
         </child>
         <child>
           <object class="GtkFlowBox" id="flowbox_queued">
-            <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">queued</property>
             <property name="valign">start</property>
@@ -79,7 +75,6 @@
         </child>
         <child>
           <object class="GtkLabel" id="label_done">
-            <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="label" translatable="yes">Done:</property>
             <property name="xalign">0.05000000074505806</property>
@@ -92,7 +87,6 @@
         </child>
         <child>
           <object class="GtkFlowBox" id="flowbox_done">
-            <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">done</property>
             <property name="valign">start</property>

--- a/data/ui/download_list.ui
+++ b/data/ui/download_list.ui
@@ -10,6 +10,10 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
+        <property name="margin-start">3</property>
+        <property name="margin-end">3</property>
+        <property name="margin-top">3</property>
+        <property name="margin-bottom">3</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkLabel" id="label_active">

--- a/data/ui/download_list.ui
+++ b/data/ui/download_list.ui
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="DownloadList" parent="GtkViewport">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="shadow-type">none</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel" id="label_active">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Active downloads:</property>
+            <property name="xalign">0.05000000074505806</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFlowBox" id="flowbox_active">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">active</property>
+            <property name="valign">start</property>
+            <property name="border-width">10</property>
+            <property name="homogeneous">True</property>
+            <property name="column-spacing">15</property>
+            <property name="row-spacing">10</property>
+            <property name="max-children-per-line">1</property>
+            <property name="selection-mode">none</property>
+            <property name="activate-on-single-click">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label_queued">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Pending:</property>
+            <property name="xalign">0.05000000074505806</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFlowBox" id="flowbox_queued">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">queued</property>
+            <property name="valign">start</property>
+            <property name="border-width">10</property>
+            <property name="homogeneous">True</property>
+            <property name="column-spacing">15</property>
+            <property name="row-spacing">10</property>
+            <property name="max-children-per-line">1</property>
+            <property name="selection-mode">none</property>
+            <property name="activate-on-single-click">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label_done">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Done:</property>
+            <property name="xalign">0.05000000074505806</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFlowBox" id="flowbox_done">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">done</property>
+            <property name="valign">start</property>
+            <property name="border-width">10</property>
+            <property name="homogeneous">True</property>
+            <property name="column-spacing">15</property>
+            <property name="row-spacing">10</property>
+            <property name="max-children-per-line">1</property>
+            <property name="selection-mode">none</property>
+            <property name="activate-on-single-click">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">5</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/ui/download_list_entry.ui
+++ b/data/ui/download_list_entry.ui
@@ -3,7 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <template class="DownloadListEntry" parent="GtkBox">
-    <property name="width-request">250</property>
+    <property name="width-request">300</property>
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="valign">start</property>
@@ -71,63 +71,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="valign">center</property>
-        <property name="margin-start">3</property>
-        <property name="margin-end">3</property>
-        <property name="margin-top">3</property>
-        <property name="margin-bottom">3</property>
-        <property name="spacing">3</property>
-        <child>
-          <object class="GtkEventBox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <signal name="button-press-event" handler="on_primary_button" swapped="no"/>
-            <child>
-              <object class="GtkImage" id="image_start_action">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="valign">center</property>
-                <property name="icon-name">media-playback-pause</property>
-                <property name="icon_size">3</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEventBox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <signal name="button-press-event" handler="on_secondary_button" swapped="no"/>
-            <child>
-              <object class="GtkImage" id="image_cancel_action">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="valign">center</property>
-                <property name="icon-name">dialog-cancel</property>
-                <property name="icon_size">3</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="position">2</property>
-      </packing>
+      <placeholder/>
     </child>
   </template>
 </interface>

--- a/data/ui/download_list_entry.ui
+++ b/data/ui/download_list_entry.ui
@@ -25,7 +25,7 @@
       </object>
       <packing>
         <property name="expand">False</property>
-        <property name="fill">True</property>
+        <property name="fill">False</property>
         <property name="position">0</property>
       </packing>
     </child>

--- a/data/ui/download_list_entry.ui
+++ b/data/ui/download_list_entry.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk+" version="3.20"/>
   <template class="DownloadListEntry" parent="GtkBox">
     <property name="width-request">300</property>
     <property name="visible">True</property>
@@ -43,7 +43,7 @@
           <object class="GtkLabel" id="game_title">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="label" translatable="yes">Game title</property>
+            <property name="label">Game title placeholder</property>
             <property name="xalign">0</property>
           </object>
           <packing>

--- a/data/ui/download_list_entry.ui
+++ b/data/ui/download_list_entry.ui
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <template class="DownloadListEntry" parent="GtkBox">
+    <property name="width-request">250</property>
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="valign">start</property>
+    <property name="margin-start">1</property>
+    <property name="margin-end">1</property>
+    <property name="margin-top">1</property>
+    <property name="margin-bottom">1</property>
+    <child>
+      <object class="GtkImage" id="icon">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="valign">center</property>
+        <property name="margin-start">3</property>
+        <property name="margin-end">3</property>
+        <property name="margin-top">3</property>
+        <property name="margin-bottom">3</property>
+        <property name="icon-name">application-x-executable</property>
+        <property name="icon_size">3</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="valign">center</property>
+        <property name="margin-start">3</property>
+        <property name="margin-end">3</property>
+        <property name="margin-top">3</property>
+        <property name="margin-bottom">3</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel" id="game_title">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Game title</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkProgressBar" id="download_progress">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="valign">center</property>
+        <property name="margin-start">3</property>
+        <property name="margin-end">3</property>
+        <property name="margin-top">3</property>
+        <property name="margin-bottom">3</property>
+        <property name="spacing">3</property>
+        <child>
+          <object class="GtkEventBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <signal name="button-press-event" handler="on_primary_button" swapped="no"/>
+            <child>
+              <object class="GtkImage" id="image_start_action">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="valign">center</property>
+                <property name="icon-name">media-playback-pause</property>
+                <property name="icon_size">3</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEventBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <signal name="button-press-event" handler="on_secondary_button" swapped="no"/>
+            <child>
+              <object class="GtkImage" id="image_cancel_action">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="valign">center</property>
+                <property name="icon-name">dialog-cancel</property>
+                <property name="icon_size">3</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+  </template>
+</interface>

--- a/minigalaxy/download.py
+++ b/minigalaxy/download.py
@@ -30,7 +30,8 @@ class Download:
 
     def __init__(self, url, save_location, download_type=None,
                  finish_func=None, progress_func=None, cancel_func=None,
-                 expected_size=None, number=1, out_of_amount=1, game=None):
+                 expected_size=None, number=1, out_of_amount=1, game=None,
+                 download_icon=None):
         self.url = url
         self.save_location = save_location
         self.__finish_func = finish_func
@@ -43,6 +44,7 @@ class Download:
         self.download_type = download_type
         self.current_progress = 0
         self.expected_size = expected_size
+        self.download_icon = download_icon
 
     def filename(self):
         return os.path.basename(self.save_location)

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -263,6 +263,7 @@ class DownloadManager:
         download_dict = dict(zip(downloads, [True] * len(downloads)))
 
         self.__cancel_paused_downloads(download_dict, cancel_state)
+        self.__cancel_stopped_downloads(download_dict, cancel_state)
 
         # Next, loop through the downloads queued for download, comparing them to the
         # cancel list
@@ -347,6 +348,16 @@ class DownloadManager:
         paused_downloads = self.config.paused_downloads
         for d in downloads:
             if d.save_location in paused_downloads:
+                self.__request_download_cancel(d, cancel_state)
+                self.__notify_listeners(cancel_state, d)
+
+    def __cancel_stopped_downloads(self, downloads, cancel_state=DownloadState.CANCELED):
+        # this method is pointless for other stop states
+        if cancel_state not in [DownloadState.CANCELED, DownloadState.PAUSED]:
+            return
+
+        for d in downloads:
+            if os.path.exists(d.save_location):
                 self.__request_download_cancel(d, cancel_state)
                 self.__notify_listeners(cancel_state, d)
 

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -2,10 +2,11 @@ import os
 import re
 import json
 
-from minigalaxy.paths import CONFIG_GAMES_DIR
+from minigalaxy.paths import CONFIG_GAMES_DIR, ICON_DIR
 
 
 class Game:
+
     def __init__(self, name: str, url: str = "", md5sum=None, game_id: int = 0, install_dir: str = "",
                  image_url="", platform="linux", dlcs=None, category=""):
         self.name = name
@@ -24,6 +25,12 @@ class Game:
 
     def get_install_directory_name(self):
         return self.__strip_string(self.name, to_path=True)
+
+    def get_cached_icon_path(self, dlc_id=None):
+        if dlc_id:
+            return os.path.join(ICON_DIR, f"{dlc_id}.jpg")
+        else:
+            return os.path.join(ICON_DIR, f'{self.id}.png')
 
     def get_status_file_path(self):
         if self.install_dir:

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -282,11 +282,13 @@ def create_applications_file(game, override=False):
     error_message = ""
     path_to_shortcut = os.path.join(APPLICATIONS_DIR, "{}.desktop".format(game.get_stripped_name(to_path=True)))
     # Create desktop file definition
+    local_icon_dir = os.path.join(game.install_dir, 'support')
+    local_icon_file = os.path.join(local_icon_dir, 'icon.png')
     desktop_context = {
         "game_bin_path": get_exec_line(game),
         "game_name": game.name,
         "game_install_dir": game.install_dir,
-        "game_icon_path": os.path.join(game.install_dir, 'support/icon.png')
+        "game_icon_path": local_icon_file
         }
     desktop_definition = """\
         [Desktop Entry]
@@ -305,6 +307,10 @@ def create_applications_file(game, override=False):
             os.remove(path_to_shortcut)
         elif file_exists:
             return error_message
+
+        if os.path.exists(game.get_cached_icon_path()):
+            os.makedirs(local_icon_dir, mode=0o755, exist_ok=True)
+            shutil.copy(game.get_cached_icon_path(), local_icon_file)
 
         with open(path_to_shortcut, 'w+') as desktop_file:
             desktop_file.writelines(textwrap.dedent(desktop_definition))

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -10,6 +10,7 @@ from minigalaxy.download_manager import DownloadManager, DownloadState
 from minigalaxy.paths import UI_DIR
 from minigalaxy.translation import _
 from minigalaxy.ui.gtk import GLib, Gtk
+from gi.overrides.GdkPixbuf import GdkPixbuf
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "download_list.ui"))
@@ -158,6 +159,11 @@ class OngoingDownloadListEntry(Gtk.Box):
                                              remove_panel_action=self.remove_from_current_box,
                                              logger=self.manager.logger)
         self.update_buttons(initial_state)
+
+        self.manager.logger.debug("trying to pull icon from: %s", download.download_icon)
+        if download.download_icon and os.path.exists(download.download_icon):
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(download.download_icon, 48, 48)
+            self.icon.set_from_pixbuf(pixbuf)
         self.pack_start(self.buttons, False, False, 0)
 
     def update_progress(self, percentage):

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -195,8 +195,6 @@ class OngoingDownloadListEntry(Gtk.Box):
             self.game_title.get_style_context().add_class(new_label_color)
             self.label_color_change = new_label_color
             self.game_title.set_text(self.game_title.get_text())
-        #else:
-        #    self.game_title.set_text(self.game_title.get_text())
 
     def update_tooltip(self, msg):
         self.game_title.set_tooltip_text(msg)

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -3,7 +3,7 @@ import os
 
 import minigalaxy.logger  # noqa: F401
 
-from minigalaxy.download import Download
+from minigalaxy.download import Download, DownloadType
 from minigalaxy.download_manager import DownloadManager, DownloadState
 from minigalaxy.paths import UI_DIR
 from minigalaxy.translation import _
@@ -17,6 +17,8 @@ class DownloadManagerList(Gtk.Viewport):
     flowbox_active = Gtk.Template.Child()
     flowbox_queued = Gtk.Template.Child()
     flowbox_done = Gtk.Template.Child()
+
+    listener_download_types = [DownloadType.GAME, DownloadType.GAME_UPDATE, DownloadType.GAME_DLC]
 
     def __init__(self, download_manager: DownloadManager):
         Gtk.Viewport.__init__(self)
@@ -41,6 +43,9 @@ class DownloadManagerList(Gtk.Viewport):
     def download_manager_listener(self, change: DownloadState, download: Download):
         self.logger.debug('Received %s for Download[save_location=%s, progress=%d]',
                           change, download.filename(), download.current_progress)
+        if download.download_type not in self.listener_download_types:
+            return
+
         GLib.idle_add(self.change_handler[change], change, download)
 
     def download_started(self, change, download):

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -182,7 +182,7 @@ class OngoingDownloadListEntry(Gtk.Box):
         self.buttons.update_buttons(new_state)
 
         new_label_color = None
-        if new_state in [DownloadState.FAILED, DownloadState.CANCELED, DownloadState.STOPPED]:
+        if new_state in [DownloadState.FAILED, DownloadState.CANCELED]:
             new_label_color = 'red'
         elif new_state in [DownloadState.COMPLETED]:
             new_label_color = 'green'

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -84,10 +84,10 @@ class DownloadManagerList(Gtk.Viewport):
         download_entry = self.__get_create_entry(change, download)
         self.__move_to_section(self.flowbox_done, download_entry, change)
 
-    def download_failed(self, change, download, error_info="Unknown error"):
+    def download_failed(self, change, download, error_info=_("Unknown error")):
         download_entry = self.__get_create_entry(change, download)
         self.__move_to_section(self.flowbox_done, download_entry, change)
-        download_entry.update_tooltip(_(error_info))
+        download_entry.update_tooltip(error_info)
 
     def download_paused(self, change, download):
         download_entry = self.__get_create_entry(change, download)
@@ -116,7 +116,8 @@ class DownloadManagerList(Gtk.Viewport):
 
         entry.add_to_box(flowbox)
         entry.update_state(new_state)
-        entry.update_tooltip(_(new_state.name))
+        # make sure to clear previous error messages when restarting a failed downloa
+        entry.update_tooltip("")
 
     def update_group_visibility(self, group_flowbox):
         if group_flowbox.get_children():
@@ -233,12 +234,23 @@ class DownloadActionButtons(Gtk.Box):
     image_secondary_action = Gtk.Template.Child()
 
     tooltip_texts = {
-        'media-playback-start': 'Resume',
-        'media-playback-pause': 'Pause',
-        'view-refresh': 'Retry',
-        'dialog-cancel': 'Cancel',
-        'edit-delete': 'Delete file',
-        'list-remove': 'Remove from list',
+        # Tooltip of icon button for download (re)start
+        'media-playback-start': _('Resume'),
+
+        # Tooltip of icon button to pause a download
+        'media-playback-pause': _('Pause'),
+
+        # Tooltip of icon button to retry a failed or canceled download
+        'view-refresh': _('Retry'),
+
+        # Tooltip of icon button to stop an active or queued download
+        'media-playback-stop': _('Stop'),
+
+        # Tooltip of icon button to delete a downloaded file
+        'edit-delete': _('Delete file'),
+
+        # Tooltip of icon button which removes a download from the ui list of downloads
+        'list-remove': _('Remove from list'),
     }
 
     # button actions are defined at the end
@@ -303,14 +315,14 @@ class DownloadActionButtons(Gtk.Box):
         primary, secondary = self.button_configs[state]['icons']
         if primary:
             self.image_primary_action.set_from_icon_name(primary, Gtk.IconSize.LARGE_TOOLBAR)
-            self.image_primary_action.set_tooltip_text(_(self.tooltip_texts[primary]))
+            self.image_primary_action.set_tooltip_text(self.tooltip_texts[primary])
             self.image_primary_action.get_parent().show()
         else:
             self.image_primary_action.get_parent().hide()
 
         if secondary:
             self.image_secondary_action.set_from_icon_name(secondary, Gtk.IconSize.LARGE_TOOLBAR)
-            self.image_secondary_action.set_tooltip_text(_(self.tooltip_texts[secondary]))
+            self.image_secondary_action.set_tooltip_text(self.tooltip_texts[secondary])
             self.image_secondary_action.get_parent().show()
         else:
             self.image_secondary_action.get_parent().hide()
@@ -353,11 +365,11 @@ class DownloadActionButtons(Gtk.Box):
     button_configs = {
         DownloadState.STARTED: {
             'actions': [pause_download, stop_download],
-            'icons': ['media-playback-pause', 'dialog-cancel']
+            'icons': ['media-playback-pause', 'media-playback-stop']
         },
         DownloadState.QUEUED: {
             'actions': [pause_download, stop_download],
-            'icons': ['media-playback-pause', 'dialog-cancel']
+            'icons': ['media-playback-pause', 'media-playback-stop']
         },
         DownloadState.COMPLETED: {
             'actions': [NOOP, trigger_remove],

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -28,10 +28,11 @@ class DownloadManagerList(Gtk.Viewport):
 
     listener_download_types = [DownloadType.GAME, DownloadType.GAME_UPDATE, DownloadType.GAME_DLC]
 
-    def __init__(self, download_manager: DownloadManager):
+    def __init__(self, download_manager: DownloadManager, downloads_menu_button):
         Gtk.Viewport.__init__(self)
         self.logger = logging.getLogger('minigalaxy.download_list.DownloadManagerList')
         self.download_manager = download_manager
+        self.menu_button = downloads_menu_button
         self.downloads = {}
 
         self.change_handler = {
@@ -76,6 +77,8 @@ class DownloadManagerList(Gtk.Viewport):
     def download_stopped(self, change, download):
         download_entry = self.__get_create_entry(change, download)
         self.__move_to_section(self.flowbox_done, download_entry, change)
+        if not self.downloads:
+            self.menu_button.get_style_context().remove_class("suggested-action")
 
     def download_paused(self, change, download):
         download_entry = self.__get_create_entry(change, download)
@@ -84,6 +87,7 @@ class DownloadManagerList(Gtk.Viewport):
     def download_progress(self, change, download):
         download_entry = self.__get_create_entry(change, download)
         download_entry.update_progress(download.current_progress)
+        self.menu_button.get_style_context().add_class("suggested-action")
 
     def __get_create_entry(self, change, download):
         if download.save_location not in self.downloads:

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -183,18 +183,20 @@ class OngoingDownloadListEntry(Gtk.Box):
 
         new_label_color = None
         if new_state in [DownloadState.FAILED, DownloadState.CANCELED]:
-            new_label_color = 'red'
+            new_label_color = 'error'
         elif new_state in [DownloadState.COMPLETED]:
-            new_label_color = 'green'
+            new_label_color = 'success'
 
         if self.label_color_change:
+            self.game_title.get_style_context().remove_class(self.label_color_change)
             self.label_color_change = None
 
         if new_label_color:
-            self.game_title.set_markup(f'<span color="{new_label_color}">{self.game_title.get_text()}</span>')
+            self.game_title.get_style_context().add_class(new_label_color)
             self.label_color_change = new_label_color
-        else:
             self.game_title.set_text(self.game_title.get_text())
+        #else:
+        #    self.game_title.set_text(self.game_title.get_text())
 
     def update_tooltip(self, msg):
         self.game_title.set_tooltip_text(msg)

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -1,0 +1,147 @@
+import logging
+import os
+
+import minigalaxy.logger  # noqa: F401
+
+from minigalaxy.download import Download
+from minigalaxy.download_manager import DownloadManager, DownloadState
+from minigalaxy.paths import UI_DIR
+from minigalaxy.translation import _
+from minigalaxy.ui.gtk import GLib, Gtk
+
+
+@Gtk.Template.from_file(os.path.join(UI_DIR, "download_list.ui"))
+class DownloadManagerList(Gtk.Viewport):
+    __gtype_name__ = "DownloadList"
+
+    flowbox_active = Gtk.Template.Child()
+    flowbox_queued = Gtk.Template.Child()
+    flowbox_done = Gtk.Template.Child()
+
+    def __init__(self, download_manager: DownloadManager):
+        Gtk.Viewport.__init__(self)
+        self.logger = logging.getLogger('minigalaxy.download_list.DownloadManagerList')
+        self.download_manager = download_manager
+        self.downloads = {}
+
+        self.change_handler = {
+            DownloadState.STARTED: self.download_started,
+            DownloadState.COMPLETED: self.download_stopped,
+            DownloadState.QUEUED: self.download_queued,
+            DownloadState.PROGRESS: self.download_progress,
+            DownloadState.FAILED: self.download_stopped,
+            DownloadState.CANCELED: self.download_stopped,
+            DownloadState.STOPPED : self.download_stopped,
+         #   DownloadState.PAUSED : self.download_paused
+        }
+
+        self.download_manager.add_active_downloads_listener(self.download_manager_listener)
+        self.show_all()
+
+    def download_manager_listener(self, change: DownloadState, download: Download):
+        self.logger.debug('Received %s for Download[save_location=%s, progress=%d]',
+                          change, download.filename(), download.current_progress)
+        GLib.idle_add(self.change_handler[change], change, download)
+
+    def download_started(self, change, download):
+        download_entry = self.__get_create_entry(change, download)
+        self.__move_to_section(self.flowbox_active, download_entry, change)
+
+    def download_queued(self, change, download):
+        download_entry = self.__get_create_entry(change, download)
+        self.__move_to_section(self.flowbox_queued, download_entry, change)
+
+    def download_stopped(self, change, download):
+        download_entry = self.__get_create_entry(change, download)
+        self.__move_to_section(self.flowbox_done, download_entry, change)
+
+    def download_paused(self, change, download):
+        download_entry = self.__get_create_entry(change, download)
+    #    self.__move_to_section(self.flowbox_paused, download_entry, change)
+
+    def download_progress(self, change, download):
+        download_entry = self.__get_create_entry(change, download)
+        download_entry.update_progress(download.current_progress)
+
+    def __get_create_entry(self, change, download):
+        if download.save_location not in self.downloads:
+            self.downloads[download.save_location] = OngoingDownloadListEntry(self, download, change)
+
+        return self.downloads[download.save_location]
+
+    def __move_to_section(self, flowbox, entry, new_state: DownloadState):
+        if entry.flowbox:
+            '''the entry needs to be removed from its parent FlowBoxChild
+            or there will be a memory access error hard crashing the application'''
+            box_child = entry.get_parent()
+            box_child.remove(entry)
+            entry.flowbox.remove(box_child)
+            box_child.destroy()
+        flowbox.add(entry)
+        entry.flowbox = flowbox
+        entry.show()
+        entry.update_buttons(new_state)
+
+
+@Gtk.Template.from_file(os.path.join(UI_DIR, "download_list_entry.ui"))
+class OngoingDownloadListEntry(Gtk.Box):
+    __gtype_name__ = "DownloadListEntry"
+
+    icon = Gtk.Template.Child()
+    game_title = Gtk.Template.Child()
+    download_progress = Gtk.Template.Child()
+    image_start_action = Gtk.Template.Child()
+    image_cancel_action = Gtk.Template.Child()
+
+    action_icon_names = {
+        DownloadState.STARTED: ['media-playback-pause', 'dialog-cancel'],
+        DownloadState.COMPLETED: [None, 'list-remove'],
+        DownloadState.QUEUED: ['media-playback-pause', 'dialog-cancel'],
+        DownloadState.PROGRESS: [None, None],
+        DownloadState.FAILED: ['view-refresh', 'list-remove'],
+        DownloadState.CANCELED: ['view-refresh', 'list-remove'],
+    }
+
+    tooltip_texts = {
+        'media-playback-start': 'Resume',
+        'media-playback-pause': 'Pause',
+        'view-refresh': 'Retry',
+        'dialog-cancel': 'Cancel',
+        'edit-delete': 'Delete File',
+        'list-remove': 'Remove from list',
+    }
+
+    def __init__(self, parent_manager, download: Download, initial_state: DownloadState):
+        Gtk.Box.__init__(self)
+        self.manager = parent_manager
+        self.flowbox = None
+        self.game_title.set_text(f'{download.game.name}:\n{os.path.basename(download.save_location)}')
+        self.update_buttons(initial_state)
+
+    def update_progress(self, percentage):
+        self.download_progress.set_fraction(percentage / 100)
+        self.download_progress.set_tooltip_text("{}%".format(percentage))
+
+    def update_buttons(self, state: DownloadState):
+        primary, secondary = self.action_icon_names[state]
+        if primary:
+            self.image_start_action.set_from_icon_name(primary, Gtk.IconSize.LARGE_TOOLBAR)
+            self.image_start_action.set_tooltip_text(_(self.tooltip_texts[primary]))
+            self.image_start_action.show()
+        else:
+            self.image_start_action.hide()
+
+        if secondary:
+            self.image_cancel_action.set_from_icon_name(secondary, Gtk.IconSize.LARGE_TOOLBAR)
+            self.image_cancel_action.set_tooltip_text(_(self.tooltip_texts[secondary]))
+            self.image_cancel_action.show()
+        else:
+            self.image_cancel_action.hide()
+
+    @Gtk.Template.Callback("on_primary_button")
+    def primary_button_clicked(self, widget, data):
+        print("primary")
+
+    @Gtk.Template.Callback("on_secondary_button")
+    def secondary_button_clicked(self, widget, data):
+        print("secondary")

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -13,6 +13,7 @@ from minigalaxy.translation import _
 from minigalaxy.ui.library import Library
 from minigalaxy.ui.gtk import Gtk, Gdk, GdkPixbuf, Notify
 from minigalaxy.config import Config
+from minigalaxy.ui.download_list import DownloadManagerList
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "application.ui"))
@@ -27,6 +28,7 @@ class Window(Gtk.ApplicationWindow):
     menu_preferences = Gtk.Template.Child()
     menu_logout = Gtk.Template.Child()
     window_library = Gtk.Template.Child()
+    download_list = Gtk.Template.Child()
 
     def __init__(self, config: Config, api: 'Api', download_manager: DownloadManager, name="Minigalaxy"):
         current_locale = config.locale
@@ -54,6 +56,7 @@ class Window(Gtk.ApplicationWindow):
 
         self.window_library.add(self.library)
         self.header_installed.set_active(self.config.installed_filter)
+        self.download_list.add(DownloadManagerList(self.download_manager))
 
         # Set the icon
         icon = GdkPixbuf.Pixbuf.new_from_file(LOGO_IMAGE_PATH)

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -57,7 +57,7 @@ class Window(Gtk.ApplicationWindow):
 
         self.window_library.add(self.library)
         self.header_installed.set_active(self.config.installed_filter)
-        self.download_list.add(DownloadManagerList(self.download_manager, self.download_list_button))
+        self.download_list.add(DownloadManagerList(self.download_manager, self.download_list_button, self.config))
 
         # Set the icon
         icon = GdkPixbuf.Pixbuf.new_from_file(LOGO_IMAGE_PATH)

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -28,6 +28,7 @@ class Window(Gtk.ApplicationWindow):
     menu_preferences = Gtk.Template.Child()
     menu_logout = Gtk.Template.Child()
     window_library = Gtk.Template.Child()
+    download_list_button = Gtk.Template.Child()
     download_list = Gtk.Template.Child()
 
     def __init__(self, config: Config, api: 'Api', download_manager: DownloadManager, name="Minigalaxy"):
@@ -56,7 +57,7 @@ class Window(Gtk.ApplicationWindow):
 
         self.window_library.add(self.library)
         self.header_installed.set_active(self.config.installed_filter)
-        self.download_list.add(DownloadManagerList(self.download_manager))
+        self.download_list.add(DownloadManagerList(self.download_manager, self.download_list_button))
 
         # Set the icon
         icon = GdkPixbuf.Pixbuf.new_from_file(LOGO_IMAGE_PATH)

--- a/scripts/update-translation-files.sh
+++ b/scripts/update-translation-files.sh
@@ -4,10 +4,10 @@ cd "$(dirname "$0")"/..
 POTFILE="data/po/minigalaxy.pot"
 
 # Generate the pot file
-xgettext --from-code=UTF-8 --keyword=_ --sort-output --language=Python minigalaxy/*.py minigalaxy/ui/*.py bin/minigalaxy -o "${POTFILE}"
+xgettext --from-code=UTF-8 --keyword=_ --sort-output --add-comments --language=Python minigalaxy/*.py minigalaxy/ui/*.py bin/minigalaxy -o "${POTFILE}"
 xgettext --join-existing --from-code=UTF-8 --keyword=translatable --sort-output --language=Glade data/ui/*.ui -o "${POTFILE}"
 
 # Update each po file
 for langfile in data/po/*.po; do
-	msgmerge -U "${langfile}" "${POTFILE}"
+	msgmerge -U "${langfile}" "${POTFILE}" -N
 done

--- a/tests/test_ui_window.py
+++ b/tests/test_ui_window.py
@@ -6,6 +6,7 @@ from simplejson.errors import JSONDecodeError
 m_gtk = MagicMock()
 m_gi = MagicMock()
 m_library = MagicMock()
+m_download_list = MagicMock()
 m_preferences = MagicMock()
 m_login = MagicMock()
 m_about = MagicMock()
@@ -52,6 +53,7 @@ class UnitTestGiRepository:
 u_gi_repository = UnitTestGiRepository()
 sys.modules['gi.repository'] = u_gi_repository
 sys.modules['gi'] = m_gi
+sys.modules['minigalaxy.ui.download_list'] = m_download_list
 sys.modules['minigalaxy.ui.library'] = m_library
 sys.modules['minigalaxy.ui.preferences'] = m_preferences
 sys.modules['minigalaxy.ui.login'] = m_login


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

I'm currently working on several issues and features related to downloads. These are:
- Some refactoring/code shifting in LibraryEntry to prepare for improvements of download handling and progress calculation.
- investigate need/current capability of minigalaxy to smartly pause/resume partial downloads. From what i can tell, manually cancelling a download will unconditionally delete the downloaded parts. The only way to keep parts is to just close minigalaxy without cancelling.
- The logic that determines which files to delete. It deletes too much right now.
- Some central place in the ui that makes downloads and their progress more visible.
- Making multi-part downloads 'first-class objects' known to download_manager. I've already code something hacked down in LibraryEntry in another branch locally, but i'd like to integrate that to download_manager where it belongs instead.

This (draft) PR is for a new UI: Showing all downloads and their current state.
As a picture often is more powerful than thousands of words, here's a little screenshot of how it looks currently:

![screenshot_download_manager](https://github.com/user-attachments/assets/16aed76f-1cf0-4250-b468-21c25fef8968)

It's still rough and there's a bit of work to do, but i've got most of the basic concept down:
1. download_manager provides an event distribution mechanism to which listeners can register themselves freely. All relevant changes to the download state will be published there. Start, queueing, (manual) cancelling, cancel caused by error, download progress, regular completion.
2. The UI attaches to these events and reacts accordingly
I've chosen that approach because it is more flexible than going to some modded callback hooks in the Download instances themselves, as passing them around to the right places would be an absolute nightmare. Moreover, it's extensible and basically decoupled from the UI.

What's missing:
- [x] The game icon on the left. The api provides game icon files, maybe optional, but it's there. Could be leveraged here.
- [x] Localisation keys
- [x] Hide empty categories
- [x] Change icon in menu bar to `folder-download-symbolic`
- [x] the action buttons/icons could use a bit of highlighting when targeted by the mouse cursor
- [x] The last pieces of event handler code for the download actions pause, ~~resume~~, ~~cancel~~, ~~delete (file)~~
- [x] ~~actions for queued downloads? pause, stop, priority change by dragging?~~ nothing special for now. too complicated because access to the priorised queue is difficult.
- [x] A way in download_manager to differentiate between 'cancel=abort' and 'cancel=pause'. Both are effectively a type of 'cancel', because the download is not actively being continued on a worker thread. Difference between both would be whether the partial file is deleted or not. See #655 
- [x] download_manager should keep track of files that were manually paused/stopped and don't automatically restart them when queued on startup. Might require an addition list of paused downloads and an addition to config to keep track of file names, not just gameids. See #655
- [x] Maybe a bit of spacing corrections in the ui
- [x] ~~Fancy bonus: do something with the button/icon while there are active downloads, e.g. some slow blinking to show that there are some downloads running~~ Menu button changes to `suggested_action` while there is any active or queued download. BUG: not undone correctly
- [x] handling of split downloads (games with several bin files). i'm going to integrate support for this into download_manager itself by using a new subclass of Download and shifting around a bit of the starting/queueing logic to make the difference invisible to download_manager. - **Will follow in another PR**
- [x] Some input, ideas, feedback - ongoing process
- [x] some visual indicator of the different types of 'completion states' (completed, stopped, failure, cancel) which all go into the 'Done' section (aside from the different button options they might have). Maybe background colors or label color, maybe another small icon in front of the name, like a green checkmark or a diagonal red cross, an exlamation mark etc..
- [x] The 'Manage' button just opens a file manager, but the library is not automatically refreshed after closing the manager again. This impacts the case that installers are deleted. In that case the GameTile button which is labeled 'install' won't change back to 'download'. Providing a synchronized subprocess is more than a quick shot here. Properly opening a file manager requires either dbus or xdg-open, both appear to fork, i can't wait for the subprocess to end to refresh the library programmatically. Something to deal with later in a dedicated PR.

How the actions and states differ:

| Action | stream remote > local? | keep partial file | prevent auto-restart | callback behavior | 
| --- | --- | --- | --- | --- |
| Pause  | ✖️ | ✔️ | (✔️) technically GameTile must try to resume them as normal. Necessary to 'transform' gameid file list to compare with list of paused files | paused download never goes active after restart, so no callbacks invoked until resumed |
| Cancel | ✖️ | ✖️ | ✔️ | stopping fires cancel. basically like failure, but different feedback regarding cancel reason. Like cancel on the game tiles. |
| Start/Resume | ✔️ | re-use partial | - | as always. resume from pause requeues download |


## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
