### PR TITLE
Icons for (windows) desktop shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minor UI change in the dialog for third-party logins (thanks to GB609)
 - Desktop shortcuts created by Minigalaxy will now be updated with environment and launch argument changes from the game's property dialog when OK is clicked (thanks to GB609)
 - Clean-up and fixes of the code used for grid and list style library views (thanks to GB609)
+- Desktop shortcuts for windows games can now have icons, if gog provides them in the game info api 'images' section (thanks to GB609)
 
 **1.3.1**
 - Fix Windows games with multiple parts not installing with wine

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -303,6 +303,7 @@ def create_applications_file(game, override=False):
 
         with open(path_to_shortcut, 'w+') as desktop_file:
             desktop_file.writelines(textwrap.dedent(desktop_definition))
+
     except Exception as e:
         os.remove(path_to_shortcut)
         error_message = e

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -303,7 +303,6 @@ def create_applications_file(game, override=False):
 
         with open(path_to_shortcut, 'w+') as desktop_file:
             desktop_file.writelines(textwrap.dedent(desktop_definition))
-
     except Exception as e:
         os.remove(path_to_shortcut)
         error_message = e

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -351,7 +351,7 @@ class LibraryEntry:
     def __check_for_update_dlc(self):
         if self.game.is_installed() and self.game.id and not self.offline:
             game_info = self.api.get_info(self.game)
-            self.__download_icon(False, game_info)
+            self.__download_icon(game_info=game_info)
             if self.game.get_info("check_for_updates") == "":
                 self.game.set_info("check_for_updates", True)
             if self.game.get_info("check_for_updates"):

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -329,6 +329,9 @@ class LibraryEntry:
             GLib.idle_add(self.update_to_state, cancel_to_state)
 
     def __download_icon(self, force=False, game_info=None):
+        if not self.config.create_applications_file:
+            return
+
         if self.offline or not self.game.is_installed():
             return
 

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -347,7 +347,7 @@ class LibraryEntry:
 
         '''game_info images dict does not contain fully valid urls.
         The entries there appear to start with //'''
-        icon_url = re.sub('.*?//', 'https://', icon)
+        icon_url = re.sub('^.*?//', 'https://', icon, count=1)
         download = Download(url=icon_url, save_location=local_name)
         self.download_manager.download(download)
 


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This is an alternative to #380 which doesn't require to add more dependencies to minigalaxy.
If `api.get_info()` provides a data entry `['images']['icon']`, the corresponding file is downloaded as `game.install_dir/support/icon.png` which matches the location linux games uses.

This means that i'm effectively ignoring all *.ico files and just download a (hopefully) compatible format.

I've added a few early returns and ifs to protect existing files and prevent error when offline etc, but thats the basic gist of it.
The icon download is currently triggered in 2 places: 
1. after a successful game install
2. when checking for updates
Why both: Game install might also happen while offline from local installer. There'd be no icon then, and no access to download it either.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
