### PR TITLE
Enhance download manager (required for download ui)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**1.4.0**
+- various improvements to the download manager, including a pause function (not usable from the UI yet) (thanks to GB609)
+
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)
 - Variables and arguments in game settings can now contain blanks when quoted shell-style (thanks to GB609)

--- a/bin/minigalaxy
+++ b/bin/minigalaxy
@@ -56,7 +56,7 @@ def main():
     session = requests.Session()
     session.headers.update({'User-Agent': 'Minigalaxy/{} (Linux {})'.format(VERSION, platform.machine())})
     api = Api(config, session)
-    download_manager = DownloadManager(session)
+    download_manager = DownloadManager(session, config)
     window = Window(config, api, download_manager, APPLICATION_NAME)
     window.connect("destroy", Gtk.main_quit)
     Gtk.main()

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -11,7 +11,7 @@ class Config:
     __config_file: str
     __config: dict
 
-    def __init__(self, config_file: str=CONFIG_FILE_PATH):
+    def __init__(self, config_file: str = CONFIG_FILE_PATH):
         self.__config_file = config_file
         self.__config = {}
         self.__load()

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -11,7 +11,7 @@ class Config:
     __config_file: str
     __config: dict
 
-    def __init__(self, config_file: str = CONFIG_FILE_PATH):
+    def __init__(self, config_file: str=CONFIG_FILE_PATH):
         self.__config_file = config_file
         self.__config = {}
         self.__load()
@@ -182,3 +182,25 @@ class Config:
         if download_id in current:
             current.remove(download_id)
             self.current_downloads = current
+
+    @property
+    def paused_downloads(self) -> List[int]:
+        return self.__config.get("paused_downloads", {})
+
+    @paused_downloads.setter
+    def paused_downloads(self, new_value: {}) -> None:
+        self.__config["paused_downloads"] = new_value
+        self.__write()
+
+    def add_paused_download(self, save_location, current_progress):
+        paused = self.paused_downloads
+        paused[save_location] = current_progress
+        self.paused_downloads = paused
+        self.__write()
+
+    def remove_paused_download(self, save_location):
+        paused = self.paused_downloads
+        if save_location in paused:
+            del paused[save_location]
+            self.paused_downloads = paused
+            self.__write()

--- a/minigalaxy/download.py
+++ b/minigalaxy/download.py
@@ -25,9 +25,10 @@ class Download:
     >>>   download = Download(image_url, thumbnail, DownloadType.THUMBNAIL, finish_func=lambda x: print("Done downloading {}!".format(x))) # noqa: E501
     >>> your_function() # doctest: +SKIP
     """
-    def __init__(self, url, save_location, download_type=None, finish_func=None,
-                 progress_func=None, cancel_func=None, number=1,
-                 out_of_amount=1, game=None):
+
+    def __init__(self, url, save_location, download_type=None,
+                 finish_func=None, progress_func=None, cancel_func=None,
+                 expected_size=None, number=1, out_of_amount=1, game=None):
         self.url = url
         self.save_location = save_location
         self.__finish_func = finish_func
@@ -38,9 +39,12 @@ class Download:
         self.game = game
         # Type of object, e.g. icon, thumbnail, game, dlc,
         self.download_type = download_type
+        self.current_progress = 0
+        self.expected_size = expected_size
 
     def set_progress(self, percentage: int) -> None:
         "Set the download progress of the Download"
+        self.current_progress = percentage
         if self.__progress_func:
             if self.out_of_amount > 1:
                 # Change the percentage based on which number we are

--- a/minigalaxy/download.py
+++ b/minigalaxy/download.py
@@ -1,3 +1,5 @@
+import os
+
 from enum import Enum
 from zipfile import BadZipFile
 
@@ -41,6 +43,9 @@ class Download:
         self.download_type = download_type
         self.current_progress = 0
         self.expected_size = expected_size
+
+    def filename(self):
+        return os.path.basename(self.save_location)
 
     def set_progress(self, percentage: int) -> None:
         "Set the download progress of the Download"

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -272,7 +272,7 @@ class DownloadManager:
         # First cancel all the active downloads
         self.cancel_current_downloads(download_dict, cancel_state)
 
-    def cancel_current_downloads(self, download_dict, cancel_state=DownloadState.CANCELED):
+    def cancel_current_downloads(self, download_dict=None, cancel_state=DownloadState.CANCELED):
         """
         Cancel the current downloads
         """

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -309,15 +309,6 @@ class DownloadManager:
                     item = new_queue.get()
                     download_queue.put(item)
 
-    def cancel_current_downloads(self):
-        """
-        Cancel the current downloads
-        """
-        self.logger.debug("Canceling current download")
-        with self.active_downloads_lock:
-            for download in self.active_downloads:
-                self.__cancel[download] = True
-
     def cancel_all_downloads(self):
         """
         Cancel all current downloads queued

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -289,16 +289,19 @@ class DownloadManager:
 
                 while not download_queue.empty():
                     queued_download = download_queue.get()
+
                     # Test a Download against a QueuedDownloadItem
-                    if download == queued_download.item:
-                        download.cancel()
+                    should_cancel = download == queued_download.item
                     # test for games
-                    elif (download.game is not None) and \
-                         (download.game == queued_download.item.game):
-                        download.cancel()
+                    if not should_cancel:
+                        should_cancel = (download.game is not None) and (download.game == queued_download.item.game)
                     # test for other assets
-                    elif download.save_location == queued_download.item.save_location:
-                        download.cancel()
+                    if not should_cancel:
+                        should_cancel = download.save_location == queued_download.item.save_location
+
+                    if should_cancel:
+                        self.__request_download_cancel(download, cancel_state)
+                        self.__notify_listeners(DownloadState.CANCELED, download)
                     else:
                         new_queue.put(queued_download)
                     # Mark the task as "done" to keep counts correct so

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -283,7 +283,7 @@ class DownloadManager:
         with self.active_downloads_lock:
             for download in self.active_downloads:
                 if download in download_dict:
-                    self.logger.debug("Canceling download: " + download.save_location)
+                    self.logger.debug("Canceling download: %s", download.save_location)
                     # mark it for canceling
                     self.__request_download_cancel(download, cancel_state)
 

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -81,7 +81,8 @@ class TestDownloadManager(TestCase):
         self.download_request.headers.get.assert_called_once()
         self.download_request.iter_content.assert_called_once()
 
-        self.assertEqual(2, progress_func.call_count)
+        # 0, 50 (hard-coded), 100 (done)
+        self.assertEqual(3, progress_func.call_count)
         self.assertEqual(0, finish_func.call_count)
         self.assertEqual(0, cancel_func.call_count)
 

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -1,6 +1,7 @@
 import os
 import random
 import tempfile
+import time
 from string import ascii_uppercase
 from unittest import TestCase
 from unittest.mock import MagicMock
@@ -12,28 +13,35 @@ from minigalaxy.download_manager import DownloadManager
 
 class TestDownloadManager(TestCase):
 
+    def setUp(self):
+        self.session = MagicMock()
+        self.config_mock = MagicMock()
+        self.config_mock.paused_downloads = {}
+        self.download_request = MagicMock()
+
+        self.session.get.return_value = self.download_request
+
+        self.chunks = [
+            bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE)),
+            bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE)),
+            bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE))
+        ]
+
+        self.download_request.iter_content.return_value = [*self.chunks]
+        self.download_request.headers.get.return_value = len(self.chunks) * DOWNLOAD_CHUNK_SIZE
+        self.download_manager = DownloadManager(self.session, self.config_mock)
+        self.download_manager.fork_listener = False
+
     def test_download_operation(self):
-        session = MagicMock()
-        download_request = MagicMock()
-        session.get.return_value = download_request
-
-        chunk1 = bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE))
-        chunk2 = bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE))
-        chunk3 = bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE))
-
-        download_request.iter_content.return_value = [chunk1, chunk2, chunk3]
-        download_request.headers.get.return_value = len(chunk1) + len(chunk2) + len(chunk3)
-        download_manager = DownloadManager(session)
-
         progress_func = MagicMock()
         finish_func = MagicMock()
         cancel_func = MagicMock()
 
         temp_file = tempfile.mktemp()
         download = Download("example.com", temp_file, DownloadType.GAME, finish_func, progress_func, cancel_func)
-        download_manager._DownloadManager__download_operation(download, 0, "wb")
+        self.download_manager._DownloadManager__download_operation(download, 0, "wb")
 
-        expected = chunk1 + chunk2 + chunk3
+        expected = b''.join(self.chunks)
         with open(temp_file) as content:
             actual = content.read().encode('utf-8')
             self.assertEqual(expected, actual)
@@ -42,25 +50,16 @@ class TestDownloadManager(TestCase):
         os.remove(temp_file)
         self.assertFalse(os.path.isfile(temp_file))
 
-        download_request.headers.get.assert_called_once()
-        download_request.iter_content.assert_called_once()
+        self.download_request.headers.get.assert_called_once()
+        self.download_request.iter_content.assert_called_once()
 
-        self.assertEqual(3 + 2, progress_func.call_count)
+        # 0 at begin, 33, 66, 100
+        self.assertEqual(3 + 1, progress_func.call_count)
         self.assertEqual(0, finish_func.call_count)
         self.assertEqual(0, cancel_func.call_count)
 
     def test_download_operation_still_downloads_without_content_length(self):
-        session = MagicMock()
-        download_request = MagicMock()
-        session.get.return_value = download_request
-
-        chunk1 = bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE))
-        chunk2 = bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE))
-        chunk3 = bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE))
-
-        download_request.iter_content.return_value = [chunk1, chunk2, chunk3]
-        download_request.headers.get.side_effect = TypeError
-        download_manager = DownloadManager(session)
+        self.download_request.headers.get.side_effect = TypeError
 
         progress_func = MagicMock()
         finish_func = MagicMock()
@@ -68,9 +67,9 @@ class TestDownloadManager(TestCase):
 
         temp_file = tempfile.mktemp()
         download = Download("example.com", temp_file, DownloadType.GAME, finish_func, progress_func, cancel_func)
-        download_manager._DownloadManager__download_operation(download, 0, "wb")
+        self.download_manager._DownloadManager__download_operation(download, 0, "wb")
 
-        expected = chunk1 + chunk2 + chunk3
+        expected = b''.join(self.chunks)
         with open(temp_file) as content:
             actual = content.read().encode('utf-8')
             self.assertEqual(expected, actual)
@@ -79,25 +78,15 @@ class TestDownloadManager(TestCase):
         os.remove(temp_file)
         self.assertFalse(os.path.isfile(temp_file))
 
-        download_request.headers.get.assert_called_once()
-        download_request.iter_content.assert_called_once()
+        self.download_request.headers.get.assert_called_once()
+        self.download_request.iter_content.assert_called_once()
 
         self.assertEqual(2, progress_func.call_count)
         self.assertEqual(0, finish_func.call_count)
         self.assertEqual(0, cancel_func.call_count)
 
     def test_download_operation_cancel_download(self):
-        session = MagicMock()
-        download_request = MagicMock()
-        session.get.return_value = download_request
-
-        chunk1 = bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE))
-        chunk2 = bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE))
-        chunk3 = bytes(random.choices(ascii_uppercase.encode('utf-8'), k=DOWNLOAD_CHUNK_SIZE))
-
-        download_request.iter_content.return_value = [chunk1, chunk2, chunk3]
-        download_request.headers.get.side_effect = TypeError
-        download_manager = DownloadManager(session)
+        self.download_request.headers.get.side_effect = TypeError
 
         progress_func = MagicMock()
         finish_func = MagicMock()
@@ -105,11 +94,11 @@ class TestDownloadManager(TestCase):
 
         temp_file = tempfile.mktemp()
         download = Download("example.com", temp_file, DownloadType.GAME, finish_func, progress_func, cancel_func)
-        download_manager.active_downloads[download] = download
-        download_manager.cancel_download(download)
-        download_manager._DownloadManager__download_operation(download, 0, "wb")
+        self.download_manager.active_downloads[download] = download
+        self.download_manager.cancel_download(download)
+        self.download_manager._DownloadManager__download_operation(download, 0, "wb")
 
-        expected = chunk1
+        expected = self.chunks[0]
         with open(temp_file) as content:
             actual = content.read().encode('utf-8')
             self.assertEqual(expected, actual)
@@ -118,29 +107,29 @@ class TestDownloadManager(TestCase):
         os.remove(temp_file)
         self.assertFalse(os.path.isfile(temp_file))
 
-        download_request.headers.get.assert_called_once()
-        download_request.iter_content.assert_called_once()
+        self.download_request.headers.get.assert_called_once()
+        self.download_request.iter_content.assert_called_once()
 
         self.assertEqual(1, progress_func.call_count)
         self.assertEqual(0, finish_func.call_count)
         self.assertEqual(0, cancel_func.call_count)
 
     def test_cancel_download(self):
-        session = MagicMock()
-        download_manager = DownloadManager(session)
-
         progress_func = MagicMock()
         finish_func = MagicMock()
+        finish_func.side_effect = lambda: print("download finished")
         cancel_func = MagicMock()
+        cancel_func.side_effect = lambda: print(str(time.time()) + " download cancel received")
 
         temp_file = tempfile.mktemp()
         download = Download("example.com", temp_file, DownloadType.GAME, finish_func, progress_func, cancel_func)
 
-        download_manager.download(download)
+        self.download_manager.download(download)
 
-        download_manager.cancel_download(download)
+        self.download_manager.cancel_download(download)
+        print(str(time.time()) + " assert")
         cancel_func.assert_called_once()
-        for queue in download_manager.queues:
+        for queue in self.download_manager.queues:
             for i in queue:
                 self.assertNotEqual(i, download)
         self.assertFalse(os.path.isfile(temp_file))


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

I'm afraid that this is a bigger pull request than my previous ones. But i've figured that it wouldn't make much sense to split this up any further.

This PR contains changes i've implemented during my draft of the new download ui. 
It consists of the following parts:
1. a small set of improvements / bugfixes in the original download manager code i found while implementing new features
2. i've tried to encapsulate access to several internal state objects to helper methods to abstract away the logic itself from code required for correct data maintenance. This mostly concerns `__active_downloads` and `__cancel`. I've done this to avoid errors and code duplication when handling the various state changes
3. introduction of a small lifecycle for downloads:
   `QUEUED -> STARTED -> PROGRESS*{3,100} -> [COMPLETED | FAILED | CANCELED | STOPPED]; PAUSED`. That is the expected flow of a regular download without intervention. However, basically any transition is possible, with a little exception: going from pause to started is guarded by one additional none-default parameter to `download`
4. Some helper methods to encapsulate checking for states and correct bookkeeping of meta data
5. I've changed bigger portions of `__download_file` and `__download_operation` to leverage the new states and helpers, also removed some unnecessary branching
6. Listeners: This is where it all started. I need a way to get information about downloads for my download manager UI. For that i've implemented a listener pattern, as is explained in #652.
The listener/callback notification runs in a dedicated thread (using a ThreadPoolExecutor to avoid frequent construction and destruction of thread objects). And while i was doing that, i've changed how callbacks in Download objects themselves are called to also run over the listener thread and be called from the same method (if the state to notify about is supported by callbacks)

I spent half the day to try and split all those changes into several commits to make the review more manageable.
I'm going to have to rebase my ui branch onto this one, as i also changed the state names and i want to remove the changes to download_manager from the ui branch.


## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
