### PR TITLE
Fixes for issues found during release pre-test

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -448,7 +448,7 @@ def match_game_lang_to_installer(installer: str, language: str, outputLogFile=No
     lang_name_regex = re.compile('(\\w+)\\s*:\\s*.*')
 
     if outputLogFile is not None:
-        logger.info('write setup language data: ', outputLogFile)
+        logger.info('write setup language data: %s', outputLogFile)
         with open(outputLogFile, "w") as text_file:
             text_file.write(stdout)
 

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -620,10 +620,10 @@ class DlcListEntry(Gtk.Box):
         elif icon:
             download = Download(
                 url="http:{}".format(icon),
-                dlc_icon=os.path.join(ICON_DIR, "{}.jpg".format(dlc_id)),
+                save_location=dlc_icon_path,
                 finish_func=self.__set_downloaded_dlc_icon
             )
-            self.download_manager.download_now(download)
+            self.parent_entry.download_manager.download_now(download)
 
     def __dlc_button_clicked(self, button):
         button.set_sensitive(False)


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

I'm in the middle of testing basic functionality of minigalaxy to prepare for the next release.
When i encounter easy to fix exceptions, i take care of them and put a commit in this PR, accompanied by a comment with error infos like the trace.

Test table:

Test | Game used | Result
-- | -- | --
Start with .cache cleared | - | OK
Simple install (no restart, no multi) | Fell Seal (1.1 G)<br>3ed2b3b7601285fdca1398a1be7e117a | worked, but got error while getting DLC icon after install
  | Ruin Raiders (269 M)<br>95eb1ade0648e2eb241899ac294c2a53 | OK
Install DLC | Fell Seal: Missions and Monsters | OK
  |   |  
Restart at 25% of download | Ruin Raiders | OK: 95eb1ade0648e2eb241899ac294c2a53
Restart at ~55-60% | Ruin Raiders | OK: 95eb1ade0648e2eb241899ac294c2a53
  |   |  
**Reverse download_manager patch to cross-check** 
Restart at 25% of download | Ruin Raiders | Download OK, but progress stays several seconds at 100%<br>Because file_size from content_length will be smaller than downloaded_size after a while
Restart at ~55-60% | Ruin Raiders | Minigalaxy tries to install immediately after restart but fails -> download never resumed, partial file was taken as complete
  |   |  
setup.py | Double-check ‚unzip -l of package‘ | OK: All translation files contained

Since large multifile-downloads can take very long, i used 2 relatively small games for my tests. But the resume works identically (its just a loop over the same basic code) and i'm pretty sure that the detection of already download files works since that is a section of the code were I worked on quite a lot recently including lots of tests.
What is problematic is that a corrupted download leads to the entire game being deleted. The same applies for manually triggering a redownload, which wipes the entire install cache dir. But that is a separate issue.

There's one potential feature gap: Right now, DLC downloads can't be resumed after restart. They are not added to the list of active downloads in config and have different game ids to their base game. This might become an issue for large addon packs.

Anything else that needs testing? If not, we should be ok after merging the fixes in this PR.