### PR TITLE
minor improvements in wine install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 **1.4.0**
-- various improvements to the download manager, including a pause function (not usable from the UI yet) (thanks to GB609)
+- Various improvements to the download manager, including a pause function (not usable from the UI yet) (thanks to GB609)
+- Speed up creation of wine prefixes during installations (thanks to GB609)
+- Use regedit to more permanently disable useless shortcut creation by wine from within a prefix (thanks to GB609)
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/data/wine_resources/disable_menubuilder.reg
+++ b/data/wine_resources/disable_menubuilder.reg
@@ -1,0 +1,5 @@
+REGEDIT4
+
+[HKEY_CURRENT_USER\Software\Wine\DllOverrides]
+"winemenubuilder.exe"="d"
+

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -14,7 +14,7 @@ from minigalaxy.game import Game
 from minigalaxy.logger import logger
 from minigalaxy.translation import _
 from minigalaxy.launcher import get_execute_command, get_wine_path, wine_restore_game_link
-from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, APPLICATIONS_DIR
+from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, APPLICATIONS_DIR, WINE_RES_PATH
 
 
 def get_available_disk_space(location):
@@ -167,8 +167,13 @@ def extract_by_wine(game, installer, game_lang, config=Config()):
 
     if not os.path.exists(prefix_dir):
         os.makedirs(prefix_dir, mode=0o755)
-        # Creating the prefix before modifying dosdevices
-        command = ["env", *wine_env, wine_bin, "wineboot", "-u"]
+        '''
+        Creating the prefix before modifying dosdevices
+        Use regedit import as first command and try to disable the menubuilder for good
+        So that it will also be disabled when patches, updates or dependencies like directx are installed
+        later on by the game itself from within the prefix. Happened with UE4.
+        '''
+        command = ["env", *wine_env, wine_bin, "regedit", f"{WINE_RES_PATH}/disable_menubuilder.reg"]
         if not try_wine_command(command):
             return _("Wineprefix creation failed.")
 

--- a/minigalaxy/paths.py
+++ b/minigalaxy/paths.py
@@ -28,6 +28,10 @@ if not os.path.exists(LOGO_IMAGE_PATH):
         os.path.join(LAUNCH_DIR, "../share/icons/hicolor/192x192/apps/io.github.sharkwouter.Minigalaxy.png")
     )
 
+WINE_RES_PATH = os.path.abspath(os.path.join(LAUNCH_DIR, "../data/wine_resources"))
+if not os.path.exists(WINE_RES_PATH):
+    WINE_RES_PATH = os.path.abspath(os.path.join(LAUNCH_DIR, "../share/minigalaxy/wine_resources"))
+
 ICON_WINE_PATH = os.path.abspath(os.path.join(LAUNCH_DIR, "../data/images/winehq_logo_glass.png"))
 if not os.path.exists(ICON_WINE_PATH):
     ICON_WINE_PATH = os.path.abspath(os.path.join(LAUNCH_DIR, "../share/minigalaxy/images/winehq_logo_glass.png"))

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         ('share/icons/hicolor/192x192/apps', ['data/icons/192x192/io.github.sharkwouter.Minigalaxy.png']),
         ('share/minigalaxy/ui', glob('data/ui/*.ui')),
         ('share/minigalaxy/images', glob('data/images/*')),
+        ('share/minigalaxy/wine_resources', glob('data/wine_resources/*')),
         ('share/minigalaxy/', ['data/style.css']),
         ('share/metainfo', ['data/io.github.sharkwouter.Minigalaxy.metainfo.xml']),
     ] + translations,


### PR DESCRIPTION
This is something i was thinking about and testing since i changed the wine install.
There are 2 little issues i have with how i changed prefix creation.

1. Speed up initial prefix creation: When a new prefix is created during install, it already is fully updated.
The additional command 'wineboot -u' forced running the same upgrade procedure a second time which can take a long time, depending on the hardware.
Since the main point of this command was just to run anything in wine to let it create the prefix, it can be changed to something that works faster. I personally am using a relatively old (yet still powerful) pc, so the difference is really noticable.
2. In addition to using an env variable to disable winemenubuilder, this commit tries to disable it more permanently in the registry to prevent additional installations triggered by the game itself from adding more shortcuts (some game engines install dependencies they need afterwards). It took me a while to find the right file format for the registry file to work.
Combined with 1., so the first action that is done to create the wineprefix is running a regedit import. 

## Checklist
 
 - [ ] _CHANGELOG.md_ was updated - will add it after the other PR is merged to prevent another merge conflict on this file
