### PR TITLE
Make more Windows games able to launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Speed up creation of wine prefixes during installations (thanks to GB609)
 - Use regedit to more permanently disable useless shortcut creation by wine from within a prefix (thanks to GB609)
 - Introduce a UI to show all active, stopped or failed downloads. Also allows to permanently pause a download (thanks to GB609)
+- Make more Windows games able to launch through Minigalaxy
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -99,7 +99,7 @@ UI_DOWNLOAD_THREADS = 4
 # Game download threads are for long-running downloads like games, DLC or updates
 GAME_DOWNLOAD_THREADS = 4
 
-# Windows executables to not consider when launching, all lower case
+# Windows executables to not consider when launching
 BINARY_NAMES_TO_IGNORE = [
     # Standard uninstaller
     "unins000.exe",

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -98,3 +98,19 @@ MINIMUM_RESUME_SIZE = 50 * 1024**2  # 50 MB
 UI_DOWNLOAD_THREADS = 4
 # Game download threads are for long-running downloads like games, DLC or updates
 GAME_DOWNLOAD_THREADS = 4
+
+# Windows executables to not consider when launching, all lower case
+BINARY_NAMES_TO_IGNORE = [
+    # Standard uninstaller
+    "unins000.exe",
+    # Common extra binaries
+    "UnityCrashHandler64.exe",
+    "nglide_config.exe",
+    # Diablo 2 specific
+    "ipxconfig.exe",
+    "BNUpdate.exe",
+    "VidSize.exe",
+    # FreeSpace 2 specific
+    "FRED2.exe",
+    "FS2.exe",
+]

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -5,6 +5,7 @@ import re
 import json
 import shlex
 import threading
+from typing import List
 
 from minigalaxy.logger import logger
 from minigalaxy.translation import _
@@ -119,7 +120,7 @@ def get_exe_cmd_with_var_command(game, exe_cmd):
     return exe_cmd
 
 
-def get_windows_exe_cmd_from_goggame_info(game, file: str) -> list[str]:
+def get_windows_exe_cmd_from_goggame_info(game, file: str) -> List[str]:
     exe_cmd = []
     os.chdir(game.install_dir)
     with open(file, 'r') as info_file:

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -161,7 +161,7 @@ def get_windows_exe_cmd(game, files):
     else:
         # Find the first executable file that is not blacklisted
         for file in files:
-            if file.upper().rsplit(".")[-1] not in ["EXE", "LNK"]:
+            if os.path.splitext(file.upper())[-1] not in [".EXE", ".LNK"]:
                 continue
             if file in BINARY_NAMES_TO_IGNORE:
                 continue

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -162,13 +162,17 @@ class Test(TestCase):
         "rootGameId": "1407287452",
         "version": 1
         }"""
-        handlers = (mock_open(read_data=goggame_1414471894_info_content).return_value, mock_open(read_data=goggame_1407287452_info_content).return_value)
+        handlers = (
+            mock_open(read_data=goggame_1414471894_info_content).return_value,
+            mock_open(read_data=goggame_1407287452_info_content).return_value,
+        )
         mo.side_effect = handlers
         mock_exists.return_value = True
         files = ['thumbnail.jpg', 'docs', 'support', 'game', 'minigalaxy-dlc.json', 'MetroExodus.exe', 'unins000.exe',
                  'goggame-1407287452.info', 'goggame-1414471894.info']
         game = Game("Test Game", install_dir="/test/install/dir")
-        exp = ['env', 'WINEPREFIX=/test/install/dir/prefix', 'wine', 'start', '/b', '/wait', '/d', 'c:\\game\\.', 'c:\\game\\MetroExodus.exe']
+        exp = ['env', 'WINEPREFIX=/test/install/dir/prefix', 'wine', 'start', '/b', '/wait', '/d', 'c:\\game\\.',
+               'c:\\game\\MetroExodus.exe']
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -112,10 +112,13 @@ class Test(TestCase):
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 
+    @mock.patch("minigalaxy.launcher.get_wine_path")
     @mock.patch('os.path.exists')
     @mock.patch('builtins.open', new_callable=mock_open, read_data="")
     @mock.patch('os.chdir')
-    def test2_get_windows_exe_cmd(self, mock_os_chdir, mo, mock_exists):
+    @mock.patch("minigalaxy.launcher.wine_restore_game_link", MagicMock)
+    def test2_get_windows_exe_cmd(self, mock_os_chdir, mo, mock_exists, mock_get_wine_path):
+        mock_get_wine_path.return_value = "wine"
         goggame_1414471894_info_content = """{
         "buildId": "53350324452482937",
         "clientId": "53185732904249211",
@@ -176,10 +179,13 @@ class Test(TestCase):
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 
+    @mock.patch("minigalaxy.launcher.get_wine_path")
     @mock.patch('os.path.exists')
     @mock.patch('builtins.open', new_callable=mock_open, read_data="")
     @mock.patch('os.chdir')
-    def test3_get_windows_exe_cmd(self, mock_os_chdir, mo, mock_exists):
+    @mock.patch("minigalaxy.launcher.wine_restore_game_link", MagicMock)
+    def test3_get_windows_exe_cmd(self, mock_os_chdir, mo, mock_exists, mock_wine_path):
+        mock_wine_path.return_value = "wine"
         goggame_1207658919_info_content = """{
         "buildId": "52095557858882770",
         "clientId": "49843178982252086",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -41,14 +41,48 @@ class Test(TestCase):
         obs = launcher.determine_launcher_type(files)
         self.assertEqual(exp, obs)
 
-    @mock.patch('os.path.exists')
-    @mock.patch('glob.glob')
-    def test1_get_windows_exe_cmd(self, mock_glob, mock_exists):
-        mock_glob.return_value = ["/test/install/dir/start.exe", "/test/install/dir/unins000.exe"]
-        mock_exists.return_value = True
-        files = ['thumbnail.jpg', 'docs', 'support', 'game', 'minigalaxy-dlc.json', 'start.exe', 'unins000.exe']
+    @mock.patch("minigalaxy.launcher.get_wine_path")
+    @mock.patch("minigalaxy.launcher.wine_restore_game_link", MagicMock)
+    def test1_get_windows_exe_cmd(self, mock_get_wine_path: MagicMock):
+        mock_get_wine_path.return_value = "/usr/bin/wine"
+        files = [
+            "thumbnail.jpg",
+            "docs",
+            "support",
+            "game",
+            "minigalaxy-dlc.json",
+            "unins000.exe",
+            "UnityCrashHandler64.exe",
+            "nglide_config.exe",
+            "ipxconfig.exe",
+            "BNUpdate.exe",
+            "VidSize.exe",
+            "FRED2.exe",
+            "FS2.exe",
+            "start.exe",
+        ]
         game = Game("Test Game", install_dir="/test/install/dir")
-        exp = ['env', 'WINEPREFIX=/test/install/dir/prefix', "wine", "start.exe"]
+        exp = ['env', 'WINEPREFIX=/test/install/dir/prefix', "/usr/bin/wine", "/test/install/dir/start.exe"]
+        obs = launcher.get_windows_exe_cmd(game, files)
+        self.assertEqual(exp, obs)
+
+    @mock.patch("minigalaxy.launcher.get_wine_path")
+    @mock.patch("minigalaxy.launcher.wine_restore_game_link", MagicMock)
+    def test1_get_windows_exe_cmd_prioritize_launch_lnk(self, mock_get_wine_path: MagicMock):
+        mock_get_wine_path.return_value = "/usr/bin/wine"
+        files = [
+            "thumbnail.jpg",
+            "docs",
+            "support",
+            "game",
+            "minigalaxy-dlc.json",
+            "run.exe",
+            "DOOM.exe",
+            "start.exe",
+            "Launch DOOM.lnk"
+        ]
+        game = Game("Test Game", install_dir="/test/install/dir")
+        exp = ['env', 'WINEPREFIX=/test/install/dir/prefix', "/usr/bin/wine", "/test/install/dir/Launch DOOM.lnk"]
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -86,6 +86,32 @@ class Test(TestCase):
         obs = launcher.get_windows_exe_cmd(game, files)
         self.assertEqual(exp, obs)
 
+    @mock.patch("minigalaxy.launcher.get_wine_path")
+    @mock.patch("minigalaxy.launcher.wine_restore_game_link", MagicMock)
+    def test1_get_windows_exe_cmd_can_choose_lnk(self, mock_get_wine_path: MagicMock):
+        mock_get_wine_path.return_value = "/usr/bin/wine"
+        files = [
+            "thumbnail.jpg",
+            "docs",
+            "support",
+            "game",
+            "minigalaxy-dlc.json",
+            "unins000.exe",
+            "UnityCrashHandler64.exe",
+            "nglide_config.exe",
+            "ipxconfig.exe",
+            "BNUpdate.exe",
+            "VidSize.exe",
+            "FRED2.exe",
+            "FS2.exe",
+            "start.lnk",
+            "start.exe",
+        ]
+        game = Game("Test Game", install_dir="/test/install/dir")
+        exp = ['env', 'WINEPREFIX=/test/install/dir/prefix', "/usr/bin/wine", "/test/install/dir/start.lnk"]
+        obs = launcher.get_windows_exe_cmd(game, files)
+        self.assertEqual(exp, obs)
+
     @mock.patch('os.path.exists')
     @mock.patch('builtins.open', new_callable=mock_open, read_data="")
     @mock.patch('os.chdir')


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

<!-- Describe what was changed -->
With this change we assume that the "Launch Game.lnk" file which every game installed through wine seems to have is the most likely candidate for being the game's entry point. When this does not exist, we have almost the same logic as before, but a bit cleaner and it includes lnk files. We can also blacklist certain file names now. I've updated the tests to include them.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
