### PR TITLE
Bugfix/download UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Use regedit to more permanently disable useless shortcut creation by wine from within a prefix (thanks to GB609)
 - Introduce a UI to show all active, stopped or failed downloads. Also allows to permanently pause a download (thanks to GB609)
 - Make more Windows games able to launch through Minigalaxy
+- The download UI also shows a rough size estimate if possible (thanks to GB609)
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/data/po/cs_CZ.po
+++ b/data/po/cs_CZ.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2022-09-24 10:17+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,7 +34,7 @@ msgctxt "about"
 msgid "About"
 msgstr "O aplikaci"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -144,11 +144,11 @@ msgid "Danish"
 msgstr "Dánština"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -170,12 +170,12 @@ msgstr "Chyba stahování"
 msgid "Downloading…"
 msgstr "Stahování…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -216,11 +216,11 @@ msgstr "Instalace {} se nezdařila"
 msgid "Failed to retrieve library"
 msgstr "Knihovnu se nepodařilo získat"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "{} se nezdařilo spustit:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -373,7 +373,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -382,7 +382,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr "Balík MangoHud nebyl nalezen. MangoHud nelze zapnout."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "{} neobsahuje žádný spustitelný soubor"
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -438,21 +438,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -510,7 +510,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -528,12 +528,12 @@ msgid "Reset wine executable"
 msgstr "Obnovit cestu k wine"
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -612,7 +612,7 @@ msgid "Stay logged in:"
 msgstr "Zapamatovat přihlášení:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr "Odinstalovat"
 msgid "Uninstalling…"
 msgstr "Odinstalace…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -788,6 +788,16 @@ msgstr "Balík Winetricks nebyl nalezen a nemůže být použit."
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "neznámé"
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
+msgstr ""
 
 #: minigalaxy/installer.py:145
 msgid "{} could not be unzipped."

--- a/data/po/de.po
+++ b/data/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: minigalaxy 0.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2025-02-26 13:03+0000\n"
 "Last-Translator: Akin Yildiz <akin.yildiz@protonmail.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/minigalaxy/"
@@ -35,7 +35,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Info"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -143,11 +143,11 @@ msgid "Danish"
 msgstr "Dänisch"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -168,12 +168,12 @@ msgstr "Download-Fehler"
 msgid "Downloading…"
 msgstr "Wird heruntergeladen…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -217,11 +217,11 @@ msgstr "Fehler beim Installieren von {}"
 msgid "Failed to retrieve library"
 msgstr "Fehler beim Abrufen der Bibliothek"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Fehler beim Starten von {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -377,7 +377,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -388,7 +388,7 @@ msgstr ""
 "MangoHud wurde nicht gefunden. Das Nutzen von MangoHud kann nicht aktiviert "
 "werden."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Es wurden keine Ausführbaren Dateien in  {} gefunden"
 
@@ -425,7 +425,7 @@ msgstr "Winecfg für dieses Spiel öffnen"
 msgid "Open Winetricks for this game"
 msgstr "Winetricks für dieses Spiel öffnen"
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -445,21 +445,21 @@ msgid "Options menu"
 msgstr "Optionsmenü"
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -517,7 +517,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -534,12 +534,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -618,7 +618,7 @@ msgid "Stay logged in:"
 msgstr "Angemeldet bleiben:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -696,7 +696,7 @@ msgstr "Deinstallieren"
 msgid "Uninstalling…"
 msgstr "Wird deinstalliert…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -801,6 +801,16 @@ msgstr ""
 
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
 msgstr ""
 
 #: minigalaxy/installer.py:145

--- a/data/po/el.po
+++ b/data/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2024-04-01 03:37+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,7 +34,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Περί"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -146,11 +146,11 @@ msgid "Danish"
 msgstr "Δανέζικα"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -171,12 +171,12 @@ msgstr "Σφάλμα κατα την διαρκεια κατεβασματος"
 msgid "Downloading…"
 msgstr "Ενυμέρωση…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -222,11 +222,11 @@ msgstr "Αδυναμία εγκατάστασης {}"
 msgid "Failed to retrieve library"
 msgstr "Αδυναμία εύρεσης βιβλιοθήκης"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Αδυναμία έναρξης {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -380,7 +380,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -391,7 +391,7 @@ msgstr ""
 "Αποτυχία εύρεσης του MangoHud. Δεν είναι δυνατή η ενεργοποιήσει χρίσης "
 "MangoHud."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Αποτυχία εύρεσης εκτελέσιμου {}"
 
@@ -429,7 +429,7 @@ msgstr "Άνοιγμα του Winecfg για αυτό το παιχνίδι"
 msgid "Open Winetricks for this game"
 msgstr "Άνοιγμα Winetricks για αυτό το παιχνίδι"
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -449,21 +449,21 @@ msgid "Options menu"
 msgstr "Μενού επιλογών"
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -521,7 +521,7 @@ msgid "Regedit"
 msgstr "Επεξεργασία μητρώου wine"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -538,12 +538,12 @@ msgid "Reset wine executable"
 msgstr "Επαναφορά εκτελέσιμου wine"
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -620,7 +620,7 @@ msgid "Stay logged in:"
 msgstr "Διατήρηση Σύνδεσης:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr "Απεγκατάσταση"
 msgid "Uninstalling…"
 msgstr "Απ εγκαθίσταται…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -799,6 +799,16 @@ msgstr "Αποτυχία εύρεσης winetricks.Δεν είναι δυνατ�
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "άγνωστο"
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
+msgstr ""
 
 #: minigalaxy/installer.py:145
 msgid "{} could not be unzipped."

--- a/data/po/es_AR.po
+++ b/data/po/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2021-10-07 18:22+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,7 +34,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Acerca de"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -147,11 +147,11 @@ msgid "Danish"
 msgstr "Danés"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -174,12 +174,12 @@ msgstr "Error en la descarga"
 msgid "Downloading…"
 msgstr "Descargando…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -220,11 +220,11 @@ msgstr "No se pudo instalar {}"
 msgid "Failed to retrieve library"
 msgstr "No se pudo recuperar la biblioteca"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "No se pudo iniciar {}"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -379,7 +379,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -390,7 +390,7 @@ msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr ""
 "No se encontro Wine. Mostrar los juegos para Windows no se puede activar"
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "No se encontró ningún ejecutable en {}"
 
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -450,21 +450,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -522,7 +522,7 @@ msgid "Regedit"
 msgstr ""
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -539,12 +539,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -625,7 +625,7 @@ msgid "Stay logged in:"
 msgstr "Permanecer conectado:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -707,7 +707,7 @@ msgstr "Desinstalar"
 msgid "Uninstalling…"
 msgstr "Desinstalando…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -810,6 +810,16 @@ msgstr ""
 
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
 msgstr ""
 
 #: minigalaxy/installer.py:145

--- a/data/po/es_ES.po
+++ b/data/po/es_ES.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2023-02-21 13:26-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,7 +34,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Acerca de"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -142,11 +142,11 @@ msgid "Danish"
 msgstr "Danés"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -168,12 +168,12 @@ msgstr "Error en la descarga"
 msgid "Downloading…"
 msgstr "Descargando…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -214,11 +214,11 @@ msgstr "No se ha podido instalar {}"
 msgid "Failed to retrieve library"
 msgstr "No se ha podido recuperar la biblioteca"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "No se ha podido iniciar {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -372,7 +372,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -382,7 +382,7 @@ msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr ""
 "No se ha encontrado MangoHud. No es posible activar el uso de MangoHud."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "No se ha encontrado ningún ejecutable en {}"
 
@@ -420,7 +420,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -440,21 +440,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -512,7 +512,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -530,12 +530,12 @@ msgid "Reset wine executable"
 msgstr "Restablecer ejecutable de wine"
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgid "Stay logged in:"
 msgstr "Permanecer conectado:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -691,7 +691,7 @@ msgstr "Desinstalar"
 msgid "Uninstalling…"
 msgstr "Desinstalando…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -792,6 +792,16 @@ msgstr "No se ha encontrado Winetricks y no se puede utilizar."
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "desconocido"
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
+msgstr ""
 
 #: minigalaxy/installer.py:145
 msgid "{} could not be unzipped."

--- a/data/po/fi.po
+++ b/data/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2021-09-30 12:59+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -35,7 +35,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Tietoja"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -146,11 +146,11 @@ msgid "Danish"
 msgstr "Tanska"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -172,12 +172,12 @@ msgstr "Latausvirhe"
 msgid "Downloading…"
 msgstr "Ladataan…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -216,11 +216,11 @@ msgstr "{} asentaminen epäonnistui"
 msgid "Failed to retrieve library"
 msgstr "Kirjaston noutaminen epäonnistui"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Kohteen {} käynnistäminen epäonnistui:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -375,7 +375,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -386,7 +386,7 @@ msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr ""
 "Wine-ohjelmaa ei löytynyt. Windows-pelien näyttämistä ei voida kytkeä päälle."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Ajettavaa käynnistystiedostoa ei löytynyt kohteelle {}"
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -443,21 +443,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -515,7 +515,7 @@ msgid "Regedit"
 msgstr "Regedit-muokkaus"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -532,12 +532,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -616,7 +616,7 @@ msgid "Stay logged in:"
 msgstr "Pysy kirjautuneena:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr "Poista asennus"
 msgid "Uninstalling…"
 msgstr "Poistetaan asennusta…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -796,6 +796,16 @@ msgstr ""
 
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
 msgstr ""
 
 #: minigalaxy/installer.py:145

--- a/data/po/fr.po
+++ b/data/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2021-10-23 16:33+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,7 +34,7 @@ msgctxt "about"
 msgid "About"
 msgstr "À propos"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -145,11 +145,11 @@ msgid "Danish"
 msgstr "Danois"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -171,12 +171,12 @@ msgstr "Erreur de téléchargement"
 msgid "Downloading…"
 msgstr "Téléchargement…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -215,11 +215,11 @@ msgstr "Impossible de démarrer {} :"
 msgid "Failed to retrieve library"
 msgstr "Impossible de récupérer la bibliothèque"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Impossible de démarrer {} :"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -375,7 +375,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -387,7 +387,7 @@ msgstr ""
 "Wine n'a pas été trouvé. L'affichage des jeux Windows ne peut pas être "
 "activé."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Aucun exécutable n'a été trouvé dans {}"
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -443,21 +443,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -515,7 +515,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -532,12 +532,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -616,7 +616,7 @@ msgid "Stay logged in:"
 msgstr "Rester connecté :"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr "Désinstaller"
 msgid "Uninstalling…"
 msgstr "Désinstallation…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -799,6 +799,16 @@ msgstr ""
 
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
 msgstr ""
 
 #: minigalaxy/installer.py:145

--- a/data/po/it_IT.po
+++ b/data/po/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2025-02-27 17:02+0000\n"
 "Last-Translator: nexal <driftlock@proton.me>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/minigalaxy/"
@@ -35,7 +35,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Informazioni"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -148,11 +148,11 @@ msgid "Danish"
 msgstr "Danese"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -173,12 +173,12 @@ msgstr "Errore di download"
 msgid "Downloading…"
 msgstr "Scaricando…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -217,11 +217,11 @@ msgstr "Installazione di {} fallita"
 msgid "Failed to retrieve library"
 msgstr "Recupero della libreria fallito"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Apertura di {} fallita:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -376,7 +376,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -388,7 +388,7 @@ msgstr ""
 "Wine non è stato trovato. Non potrai abilitare la Visualizzazione dei giochi "
 "di Windows."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Nessun eseguibile trovato in {}"
 
@@ -424,7 +424,7 @@ msgstr "Apri Winecfg per questo gioco"
 msgid "Open Winetricks for this game"
 msgstr "Apri Winetricks per questo gioco"
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -444,21 +444,21 @@ msgid "Options menu"
 msgstr "Menu di opzioni"
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -516,7 +516,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -533,12 +533,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Stay logged in:"
 msgstr "Mantieni l'accesso:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -692,7 +692,7 @@ msgstr "Disinstalla"
 msgid "Uninstalling…"
 msgstr "Disinstallando…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -797,6 +797,16 @@ msgstr ""
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "sconosciuto"
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
+msgstr ""
 
 #: minigalaxy/installer.py:145
 msgid "{} could not be unzipped."

--- a/data/po/minigalaxy.pot
+++ b/data/po/minigalaxy.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-05 11:30+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,7 @@ msgctxt "about"
 msgid "About"
 msgstr ""
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -141,11 +141,11 @@ msgid "Danish"
 msgstr ""
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -166,12 +166,12 @@ msgstr ""
 msgid "Downloading…"
 msgstr ""
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -210,11 +210,11 @@ msgstr ""
 msgid "Failed to retrieve library"
 msgstr ""
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr ""
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -364,7 +364,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr ""
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr ""
 
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -429,21 +429,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -501,7 +501,7 @@ msgid "Regedit"
 msgstr ""
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -518,12 +518,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgid "Stay logged in:"
 msgstr ""
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -674,7 +674,7 @@ msgstr ""
 msgid "Uninstalling…"
 msgstr ""
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -769,6 +769,16 @@ msgstr ""
 
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
 msgstr ""
 
 #: minigalaxy/installer.py:145

--- a/data/po/nb_NO.po
+++ b/data/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2021-11-10 14:20+0100\n"
 "Last-Translator: Kim Malmo <berencamlost@msn.com>\n"
 "Language-Team: \n"
@@ -34,7 +34,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Om"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -144,11 +144,11 @@ msgid "Danish"
 msgstr "Dansk"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -170,12 +170,12 @@ msgstr "Feil ved nedlasting"
 msgid "Downloading…"
 msgstr "Laster ned…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -216,11 +216,11 @@ msgstr "Kunne ikke installere {}:"
 msgid "Failed to retrieve library"
 msgstr "Kunne ikke hente bibliotek"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Kunne ikke starte {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -373,7 +373,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -382,7 +382,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr "MangoHud ble ikke funnet. MangoHud kan ikke aktiveres."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Ingen kjørbar fil funnet i {}"
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -438,21 +438,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -510,7 +510,7 @@ msgid "Regedit"
 msgstr ""
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -527,12 +527,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -611,7 +611,7 @@ msgid "Stay logged in:"
 msgstr "Forbli pålogget:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -688,7 +688,7 @@ msgstr "Avinstaller"
 msgid "Uninstalling…"
 msgstr "Avinstallerer…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -786,6 +786,16 @@ msgstr "Winetricks ble ikke funnet. Winetricks kan ikke aktiveres."
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "ukjent"
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
+msgstr ""
 
 #: minigalaxy/installer.py:145
 msgid "{} could not be unzipped."

--- a/data/po/nl.po
+++ b/data/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: minigalaxy 0.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-05 11:30+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2025-02-26 11:02+0000\n"
 "Last-Translator: Wouter Wijsman <wwijsman@live.nl>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/minigalaxy/"
@@ -35,7 +35,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Over Minigalaxy"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -148,11 +148,11 @@ msgid "Danish"
 msgstr "Deens"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -174,12 +174,12 @@ msgstr "Downloadfout"
 msgid "Downloading…"
 msgstr "Downloaden…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -218,11 +218,11 @@ msgstr "Kon {} niet geïnstalleerd worden:"
 msgid "Failed to retrieve library"
 msgstr "De lijst me games kon niet opgehaald worden"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Kon {} niet starten:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -378,7 +378,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -390,7 +390,7 @@ msgstr ""
 "Wine kon niet gevonden worden. Het tonen van Windows games kan niet aangezet "
 "worden."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Geen programma gevonden in {}"
 
@@ -426,7 +426,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -446,21 +446,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -518,7 +518,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -535,12 +535,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -619,7 +619,7 @@ msgid "Stay logged in:"
 msgstr "Blijf ingelogd:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr "Verwijderen"
 msgid "Uninstalling…"
 msgstr "Verwijderen…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -803,6 +803,16 @@ msgstr ""
 
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
 msgstr ""
 
 #: minigalaxy/installer.py:145

--- a/data/po/nn_NO.po
+++ b/data/po/nn_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2021-10-04 11:33+0200\n"
 "Last-Translator: Jan Kjetil Myklebust\n"
 "Language-Team: \n"
@@ -34,7 +34,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Om"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -145,11 +145,11 @@ msgid "Danish"
 msgstr "Dansk"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -171,12 +171,12 @@ msgstr "Nedlastingsfeil"
 msgid "Downloading…"
 msgstr "Lastar ned…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -215,11 +215,11 @@ msgstr "Klarte ikkje å installere {}"
 msgid "Failed to retrieve library"
 msgstr "Klarte ikkje å hente bibliotek"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Klarte ikkje å starte {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -373,7 +373,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -383,7 +383,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr "Fann ikkje Wine. Kan ikkje skru på vising av Windows-spel."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Inga køyrbar fil funnen i {}"
 
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -439,21 +439,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -511,7 +511,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -528,12 +528,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -612,7 +612,7 @@ msgid "Stay logged in:"
 msgstr "Bli verande pålogga:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -690,7 +690,7 @@ msgstr "Avinstaller"
 msgid "Uninstalling…"
 msgstr "Avinstallerar…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -789,6 +789,16 @@ msgstr "Fann ikkje Wine. Kan ikkje skru på vising av Windows-spel."
 
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
 msgstr ""
 
 #: minigalaxy/installer.py:145

--- a/data/po/pl.po
+++ b/data/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2025-02-27 17:02+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/minigalaxy/"
@@ -36,7 +36,7 @@ msgctxt "about"
 msgid "About"
 msgstr "O programie"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -147,11 +147,11 @@ msgid "Danish"
 msgstr "Duński"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -173,12 +173,12 @@ msgstr "Błąd pobierania"
 msgid "Downloading…"
 msgstr "Pobieranie…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -217,11 +217,11 @@ msgstr "Instalacja {} nie powiodła się"
 msgid "Failed to retrieve library"
 msgstr "Nie można pobrać biblioteki"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Nie można uruchomić {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -377,7 +377,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -389,7 +389,7 @@ msgstr ""
 "Wine nie został znaleziony. Nie można włączyć wyświetlania gier systemu "
 "Windows."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Nie znaleziono pliku wykonywalnego w {}"
 
@@ -425,7 +425,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -445,21 +445,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -517,7 +517,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -534,12 +534,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -617,7 +617,7 @@ msgid "Stay logged in:"
 msgstr "Pozostań zalogowany:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr "Odinstaluj"
 msgid "Uninstalling…"
 msgstr "Odinstalowywanie…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -801,6 +801,16 @@ msgstr ""
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "nieznane"
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
+msgstr ""
 
 #: minigalaxy/installer.py:145
 msgid "{} could not be unzipped."

--- a/data/po/pt_BR.po
+++ b/data/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2020-11-17 03:06-0300\n"
 "Last-Translator: Esdras Tarsis <esdrastarsis@gmail.com>\n"
 "Language-Team: \n"
@@ -34,7 +34,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Sobre"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -147,11 +147,11 @@ msgid "Danish"
 msgstr "Dinamarquês"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -173,12 +173,12 @@ msgstr "Erro ao baixar"
 msgid "Downloading…"
 msgstr "Baixando…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -217,11 +217,11 @@ msgstr "Falha ao instalar {}"
 msgid "Failed to retrieve library"
 msgstr "Falha ao recuperar a biblioteca"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Falha ao iniciar {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -374,7 +374,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -383,7 +383,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr ""
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Nenhum executável foi encontrado em {}"
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -441,21 +441,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -513,7 +513,7 @@ msgid "Regedit"
 msgstr ""
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -530,12 +530,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -616,7 +616,7 @@ msgid "Stay logged in:"
 msgstr "Permanecer conectado:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr "Desinstalar"
 msgid "Uninstalling…"
 msgstr "Desinstalando…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -797,6 +797,16 @@ msgstr ""
 
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
 msgstr ""
 
 #: minigalaxy/installer.py:145

--- a/data/po/pt_PT.po
+++ b/data/po/pt_PT.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2024-08-28 12:44+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -28,7 +28,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Sobre"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -136,11 +136,11 @@ msgid "Danish"
 msgstr "Dinamarquês"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -161,12 +161,12 @@ msgstr "Erro ao descarregar"
 msgid "Downloading…"
 msgstr "A descarregar…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -205,11 +205,11 @@ msgstr "Falha ao instalar {}"
 msgid "Failed to retrieve library"
 msgstr "Falha ao descarregar biblioteca"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Falha ao iniciar {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -361,7 +361,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -370,7 +370,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr "MangoHud não foi encontrado."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Nenhum executável foi encontrado em {}"
 
@@ -408,7 +408,7 @@ msgstr "Abrir Winecfg para este jogo"
 msgid "Open Winetricks for this game"
 msgstr "Abrir Winetricks para este jogo"
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -428,21 +428,21 @@ msgid "Options menu"
 msgstr "Menu de Opções"
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -500,7 +500,7 @@ msgid "Regedit"
 msgstr ""
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -517,12 +517,12 @@ msgid "Reset wine executable"
 msgstr "Reiniciar o executável Wine"
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgid "Stay logged in:"
 msgstr "Manter-se ligado:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -675,7 +675,7 @@ msgstr "Desinstalar"
 msgid "Uninstalling…"
 msgstr "A desinstalar…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -772,6 +772,16 @@ msgstr "Winetricks não foi encontrado e não pode ser usado."
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "desconhecido"
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
+msgstr ""
 
 #: minigalaxy/installer.py:145
 msgid "{} could not be unzipped."

--- a/data/po/ro.po
+++ b/data/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2021-09-29 19:02+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -35,7 +35,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Despre"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -146,11 +146,11 @@ msgid "Danish"
 msgstr "Danez"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -172,12 +172,12 @@ msgstr "Eroare de descărcare"
 msgid "Downloading…"
 msgstr "Se descarcă…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -218,11 +218,11 @@ msgstr "Nu s-a putut instala {}"
 msgid "Failed to retrieve library"
 msgstr "Nu s-a putut descărca libraria"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Nu s-a putut porni {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -376,7 +376,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -386,7 +386,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr "Wine nu a fost găsit. Arătarea jocurilor Windows nu poate fi pornită."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Nici-un executabil nu a fost găsit în {}"
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -443,21 +443,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -515,7 +515,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -532,12 +532,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -616,7 +616,7 @@ msgid "Stay logged in:"
 msgstr "Rămâi conectat:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr "Dezinstalează"
 msgid "Uninstalling…"
 msgstr "Se dezinstalează…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -795,6 +795,16 @@ msgstr "Wine nu a fost găsit. Arătarea jocurilor Windows nu poate fi pornită.
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "necunoscut"
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
+msgstr ""
 
 #: minigalaxy/installer.py:145
 msgid "{} could not be unzipped."

--- a/data/po/ru_RU.po
+++ b/data/po/ru_RU.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2025-03-04 14:02+0000\n"
 "Last-Translator: AnanaSeek4Jam <furryananasik@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/minigalaxy/"
@@ -37,7 +37,7 @@ msgctxt "about"
 msgid "About"
 msgstr "О Minigalaxy"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -148,11 +148,11 @@ msgid "Danish"
 msgstr "Датский"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -174,12 +174,12 @@ msgstr "Ошибка загрузки"
 msgid "Downloading…"
 msgstr "Скачивание…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -225,11 +225,11 @@ msgstr "Не удалось установить {}"
 msgid "Failed to retrieve library"
 msgstr "Не удалось получить библиотеку"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Не удалось запустить {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -382,7 +382,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -391,7 +391,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr "MangoHud не может быть включен: его не удалось найти."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Не найден запускаемый файл в {}"
 
@@ -427,7 +427,7 @@ msgstr "Открыть Winecfg для этой игры"
 msgid "Open Winetricks for this game"
 msgstr "Открыть Winetricks для этой игры"
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -447,21 +447,21 @@ msgid "Options menu"
 msgstr "Меню настроек"
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -519,7 +519,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -537,12 +537,12 @@ msgid "Reset wine executable"
 msgstr "Сбросить запускаемый файл wine"
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -621,7 +621,7 @@ msgid "Stay logged in:"
 msgstr "Не выходить из системы:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr "Удалить"
 msgid "Uninstalling…"
 msgstr "Удаление…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -797,6 +797,16 @@ msgstr "Winetricks не может быть включен: его не удал
 #, fuzzy
 msgid "unknown"
 msgstr "неизвестно"
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
+msgstr ""
 
 #: minigalaxy/installer.py:145
 msgid "{} could not be unzipped."

--- a/data/po/sv_SE.po
+++ b/data/po/sv_SE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2021-10-01 12:46+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,7 +34,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Om"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -145,11 +145,11 @@ msgid "Danish"
 msgstr "Danska"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -171,12 +171,12 @@ msgstr "Nedladdningsfel"
 msgid "Downloading…"
 msgstr "Laddar ner…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -215,11 +215,11 @@ msgstr "Misslyckades att installera {}"
 msgid "Failed to retrieve library"
 msgstr "Misslyckades att hämta bibliotek"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Misslyckades att starta {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -373,7 +373,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -383,7 +383,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr "Wine kunde inte hittas. Visning av Windowsspel kan inte slås på."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "Ingen körbar fil hittades i {}"
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -442,21 +442,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -514,7 +514,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -531,12 +531,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Stay logged in:"
 msgstr "Håll mig inloggad:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -693,7 +693,7 @@ msgstr "Avinstallera"
 msgid "Uninstalling…"
 msgstr "Avinstallerar…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -793,6 +793,16 @@ msgstr "Wine kunde inte hittas. Visning av Windowsspel kan inte slås på."
 
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
 msgstr ""
 
 #: minigalaxy/installer.py:145

--- a/data/po/tr.po
+++ b/data/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2021-09-30 11:22+0300\n"
 "Last-Translator: Hüseyin Fahri Uzun <mail@fahriuzun.com>\n"
 "Language-Team: \n"
@@ -34,7 +34,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Hakkında"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -145,11 +145,11 @@ msgid "Danish"
 msgstr "Danimarka Dili"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -171,12 +171,12 @@ msgstr "İndirme hatası"
 msgid "Downloading…"
 msgstr "Indirliyor…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -215,11 +215,11 @@ msgstr "{} yüklenemedi:"
 msgid "Failed to retrieve library"
 msgstr "Kütüphane alınamadı"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "{} başlatılamadı:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -373,7 +373,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -383,7 +383,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr "Wine bulunamadı. Windows oyunlarının gösterimi etkinleştirilemez."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "{} burada başlatma dosyası bulunamadı"
 
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -439,21 +439,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -511,7 +511,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -528,12 +528,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -612,7 +612,7 @@ msgid "Stay logged in:"
 msgstr "Çevrimci tut:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -688,7 +688,7 @@ msgstr "Kaldır"
 msgid "Uninstalling…"
 msgstr "Siliniyor…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -786,6 +786,16 @@ msgstr "Wine bulunamadı. Windows oyunlarının gösterimi etkinleştirilemez."
 
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
 msgstr ""
 
 #: minigalaxy/installer.py:145

--- a/data/po/uk.po
+++ b/data/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2025-02-27 17:02+0000\n"
 "Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/minigalaxy/"
@@ -36,7 +36,7 @@ msgctxt "about"
 msgid "About"
 msgstr "Про MiniGalaxy"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -144,11 +144,11 @@ msgid "Danish"
 msgstr "Датська"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -169,12 +169,12 @@ msgstr "Помилка при завантаженні"
 msgid "Downloading…"
 msgstr "Завантаження…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -219,11 +219,11 @@ msgstr "Не вдалося встановити {}"
 msgid "Failed to retrieve library"
 msgstr "Не вдалося отримати бібліотеку"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "Не вдалося запустити {}:"
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -375,7 +375,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -384,7 +384,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr "MangoHud не знайдено. Його не можна ввімкнути."
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "У {} не знайдено жодного виконуваного файлу"
 
@@ -420,7 +420,7 @@ msgstr "Відкрити Winecfg для цієї гри"
 msgid "Open Winetricks for this game"
 msgstr "Відкрити Winetricks для цієї гри"
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -440,21 +440,21 @@ msgid "Options menu"
 msgstr "Меню налаштувань"
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -512,7 +512,7 @@ msgid "Regedit"
 msgstr "Regedit"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -529,12 +529,12 @@ msgid "Reset wine executable"
 msgstr "Скинути виконуваний файл Wine"
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -611,7 +611,7 @@ msgid "Stay logged in:"
 msgstr "Залишатися в системі:"
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -687,7 +687,7 @@ msgstr "Видалити"
 msgid "Uninstalling…"
 msgstr "Видалення…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -786,6 +786,16 @@ msgstr "Winetricks не знайдено і не може бути викори�
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "невідомо"
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
+msgstr ""
 
 #: minigalaxy/installer.py:145
 msgid "{} could not be unzipped."

--- a/data/po/zh_CN.po
+++ b/data/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2021-11-06 23:37+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,7 +34,7 @@ msgctxt "about"
 msgid "About"
 msgstr "关于"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -145,11 +145,11 @@ msgid "Danish"
 msgstr "丹麦语"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -171,12 +171,12 @@ msgstr "下载错误"
 msgid "Downloading…"
 msgstr "正在下载…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -215,11 +215,11 @@ msgstr "安装 {} 失败"
 msgid "Failed to retrieve library"
 msgstr "获取游戏库失败"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "启动 {} 失败："
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -371,7 +371,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -381,7 +381,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr "未找到 Wine。无法启用显示 Windows 游戏"
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "在 {} 内未找到可执行文件"
 
@@ -417,7 +417,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -437,21 +437,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -509,7 +509,7 @@ msgid "Regedit"
 msgstr "注册表"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -526,12 +526,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -610,7 +610,7 @@ msgid "Stay logged in:"
 msgstr "保持登录："
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -688,7 +688,7 @@ msgstr "卸载"
 msgid "Uninstalling…"
 msgstr "正在卸载…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -786,6 +786,16 @@ msgstr "未找到 Wine。无法启用显示 Windows 游戏"
 
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
 msgstr ""
 
 #: minigalaxy/installer.py:145

--- a/data/po/zh_TW.po
+++ b/data/po/zh_TW.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-04 20:22+0100\n"
+"POT-Creation-Date: 2025-03-06 11:16+0100\n"
 "PO-Revision-Date: 2023-03-19 20:48+0800\n"
 "Last-Translator: Jeff Huang <s8321414@gmail.com>\n"
 "Language-Team: Chinese <zh-l10n@linux.org.tw>\n"
@@ -33,7 +33,7 @@ msgctxt "about"
 msgid "About"
 msgstr "關於"
 
-#: data/ui/download_list.ui:23
+#: data/ui/download_list.ui:28
 msgctxt "download_group"
 msgid "Active Downloads:"
 msgstr ""
@@ -144,11 +144,11 @@ msgid "Danish"
 msgstr "丹麥文"
 
 #. Tooltip of icon button to delete a downloaded file
-#: minigalaxy/ui/download_list.py:250
+#: minigalaxy/ui/download_list.py:289
 msgid "Delete file"
 msgstr ""
 
-#: data/ui/download_list.ui:116
+#: data/ui/download_list.ui:121
 msgctxt "download_group"
 msgid "Done:"
 msgstr ""
@@ -170,12 +170,12 @@ msgstr "下載錯誤"
 msgid "Downloading…"
 msgstr "正在下載…"
 
-#: data/ui/download_list.ui:115
+#: data/ui/download_list.ui:120
 msgctxt "download_group"
 msgid "Downloads that completed, failed or were stopped."
 msgstr ""
 
-#: data/ui/download_list.ui:53
+#: data/ui/download_list.ui:58
 msgctxt "download_group"
 msgid "Downloads waiting for a free worker slot."
 msgstr ""
@@ -214,11 +214,11 @@ msgstr "安裝 {} 失敗"
 msgid "Failed to retrieve library"
 msgstr "擷取收藏庫失敗"
 
-#: minigalaxy/launcher.py:60 minigalaxy/ui/library_entry.py:109
+#: minigalaxy/launcher.py:61 minigalaxy/ui/library_entry.py:109
 msgid "Failed to start {}:"
 msgstr "啟動 {} 失敗："
 
-#: data/ui/download_list.ui:22
+#: data/ui/download_list.ui:27
 msgctxt "download_group"
 msgid "Files being actively downloaded."
 msgstr ""
@@ -372,7 +372,7 @@ msgid "Manage downloads"
 msgstr ""
 
 #. Klick on button will open file explorer to manage downloaded installers
-#: data/ui/download_list.ui:173
+#: data/ui/download_list.ui:178
 msgctxt "game_download_management"
 msgid "Manage installers"
 msgstr ""
@@ -382,7 +382,7 @@ msgstr ""
 msgid "MangoHud wasn't found. Using MangoHud cannot be enabled."
 msgstr "找不到 Wine。無法啟用顯示 Windows 遊戲。"
 
-#: minigalaxy/launcher.py:230
+#: minigalaxy/launcher.py:246
 msgid "No executable was found in {}"
 msgstr "在 {} 找不到可執行檔"
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Open Winetricks for this game"
 msgstr ""
 
-#: data/ui/download_list.ui:147
+#: data/ui/download_list.ui:152
 msgctxt "game_download_management"
 msgid "Open file manager at location where installers are saved"
 msgstr ""
@@ -438,21 +438,21 @@ msgid "Options menu"
 msgstr ""
 
 #. Tooltip of icon button to pause a download
-#: minigalaxy/ui/download_list.py:241
+#: minigalaxy/ui/download_list.py:280
 msgid "Pause"
 msgstr ""
 
-#: data/ui/download_list.ui:84
+#: data/ui/download_list.ui:89
 msgctxt "download_group"
 msgid "Paused downlods will not automatically resume."
 msgstr ""
 
-#: data/ui/download_list.ui:85
+#: data/ui/download_list.ui:90
 msgctxt "download_group"
 msgid "Paused:"
 msgstr ""
 
-#: data/ui/download_list.ui:54
+#: data/ui/download_list.ui:59
 msgctxt "download_group"
 msgid "Pending:"
 msgstr ""
@@ -510,7 +510,7 @@ msgid "Regedit"
 msgstr "登錄檔編輯"
 
 #. Tooltip of icon button which removes a download from the ui list of downloads
-#: minigalaxy/ui/download_list.py:253
+#: minigalaxy/ui/download_list.py:292
 msgid "Remove from list"
 msgstr ""
 
@@ -527,12 +527,12 @@ msgid "Reset wine executable"
 msgstr ""
 
 #. Tooltip of icon button for download (re)start
-#: minigalaxy/ui/download_list.py:238
+#: minigalaxy/ui/download_list.py:277
 msgid "Resume"
 msgstr ""
 
 #. Tooltip of icon button to retry a failed or canceled download
-#: minigalaxy/ui/download_list.py:244
+#: minigalaxy/ui/download_list.py:283
 msgid "Retry"
 msgstr ""
 
@@ -611,7 +611,7 @@ msgid "Stay logged in:"
 msgstr "保持登入："
 
 #. Tooltip of icon button to stop an active or queued download
-#: minigalaxy/ui/download_list.py:247
+#: minigalaxy/ui/download_list.py:286
 msgid "Stop"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr "解除安裝"
 msgid "Uninstalling…"
 msgstr "正在解除安裝…"
 
-#: minigalaxy/ui/download_list.py:87
+#: minigalaxy/ui/download_list.py:91
 msgid "Unknown error"
 msgstr ""
 
@@ -788,6 +788,16 @@ msgstr "找不到 Wine。無法啟用顯示 Windows 遊戲。"
 #: minigalaxy/ui/information.py:137
 msgid "unknown"
 msgstr "未知"
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:216
+msgid "{} GB"
+msgstr ""
+
+#. game size estimate for download ui
+#: minigalaxy/ui/download_list.py:219
+msgid "{} MB"
+msgstr ""
 
 #: minigalaxy/installer.py:145
 msgid "{} could not be unzipped."

--- a/data/ui/download_list.ui
+++ b/data/ui/download_list.ui
@@ -2,190 +2,197 @@
 <!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <template class="DownloadList" parent="GtkViewport">
+  <template class="DownloadList" parent="GtkScrolledWindow">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="shadow-type">none</property>
-    <signal name="map" handler="manage_button_visibility" swapped="no"/>
+    <property name="can-focus">True</property>
+    <property name="hscrollbar-policy">never</property>
     <child>
-      <object class="GtkBox">
+      <object class="GtkViewport">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="margin-start">3</property>
-        <property name="margin-end">3</property>
-        <property name="margin-top">3</property>
-        <property name="margin-bottom">3</property>
-        <property name="orientation">vertical</property>
+        <property name="shadow-type">none</property>
+        <signal name="map" handler="manage_button_visibility" swapped="no"/>
         <child>
-          <object class="GtkLabel" id="label_active">
+          <object class="GtkBox" id="content_box">
+            <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes" context="download_group">Files being actively downloaded.</property>
-            <property name="label" translatable="yes" context="download_group">Active Downloads:</property>
-            <property name="xalign">0.05000000074505806</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkFlowBox" id="flowbox_active">
-            <property name="can-focus">False</property>
-            <property name="valign">start</property>
-            <property name="border-width">10</property>
-            <property name="homogeneous">True</property>
-            <property name="column-spacing">15</property>
-            <property name="row-spacing">10</property>
-            <property name="max-children-per-line">1</property>
-            <property name="selection-mode">none</property>
-            <property name="activate-on-single-click">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="label_queued">
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes" context="download_group">Downloads waiting for a free worker slot.</property>
-            <property name="label" translatable="yes" context="download_group">Pending:</property>
-            <property name="xalign">0.05000000074505806</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkFlowBox" id="flowbox_queued">
-            <property name="can-focus">False</property>
-            <property name="valign">start</property>
-            <property name="border-width">10</property>
-            <property name="homogeneous">True</property>
-            <property name="column-spacing">15</property>
-            <property name="row-spacing">10</property>
-            <property name="max-children-per-line">1</property>
-            <property name="selection-mode">none</property>
-            <property name="activate-on-single-click">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="label_paused">
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes" context="download_group">Paused downlods will not automatically resume.</property>
-            <property name="label" translatable="yes" context="download_group">Paused:</property>
-            <property name="xalign">0.05000000074505806</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkFlowBox" id="flowbox_paused">
-            <property name="can-focus">False</property>
-            <property name="valign">start</property>
-            <property name="border-width">10</property>
-            <property name="homogeneous">True</property>
-            <property name="column-spacing">15</property>
-            <property name="row-spacing">10</property>
-            <property name="max-children-per-line">1</property>
-            <property name="selection-mode">none</property>
-            <property name="activate-on-single-click">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">5</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="label_done">
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes" context="download_group">Downloads that completed, failed or were stopped.</property>
-            <property name="label" translatable="yes" context="download_group">Done:</property>
-            <property name="xalign">0.05000000074505806</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">6</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkFlowBox" id="flowbox_done">
-            <property name="can-focus">False</property>
-            <property name="valign">start</property>
-            <property name="border-width">10</property>
-            <property name="homogeneous">True</property>
-            <property name="column-spacing">15</property>
-            <property name="row-spacing">10</property>
-            <property name="max-children-per-line">1</property>
-            <property name="selection-mode">none</property>
-            <property name="activate-on-single-click">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">7</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="button_manage_installers">
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="tooltip-text" translatable="yes" context="game_download_management">Open file manager at location where installers are saved</property>
-            <property name="halign">center</property>
-            <property name="valign">center</property>
-            <property name="always-show-image">True</property>
-            <signal name="clicked" handler="on_manage_button" swapped="no"/>
+            <property name="margin-start">3</property>
+            <property name="margin-end">3</property>
+            <property name="margin-top">3</property>
+            <property name="margin-bottom">3</property>
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
+              <object class="GtkLabel" id="label_active">
                 <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="download_group">Files being actively downloaded.</property>
+                <property name="label" translatable="yes" context="download_group">Active Downloads:</property>
+                <property name="xalign">0.05000000074505806</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox" id="flowbox_active">
+                <property name="can-focus">False</property>
+                <property name="valign">start</property>
+                <property name="border-width">10</property>
+                <property name="homogeneous">True</property>
+                <property name="column-spacing">15</property>
+                <property name="row-spacing">5</property>
+                <property name="max-children-per-line">1</property>
+                <property name="selection-mode">none</property>
+                <property name="activate-on-single-click">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label_queued">
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="download_group">Downloads waiting for a free worker slot.</property>
+                <property name="label" translatable="yes" context="download_group">Pending:</property>
+                <property name="xalign">0.05000000074505806</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox" id="flowbox_queued">
+                <property name="can-focus">False</property>
+                <property name="valign">start</property>
+                <property name="border-width">10</property>
+                <property name="homogeneous">True</property>
+                <property name="column-spacing">15</property>
+                <property name="row-spacing">5</property>
+                <property name="max-children-per-line">1</property>
+                <property name="selection-mode">none</property>
+                <property name="activate-on-single-click">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label_paused">
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="download_group">Paused downlods will not automatically resume.</property>
+                <property name="label" translatable="yes" context="download_group">Paused:</property>
+                <property name="xalign">0.05000000074505806</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox" id="flowbox_paused">
+                <property name="can-focus">False</property>
+                <property name="valign">start</property>
+                <property name="border-width">10</property>
+                <property name="homogeneous">True</property>
+                <property name="column-spacing">15</property>
+                <property name="row-spacing">5</property>
+                <property name="max-children-per-line">1</property>
+                <property name="selection-mode">none</property>
+                <property name="activate-on-single-click">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label_done">
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="download_group">Downloads that completed, failed or were stopped.</property>
+                <property name="label" translatable="yes" context="download_group">Done:</property>
+                <property name="xalign">0.05000000074505806</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox" id="flowbox_done">
+                <property name="can-focus">False</property>
+                <property name="valign">start</property>
+                <property name="border-width">10</property>
+                <property name="homogeneous">True</property>
+                <property name="column-spacing">15</property>
+                <property name="row-spacing">5</property>
+                <property name="max-children-per-line">1</property>
+                <property name="selection-mode">none</property>
+                <property name="activate-on-single-click">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_manage_installers">
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes" context="game_download_management">Open file manager at location where installers are saved</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="always-show-image">True</property>
+                <signal name="clicked" handler="on_manage_button" swapped="no"/>
                 <child>
-                  <object class="GtkImage" id="icon-harddisk">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="icon-name">drive-harddisk</property>
-                    <property name="icon_size">3</property>
+                    <child>
+                      <object class="GtkImage" id="icon-harddisk">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="icon-name">drive-harddisk</property>
+                        <property name="icon_size">3</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_manage_installers">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes" context="game_download_management" comments="Klick on button will open file explorer to manage downloaded installers">Manage installers</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label_manage_installers">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="label" translatable="yes" context="game_download_management" comments="Klick on button will open file explorer to manage downloaded installers">Manage installers</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">8</property>
+              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">8</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/data/ui/download_list_entry.ui
+++ b/data/ui/download_list_entry.ui
@@ -53,9 +53,37 @@
           </packing>
         </child>
         <child>
-          <object class="GtkProgressBar" id="download_progress">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <child>
+              <object class="GtkProgressBar" id="download_progress">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="valign">center</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label_size">
+                <property name="can-focus">False</property>
+                <property name="halign">end</property>
+                <property name="valign">start</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
+                <property name="label" translatable="yes">label_size</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack-type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/data/ui/download_list_entry.ui
+++ b/data/ui/download_list_entry.ui
@@ -75,7 +75,7 @@
                 <property name="valign">start</property>
                 <property name="margin-start">5</property>
                 <property name="margin-end">5</property>
-                <property name="label" translatable="yes">label_size</property>
+                <property name="label">label_size</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -172,6 +172,7 @@ class OngoingDownloadListEntry(Gtk.Box):
     icon = Gtk.Template.Child()
     game_title = Gtk.Template.Child()
     download_progress = Gtk.Template.Child()
+    label_size = Gtk.Template.Child()
 
     def __init__(self, parent_manager, download: Download, initial_state: DownloadState):
         Gtk.Box.__init__(self)
@@ -196,6 +197,24 @@ class OngoingDownloadListEntry(Gtk.Box):
     def update_progress(self, percentage):
         self.download_progress.set_fraction(percentage / 100)
         self.download_progress.set_tooltip_text("{}%".format(percentage))
+
+        if self.label_size.get_text() != 'label_size':
+            return
+
+        if self.download.expected_size:
+            label_text = self.__format_size(self.download.expected_size)
+            self.label_size.set_text(label_text)
+            self.label_size.show()
+
+    def __format_size(self, filesize=None):
+        if not filesize:
+            return None
+
+        size = filesize / 1024 ** 3
+        if int(size) >= 1:
+            return _('{} GB').format(round(size, 1))
+
+        return _('{} MB').format(int(size * 1024))
 
     def update_state(self, new_state):
         self.buttons.update_buttons(new_state)

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -212,8 +212,10 @@ class OngoingDownloadListEntry(Gtk.Box):
 
         size = filesize / 1024 ** 3
         if int(size) >= 1:
+            # game size estimate for download ui
             return _('{} GB').format(round(size, 1))
 
+        # game size estimate for download ui
         return _('{} MB').format(int(size * 1024))
 
     def update_state(self, new_state):

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -57,7 +57,7 @@ class Window(Gtk.ApplicationWindow):
 
         self.window_library.add(self.library)
         self.header_installed.set_active(self.config.installed_filter)
-        self.download_list.add(DownloadManagerList(self.download_manager, self.download_list_button, self.config))
+        self.download_list.add(DownloadManagerList(self.download_manager, self, self.config))
 
         # Set the icon
         icon = GdkPixbuf.Pixbuf.new_from_file(LOGO_IMAGE_PATH)


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

Now it's my turn again :-)

This PR deals with 2 small issues:
- #667: I've added a scrollable container and let it calculate the maximum height to use dynamically
- #635: adding an estimated size info to the download list. I think there's not much more we can do for that feature request otherwise. the only thing left would be to change the download location on a per-game basis and i think that is not feasible.

I've used the following test code snippet in the constructor of DownloadList to generate the screenshot:
```python
        for i in range(20):
            game = Game('Name:' + str(i))
            size = 1024**(2+min(int(i / 10), 1)) + (1024**2 * i * 72)
            download = Download('None', str(i), DownloadType.GAME, game=game, expected_size=size)
            self.download_manager_listener(DownloadState.QUEUED, download)
            self.download_manager_listener(DownloadState.PROGRESS, download)
```

![size_adjust](https://github.com/user-attachments/assets/efdca9ae-37f5-4ebe-8673-600fae81baeb)


## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
