### PR TITLE
Bugfixes/download manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Introduce a UI to show all active, stopped or failed downloads. Also allows to permanently pause a download (thanks to GB609)
 - Make more Windows games able to launch through Minigalaxy
 - The download UI also shows a rough size estimate if possible (thanks to GB609)
+- fix connection resource leak in DownloadManager (thanks to GB609)
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/data/ui/download_list.ui
+++ b/data/ui/download_list.ui
@@ -151,7 +151,7 @@
                 <property name="receives-default">True</property>
                 <property name="tooltip-text" translatable="yes" context="game_download_management">Open file manager at location where installers are saved</property>
                 <property name="halign">center</property>
-                <property name="valign">center</property>
+                <property name="valign">start</property>
                 <property name="always-show-image">True</property>
                 <signal name="clicked" handler="on_manage_button" swapped="no"/>
                 <child>

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -92,7 +92,7 @@ IGNORE_GAME_IDS = [
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB
 
 # This is the file size needed for the download manager to consider resuming worthwhile
-MINIMUM_RESUME_SIZE = 50 * 1024**2  # 50 MB
+MINIMUM_RESUME_SIZE = 20 * 1024**2  # 20 MB
 
 # UI download threads are for UI assets like thumbnails or icons
 UI_DOWNLOAD_THREADS = 4

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -630,7 +630,7 @@ class DownloadManager:
         if self.__is_cancel_type(last_state) and download in self.__cancel:
             del self.__cancel[download]
 
-        if last_state in [DownloadState.FAILED, DownloadState.CANCELED]:
+        if last_state in [DownloadState.CANCELED]:
             if os.path.isfile(download.save_location):
                 os.remove(download.save_location)
 

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -29,7 +29,7 @@ from enum import Enum
 from minigalaxy.config import Config
 from minigalaxy.constants import DOWNLOAD_CHUNK_SIZE, MINIMUM_RESUME_SIZE, GAME_DOWNLOAD_THREADS, UI_DOWNLOAD_THREADS
 from minigalaxy.download import Download, DownloadType
-from requests import Session
+from requests import codes, Session
 from requests.exceptions import RequestException
 
 module_logger = logging.getLogger("minigalaxy.download_manager")
@@ -488,28 +488,28 @@ class DownloadManager:
               or "ab" to append to a file for download resumes
         """
         resume_header = {'Range': 'bytes={}-'.format(start_point)}
-        download_request = self.session.get(download.url, headers=resume_header, stream=True, timeout=30)
-        # stop retries when 404 is received
-        if download_request.status_code == 404:
-            return DownloadState.FAILED
+        with self.session.get(download.url, headers=resume_header, stream=True, timeout=30) as download_request:
+            # stop retries when 404 is received
+            if download_request.status_code == 404:
+                return DownloadState.FAILED
 
-        downloaded_size = start_point
-        self.__notify_listeners(DownloadState.PROGRESS, download, download_params=[0])
-        file_size = self.__handle_download_size(download_request, download, downloaded_size)
+            downloaded_size = start_point
+            self.__notify_listeners(DownloadState.PROGRESS, download, download_params=[0])
+            file_size = self.__handle_download_size(download_request, download, downloaded_size)
 
-        if file_size == downloaded_size:
-            self.__notify_listeners(DownloadState.PROGRESS, download, download_params=[100])
-            return DownloadState.COMPLETED
+            if file_size == downloaded_size:
+                self.__notify_listeners(DownloadState.PROGRESS, download, download_params=[100])
+                return DownloadState.COMPLETED
 
-        current_progress = 0
-        with open(download.save_location, download_mode) as save_file:
-            for chunk in download_request.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
-                save_file.write(chunk)
-                downloaded_size += len(chunk)
-                if self.__cancel_requested(download):
-                    return None
+            current_progress = 0
+            with open(download.save_location, download_mode) as save_file:
+                for chunk in download_request.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                    save_file.write(chunk)
+                    downloaded_size += len(chunk)
+                    if self.__cancel_requested(download):
+                        return None
 
-                current_progress = self.__update_download_progress(downloaded_size, file_size, current_progress, download)
+                    current_progress = self.__update_download_progress(downloaded_size, file_size, current_progress, download)
 
         if not file_size:
             self.__notify_listeners(DownloadState.PROGRESS, download, download_params=[100])
@@ -564,13 +564,26 @@ class DownloadManager:
         if file_stats.st_size < MINIMUM_RESUME_SIZE:
             return False
 
-        # Check if the first part of the file
-        download_request = self.session.get(download.url, stream=True)
         size_to_check = DOWNLOAD_CHUNK_SIZE * 5
-        for chunk in download_request.iter_content(chunk_size=size_to_check):
-            with open(download.save_location, "rb") as file:
-                file_content = file.read(size_to_check)
-                return file_content == chunk
+        # Check first part of the file
+        resume_header = {'Range': 'bytes=0-{}'.format(size_to_check - 1)}  # range header is index-0-based
+        with self.session.get(download.url, headers=resume_header, stream=True, timeout=30) as download_request:
+            if not download_request.status_code == codes.ok:
+                '''
+                Response is not ok, so we can't download the file.
+                Raise an error instead of returning False to prevent the potentially correct partial files from being deleted.
+                '''
+                download_request.raise_for_status()
+
+            content_length = int(download_request.headers.get('content-length'))
+            if content_length > size_to_check or download_request.status_code != 206:  # 206: partial content
+                self.logger.debug("%s: server does not support http header 'Range' - need to restart download")
+                return False
+
+            for chunk in download_request.iter_content(chunk_size=size_to_check):
+                with open(download.save_location, "rb") as file:
+                    file_content = file.read(size_to_check)
+                    return file_content == chunk
 
     def __download_callback(self, download, state, *params, forked=False):
         '''encapsulates invocation of callbacks on Download to assure uniform threading and

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -123,8 +123,6 @@ class DownloadManagerList(Gtk.ScrolledWindow):
         # make sure to clear previous error messages when restarting a failed download
         entry.update_tooltip("")
 
-        self.__update_list_size()
-
     def update_group_visibility(self, group_flowbox):
         if group_flowbox.get_children():
             self.flowbow_labels[group_flowbox].show()
@@ -137,6 +135,7 @@ class DownloadManagerList(Gtk.ScrolledWindow):
             self.menu_button.get_style_context().add_class("suggested-action")
         else:
             self.menu_button.get_style_context().remove_class("suggested-action")
+        self.__update_list_size()
 
     @Gtk.Template.Callback("on_manage_button")
     def open_file_manager(self, widget, *data):
@@ -162,7 +161,7 @@ class DownloadManagerList(Gtk.ScrolledWindow):
         # try to keep download list height between 300 - 50% of window height
         # minimum of 300 is reduced of that would be larger than the window
         max_height = max([int(window_height * 0.75), min([300, window_height - 25])])
-        self.get_parent().set_size_request(-1, min([content_height, max_height]))
+        self.set_size_request(-1, min([content_height, max_height]))
 
 
 @Gtk.Template.from_file(os.path.join(UI_DIR, "download_list_entry.ui"))

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -18,6 +18,7 @@ class TestDownloadManager(TestCase):
         self.config_mock = MagicMock()
         self.config_mock.paused_downloads = {}
         self.download_request = MagicMock()
+        self.download_request.__enter__.return_value = self.download_request
 
         self.session.get.return_value = self.download_request
 


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

Another PR with a small batch of different bug fixes:
- #630: don't delete partial files when the download fails. Files now are only deleted/moved when: The user fully cancels the download or the installer is done. There is a possible downside to this related to cache management in some rare circumstances: when the download url/name changes when resuming after failure. this can happen when the game got an update between failure and resume as this would change the file name.
- #665: added `with` statements for http response objects and i've also made the 'is same file' check a bit more clever
- While testing with 2-4 parallel downloads, i noticed that the 'manage installers' button wasn't fully displayed in the new scrollable download list. It turned out that i was assigning the calculated size to the wrong widget so that the borders and padding of the parent container interfered/cut into the allocated size.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
