### PR TITLE
Feature/configurable download workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Make more Windows games able to launch through Minigalaxy
 - The download UI also shows a rough size estimate if possible (thanks to GB609)
 - fix connection resource leak in DownloadManager (thanks to GB609)
+- The number of parallel downloads can now be adjusted dynamically. Previous setting is saved. (thanks to GB609)
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/data/ui/download_list.ui
+++ b/data/ui/download_list.ui
@@ -2,6 +2,12 @@
 <!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkAdjustment" id="download_worker_range">
+    <property name="lower">1</property>
+    <property name="upper">8</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <template class="DownloadList" parent="GtkScrolledWindow">
     <property name="visible">True</property>
     <property name="can-focus">True</property>
@@ -22,6 +28,81 @@
             <property name="margin-bottom">3</property>
             <property name="orientation">vertical</property>
             <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
+                <property name="homogeneous">True</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">baseline</property>
+                    <property name="valign">center</property>
+                    <property name="label" translatable="yes" context="download_configuration" comments="Label for configuration option">Max. active downloads:</property>
+                    <property name="xalign">0.10000000149011612</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="download_worker_config">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="tooltip-text" translatable="yes" context="download_configuration">Change how many parallel downloads are allowed.
+Range is 1-8.</property>
+                    <property name="halign">end</property>
+                    <property name="valign">center</property>
+                    <property name="max-length">2</property>
+                    <property name="width-chars">1</property>
+                    <property name="max-width-chars">1</property>
+                    <property name="overwrite-mode">True</property>
+                    <property name="progress-pulse-step">1</property>
+                    <property name="primary-icon-activatable">False</property>
+                    <property name="secondary-icon-activatable">False</property>
+                    <property name="primary-icon-sensitive">False</property>
+                    <property name="secondary-icon-sensitive">False</property>
+                    <property name="primary-icon-tooltip-text" translatable="yes">P</property>
+                    <property name="secondary-icon-tooltip-text" translatable="yes">S</property>
+                    <property name="input-purpose">digits</property>
+                    <property name="adjustment">download_worker_range</property>
+                    <property name="climb-rate">1</property>
+                    <property name="numeric">True</property>
+                    <property name="update-policy">if-valid</property>
+                    <signal name="value-changed" handler="update_worker_number" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="pack-type">end</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSeparator">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkLabel" id="label_active">
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes" context="download_group">Files being actively downloaded.</property>
@@ -31,7 +112,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
@@ -49,7 +130,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child>
@@ -62,7 +143,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">4</property>
               </packing>
             </child>
             <child>
@@ -80,7 +161,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">5</property>
               </packing>
             </child>
             <child>
@@ -93,7 +174,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">4</property>
+                <property name="position">6</property>
               </packing>
             </child>
             <child>
@@ -111,7 +192,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">5</property>
+                <property name="position">7</property>
               </packing>
             </child>
             <child>
@@ -124,7 +205,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">6</property>
+                <property name="position">8</property>
               </packing>
             </child>
             <child>
@@ -142,7 +223,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">7</property>
+                <property name="position">9</property>
               </packing>
             </child>
             <child>
@@ -189,7 +270,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">8</property>
+                <property name="position">10</property>
               </packing>
             </child>
           </object>

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -9,7 +9,7 @@ from minigalaxy.paths import CONFIG_FILE_PATH, DEFAULT_INSTALL_DIR
 # UI download threads are for UI assets like thumbnails or icons
 UI_DOWNLOAD_THREADS = 4
 # Game download threads are for long-running downloads like games, DLC or updates
-GAME_DOWNLOAD_THREADS = 4
+DEFAULT_DOWNLOAD_THREAD_COUNT = 4
 
 
 class Config:
@@ -168,7 +168,7 @@ class Config:
 
     @property
     def max_parallel_game_downloads(self) -> int:
-        return self.__config.get("max_download_workers", GAME_DOWNLOAD_THREADS)
+        return self.__config.get("max_download_workers", DEFAULT_DOWNLOAD_THREAD_COUNT)
 
     @max_parallel_game_downloads.setter
     def max_parallel_game_downloads(self, new_value: int) -> None:

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -5,6 +5,12 @@ from typing import List
 from minigalaxy.logger import logger
 from minigalaxy.paths import CONFIG_FILE_PATH, DEFAULT_INSTALL_DIR
 
+# Moved from constants.py to here because of circular import between translations, config and constants
+# UI download threads are for UI assets like thumbnails or icons
+UI_DOWNLOAD_THREADS = 4
+# Game download threads are for long-running downloads like games, DLC or updates
+GAME_DOWNLOAD_THREADS = 4
+
 
 class Config:
 
@@ -158,6 +164,15 @@ class Config:
     @create_applications_file.setter
     def create_applications_file(self, new_value: bool) -> None:
         self.__config["create_applications_file"] = new_value
+        self.__write()
+
+    @property
+    def max_parallel_game_downloads(self) -> int:
+        return self.__config.get("max_download_workers", GAME_DOWNLOAD_THREADS)
+
+    @max_parallel_game_downloads.setter
+    def max_parallel_game_downloads(self, new_value: int) -> None:
+        self.__config["max_download_workers"] = new_value
         self.__write()
 
     @property

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -94,11 +94,6 @@ DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB
 # This is the file size needed for the download manager to consider resuming worthwhile
 MINIMUM_RESUME_SIZE = 20 * 1024**2  # 20 MB
 
-# UI download threads are for UI assets like thumbnails or icons
-UI_DOWNLOAD_THREADS = 4
-# Game download threads are for long-running downloads like games, DLC or updates
-GAME_DOWNLOAD_THREADS = 4
-
 # Windows executables to not consider when launching
 BINARY_NAMES_TO_IGNORE = [
     # Standard uninstaller

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -428,6 +428,7 @@ class DownloadManager:
                 max_workers = self.queues[download_queue]
                 if len(self.workers[download_queue]) > max_workers:
                     self.logger.debug("Shutting down worker because there are more then allowed")
+                    self.workers[download_queue].remove(threading.current_thread())
                     # The number of workers was reduced and the current thread is idle:
                     # Exit the thread in an orderly way
                     return

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -31,6 +31,7 @@ from minigalaxy.constants import DOWNLOAD_CHUNK_SIZE, MINIMUM_RESUME_SIZE
 from minigalaxy.download import Download, DownloadType
 from requests import Session
 from requests.exceptions import RequestException
+from minigalaxy import download
 
 module_logger = logging.getLogger("minigalaxy.download_manager")
 
@@ -109,14 +110,16 @@ class DownloadManager:
         self.__game_queue = queue.PriorityQueue()
 
         # The queues and associated limits
-        self.queues = [(self.__ui_queue, UI_DOWNLOAD_THREADS),
-                       (self.__game_queue, config.max_parallel_game_downloads)]
+        self.queues = {
+            self.__ui_queue: UI_DOWNLOAD_THREADS,
+            self.__game_queue: config.max_parallel_game_downloads
+        }
 
         self.__cancel = {}
         self.workers = {}
         # The list of currently active downloads
         # These are items not in the queue, but currently being downloaded
-        self.active_downloads = {}
+        self._active_downloads_data = {}
         self.active_downloads_lock = threading.RLock()
 
         # to keep track and prevent re-queueing, because queue.get() would empty it otherwise
@@ -129,9 +132,18 @@ class DownloadManager:
 
         self.logger = logging.getLogger("minigalaxy.download_manager.DownloadManager")
 
-        for q, number_threads in self.queues:
+        for q, number_threads in self.queues.items():
             self.workers[q] = []
             self.__initialize_workers(q, number_threads)
+            
+    @property
+    def active_downloads(self):
+        '''produces a simple list view of the all currently active downloads'''
+        with self.active_downloads_lock:
+            result = []
+            for d in self._active_downloads_data.values():
+                result.append(d['download'])
+            return result
 
     def __initialize_workers(self, queue, num_workers):
         for i in range(num_workers):
@@ -239,6 +251,39 @@ class DownloadManager:
             # Add other items to the UI queue
             self.__ui_queue.put(QueuedDownloadItem(download, 0))
 
+    def adjust_game_workers(self, new_amount, stop_active=False):
+        '''
+        This method allows to dynamically change the number of download threads used by the game queue.
+        The new number is compared against the current value set in config, afterwards the config value is updated.
+          1. When greater, new threads are spawned for this queue.
+          2. When smaller, idle threads will orderly terminate until len(workers[game_queue]) == new_amount (TBD)
+          2a. Threads which are currently busy will only be actively stopped when stop_active=True is given. (TBD)
+              In that case, the download with the least amount of progress is stopped and requeued afterwards
+        '''
+
+        difference = new_amount - self.config.max_parallel_game_downloads
+        if difference == 0 or new_amount < 1:
+            return
+
+        self.config.max_parallel_game_downloads = new_amount
+        self.queues[self.__game_queue] = new_amount
+        if difference > 0:
+            self.__initialize_workers(self.__game_queue, difference)
+            return
+
+        if not stop_active:
+            return
+
+        with self.active_downloads_lock:
+            downloads_on_queue = self.__get_active_from_queue(self.__game_queue)
+            if len(downloads_on_queue) > new_amount:
+                # when stop_active=True, sort by progress and stop the lowest until
+                # max workers is reached
+                downloads_on_queue.sort(key=lambda d: d.current_progress)
+                to_stop = downloads_on_queue[0:abs(difference)]
+                self.cancel_download(to_stop, DownloadState.STOPPED)
+                self.download(to_stop)
+
     def download_now(self, download):
         """
         Download an item with a higher priority
@@ -304,7 +349,7 @@ class DownloadManager:
         """
         for download in download_dict.keys():
             self.logger.debug("download: {}".format(download))
-            for download_queue, limit in self.queues:
+            for download_queue in self.queues:
                 new_queue = queue.PriorityQueue()
 
                 while not download_queue.empty():
@@ -337,7 +382,7 @@ class DownloadManager:
         Cancel all current downloads queued
         """
         self.logger.debug("Canceling all downloads")
-        for download_queue, limit in self.queues:
+        for download_queue in self.queues:
             self.logger.debug("queue length: {}".format(download_queue.qsize()))
             while not download_queue.empty():
                 download = download_queue.get().item
@@ -367,15 +412,6 @@ class DownloadManager:
                 self.__request_download_cancel(d, cancel_state)
                 self.__notify_listeners(cancel_state, d)
 
-    def __remove_download_from_active_downloads(self, download):
-        "Remove a download from the list of active downloads"
-        with self.active_downloads_lock:
-            if download in self.active_downloads:
-                self.logger.debug("Removing download from active downloads list")
-                del self.active_downloads[download]
-            else:
-                self.logger.debug("Didn't find download in active downloads list")
-
     def __download_thread(self, download_queue):
         """
         The main DownloadManager thread calls this when it is created
@@ -383,11 +419,18 @@ class DownloadManager:
         Users of this library should not need to call this.
         """
         while True:
+            if download_queue in self.queues: 
+                max_workers = self.queues[download_queue]
+                if len(self.workers[download_queue]) > max_workers:
+                    # The number of workers was reduced and the current thread is idle:
+                    # Exit the thread in an orderly way
+                    return
+
             if not download_queue.empty():
                 # Update the active downloads
                 with self.active_downloads_lock:
                     download = download_queue.get().item
-                    self.active_downloads[download] = download
+                    self._add_to_active_downloads(download, download_queue)
                     self.__remove_from_queued_list(download)
 
                 self.__notify_listeners(DownloadState.STARTED, download)
@@ -422,7 +465,9 @@ class DownloadManager:
                 last_error = str(e)  # FIXME: need a way to remove token from error
                 download_attempt += 1
                 # TODO: maybe add an incrementally growing sleep time instead
-                time.sleep(10)  # don't immediately use up all retries
+                if download_attempt < download_max_attempts:
+                    # only sleep when there are retries left
+                    time.sleep(10)  # don't immediately use up all retries
 
         if download_attempt == download_max_attempts:
             result = DownloadState.FAILED
@@ -441,7 +486,7 @@ class DownloadManager:
             result = DownloadState.FAILED
 
         self.__notify_listeners(result, download, additional_params=additional_info)
-        self.__remove_download_from_active_downloads(download)
+        self._remove_from_active_downloads(download)
         self.__cleanup_meta(download, result)
 
     def __prepare_location(self, save_location):
@@ -602,7 +647,35 @@ class DownloadManager:
         file = download.save_location
         with self.active_downloads_lock:
             # ignore if the file is already pending
-            return file in self.active_downloads or file in self.queued_downloads
+            return file in self._active_downloads_data or file in self.queued_downloads
+
+    def _add_to_active_downloads(self, download, on_queue=None):
+        if not on_queue:
+            on_queue = self.__game_queue
+        with self.active_downloads_lock:
+            self._active_downloads_data[download.save_location] = {
+                'download': download,
+                'queue': on_queue
+            }
+
+    def _remove_from_active_downloads(self, download):
+        "Remove a download from the list of active downloads"
+        with self.active_downloads_lock:
+            save_loc = download.save_location
+            if save_loc in self._active_downloads_data:
+                self.logger.debug("Removing download %s from active downloads list", save_loc)
+                del self._active_downloads_data[save_loc]
+            else:
+                self.logger.debug("Didn't find download %s in active downloads list", save_loc)
+
+    def __get_active_from_queue(self, queue):
+        '''Goes through all active downloads and collects all are active in workers from the given queue'''
+        with self.active_downloads_lock:
+            result = []
+            for d in self._active_downloads_data.values():
+                if queue == d['queue']:
+                    result.append(d['download'])
+            return result
 
     def __add_to_queued_list(self, download):
         with self.active_downloads_lock:

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -567,7 +567,7 @@ class DownloadManager:
         # Check first part of the file
         resume_header = {'Range': 'bytes=0-{}'.format(size_to_check - 1)}  # range header is index-0-based
         with self.session.get(download.url, headers=resume_header, stream=True, timeout=30) as download_request:
-            if not download_request.status_code == codes.ok:
+            if not 200 <= download_request.status_code < 300:
                 '''
                 Response is not ok, so we can't download the file.
                 Raise an error instead of returning False to prevent the potentially correct partial files from being deleted.

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -26,10 +26,10 @@ import minigalaxy.logger  # noqa: F401
 
 from concurrent.futures.thread import ThreadPoolExecutor
 from enum import Enum
-from minigalaxy.config import Config
-from minigalaxy.constants import DOWNLOAD_CHUNK_SIZE, MINIMUM_RESUME_SIZE, GAME_DOWNLOAD_THREADS, UI_DOWNLOAD_THREADS
+from minigalaxy.config import Config, GAME_DOWNLOAD_THREADS, UI_DOWNLOAD_THREADS
+from minigalaxy.constants import DOWNLOAD_CHUNK_SIZE, MINIMUM_RESUME_SIZE
 from minigalaxy.download import Download, DownloadType
-from requests import codes, Session
+from requests import Session
 from requests.exceptions import RequestException
 
 module_logger = logging.getLogger("minigalaxy.download_manager")

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -31,7 +31,6 @@ from minigalaxy.constants import DOWNLOAD_CHUNK_SIZE, MINIMUM_RESUME_SIZE
 from minigalaxy.download import Download, DownloadType
 from requests import Session
 from requests.exceptions import RequestException
-from minigalaxy import download
 
 module_logger = logging.getLogger("minigalaxy.download_manager")
 

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -623,7 +623,7 @@ class DownloadManager:
         # Check first part of the file
         resume_header = {'Range': 'bytes=0-{}'.format(size_to_check - 1)}  # range header is index-0-based
         with self.session.get(download.url, headers=resume_header, stream=True, timeout=30) as download_request:
-            if not 200 <= download_request.status_code < 300:
+            if not download_request.ok:
                 '''
                 Response is not ok, so we can't download the file.
                 Raise an error instead of returning False to prevent the potentially correct partial files from being deleted.

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -209,8 +209,7 @@ class DownloadManager:
                 else:
                     self.__notify_listeners(DownloadState.PAUSED, d)
                     # let paused downloads at least display a rough estimate of where they are
-                    d.current_progress = paused_downloads[file]
-                    self.__notify_listeners(DownloadState.PROGRESS, d, d.current_progress)
+                    self.__notify_listeners(DownloadState.PROGRESS, d, download_params=[paused_downloads[file]])
                     continue
 
             self.put_in_proper_queue(d)

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -589,11 +589,10 @@ class DownloadManager:
         error safeguarding to not kill downloads threads by uncaught exceptions'''
         if state in DownloadManager.STATE_DOWNLOAD_CALLBACKS:
             callback = DownloadManager.STATE_DOWNLOAD_CALLBACKS[state]
-            error_wrapper = self.__call_listener_failsafe
             if forked:
-                error_wrapper(callback, download, *params)
+                self.__call_listener_failsafe(callback, download, *params)
             else:
-                self.listener_thread.submit(error_wrapper, callback, download, *params)
+                self.listener_thread.submit(self.__download_callback, download, state, *params)
 
     def __is_pending(self, download):
         file = download.save_location

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -20,6 +20,8 @@ class DownloadManagerList(Gtk.ScrolledWindow):
 
     content_box = Gtk.Template.Child()
 
+    download_worker_config = Gtk.Template.Child()
+
     label_active = Gtk.Template.Child()
     flowbox_active = Gtk.Template.Child()
 
@@ -43,6 +45,7 @@ class DownloadManagerList(Gtk.ScrolledWindow):
         self.parent_window = window
         self.menu_button = window.download_list_button
         self.config = config
+        self.download_worker_config.set_value(config.max_parallel_game_downloads)
         self.downloads = {}
 
         self.change_handler = {
@@ -154,6 +157,10 @@ class DownloadManagerList(Gtk.ScrolledWindow):
         else:
             self.button_manage_installers.hide()
         self.__update_list_size()
+
+    @Gtk.Template.Callback("update_worker_number")
+    def update_worker_number(self, widget):
+        self.logger.debug("Number of workers was adjusted. New: %s", str(widget.get_value()))
 
     def __update_list_size(self):
         content_height = self.content_box.get_preferred_height()[1] + 6  # pixel of upper and lower border

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -168,7 +168,9 @@ class DownloadManagerList(Gtk.ScrolledWindow):
 
     @Gtk.Template.Callback("update_worker_number")
     def update_worker_number(self, widget):
-        self.logger.debug("Number of workers was adjusted. New: %s", str(widget.get_value()))
+        new_workers = int(widget.get_value())
+        self.logger.debug("Number of workers was adjusted. New: %s", new_workers)
+        self.download_manager.adjust_game_workers(new_workers, stop_active=True)
 
     def __update_list_size(self):
         content_height = self.content_box.get_preferred_height()[1] + 6  # pixel of upper and lower border

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -156,7 +156,7 @@ class DownloadManagerList(Gtk.ScrolledWindow):
         self.__update_list_size()
 
     def __update_list_size(self):
-        content_height = self.content_box.get_preferred_height()[1]
+        content_height = self.content_box.get_preferred_height()[1] + 6  # pixel of upper and lower border
         window_height = self.parent_window.get_allocated_height()
         # try to keep download list height between 300 - 50% of window height
         # minimum of 300 is reduced of that would be larger than the window

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -280,14 +280,14 @@ class LibraryEntry:
 
         if check_diskspace(total_file_size, self.game.install_dir):
             self.download_manager.download(download_files)
-            ds_msg_title = ""
-            ds_msg_text = ""
         else:
-            ds_msg_title = "Download error"
-            ds_msg_text = "Not enough disk space to install game."
-            download_success = False
-        if ds_msg_title:
+            ds_msg_title = _("Download error")
+            dl_name = download_info.get('name', self.game.name)
+            ds_msg_text = _("Not enough disk space to install game:\n{}").format(dl_name)
             GLib.idle_add(self.parent_window.show_error, _(ds_msg_title), _(ds_msg_text))
+            self.config.remove_ongoing_download(self.game.id)
+            download_success = False
+
         return download_success
 
     '''----- END DOWNLOAD ACTIONS -----'''

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -284,7 +284,7 @@ class LibraryEntry:
             ds_msg_title = _("Download error")
             dl_name = download_info.get('name', self.game.name)
             ds_msg_text = _("Not enough disk space to install game:\n{}").format(dl_name)
-            GLib.idle_add(self.parent_window.show_error, _(ds_msg_title), _(ds_msg_text))
+            GLib.idle_add(self.parent_window.show_error, ds_msg_title, ds_msg_text)
             self.config.remove_ongoing_download(self.game.id)
             download_success = False
 

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -96,7 +96,7 @@ class TestDownloadManager(TestCase):
 
         temp_file = tempfile.mktemp()
         download = Download("example.com", temp_file, DownloadType.GAME, finish_func, progress_func, cancel_func)
-        self.download_manager.active_downloads[download] = download
+        self.download_manager._add_to_active_downloads(download)
         self.download_manager.cancel_download(download)
         self.download_manager._DownloadManager__download_operation(download, 0, "wb")
 
@@ -131,7 +131,7 @@ class TestDownloadManager(TestCase):
         self.download_manager.cancel_download(download)
         print(str(time.time()) + " assert")
         cancel_func.assert_called_once()
-        for queue in self.download_manager.queues:
-            for i in queue:
-                self.assertNotEqual(i, download)
+        self.assertFalse(download in self.download_manager.active_downloads)
+        for d in self.download_manager.queued_downloads.values():
+            self.assertNotEqual(download, d)
         self.assertFalse(os.path.isfile(temp_file))


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

1. Another assortment of bugs i stumbled across while working on the new feature
2. A UI option to reduce/increase the amount of parallel workers. Covers #664 

Preview of the ui:

![download_workers_option](https://github.com/user-attachments/assets/afa17e34-1152-434d-bb50-a0dcb0dc45a6)

The worker number is saved in config and thus persists across restarts.
But i also implemented a method to increase/reduce the worker number on the fly. So the new setting applies immediately without restart, even when there are active downloads already.
The stopping function comes with 2 variants:
1. Do not actively stop running downloads. Worker will finish their current task and terminate if there are more workers than configured.
2. As an addition to 1, stop and requeue downloads with the least progress. This is the current default behavior.

The 2 variants are controlled by a boolean method parameter, which is hard coded at the moment. I'm not sure which of both variants is the better one and whether we should just open both variants to let the user decide, maybe through an option or a yes/no question.

~~Edit 2: I just saw that i'm missing one thing: the workers arent removed from the list of workers when stopped. Need to fix/add this.~~ - FIXED

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
