### PR TITLE
DLC handling fixes, improve logic searching for executable command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - The download UI also shows a rough size estimate if possible (thanks to GB609)
 - fix connection resource leak in DownloadManager (thanks to GB609)
 - The number of parallel downloads can now be adjusted dynamically. Previous setting is saved. (thanks to GB609)
+- Fixed a bug that would lead to DLCs being recognized as stand-alone games (thanks to GB609)
+- Allow more games to be launched via information from goggame.info (thanks to GB609)
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - The number of parallel downloads can now be adjusted dynamically. Previous setting is saved. (thanks to GB609)
 - Fixed a bug that would lead to DLCs being recognized as stand-alone games (thanks to GB609)
 - Allow more games to be launched via information from goggame.info (thanks to GB609)
+- The DLC list will now show a table-like multi-column view where necessary. This fixes issues with games having a high number of DLCs. (thanks to GB609)
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/data/ui/gametile.ui
+++ b/data/ui/gametile.ui
@@ -1,7 +1,126 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface domain="minigalaxy">
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkPopover" id="dlc_popover">
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkScrolledWindow" id="dlc_scroll_panel">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="vscrollbar-policy">never</property>
+        <child>
+          <object class="GtkViewport">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkFlowBox" id="dlc_horizontal_box">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="min-children-per-line">4</property>
+                <property name="max-children-per-line">10</property>
+                <property name="selection-mode">none</property>
+                <property name="activate-on-single-click">False</property>
+                <signal name="map" handler="recalculate_dlc_list_size" swapped="no"/>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkPopover" id="menu">
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkModelButton" id="menu_button_update">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Update</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_menu_button_update_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkMenuButton" id="menu_button_dlc">
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <property name="direction">left</property>
+            <property name="popover">dlc_popover</property>
+            <child>
+              <object class="GtkLabel" id="label_button_dlc">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">DLC</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="menu_button_uninstall">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Uninstall</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_menu_button_uninstall_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="menu_button_information">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Information</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_menu_button_information_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="menu_button_properties">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Properties</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_menu_button_properties_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
   <template class="GameTile" parent="GtkBox">
     <property name="name">gametile</property>
     <property name="width-request">196</property>
@@ -88,13 +207,16 @@
         </child>
         <child type="overlay">
           <object class="GtkProgressBar" id="progress_bar">
-            <property name="visible">False</property>
+            <property name="can-focus">False</property>
             <property name="no-show-all">True</property>
             <property name="valign">end</property>
             <style>
               <class name="progress-bar"/>
             </style>
           </object>
+          <packing>
+            <property name="index">3</property>
+          </packing>
         </child>
       </object>
       <packing>
@@ -105,104 +227,42 @@
     </child>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
         <property name="width-request">196</property>
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="GtkButton" id="button">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
             <signal name="clicked" handler="on_button_clicked" swapped="no"/>
-            <style>
-              <class name="button-left"/>
-            </style>
             <child>
               <placeholder/>
             </child>
-          </object>
-            <packing>
-              <property name="expand">True</property>
-              <property name="fill">True</property>
-              <property name="pack-type">start</property>
-              <property name="position">0</property>
-            </packing>
-        </child>
-        <child>
-          <object class="GtkMenuButton" id="menu_button">
-            <property name="use_action_appearance">False</property>
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="use-popover">False</property>
-            <property name="popover">menu</property>
-            <property name="receives-default">True</property>
             <style>
-              <class name="button-right"/>
+              <class name="button-left"/>
             </style>
           </object>
           <packing>
-              <property name="expand">False</property>
-              <property name="fill">True</property>
-              <property name="pack-type">start</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-
-      </object>
-    </child>
-    <child>
-      <placeholder/>
-    </child>
-  </template>
-  <object class="GtkPopover" id="dlc_popover">
-    <property name="can-focus">False</property>
-    <child>
-      <object class="GtkBox" id="dlc_horizontal_box">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <placeholder/>
-        </child>
-      </object>
-    </child>
-  </object>
-  <object class="GtkPopover" id="menu">
-    <property name="can-focus">False</property>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkModelButton" id="menu_button_update">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="text" translatable="yes">Update</property>
-            <property name="centered">True</property>
-            <signal name="clicked" handler="on_menu_button_update_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkMenuButton" id="menu_button_dlc">
-            <property name="can-focus">True</property>
+          <object class="GtkMenuButton" id="menu_button">
+            <property name="use-action-appearance">False</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
             <property name="receives-default">True</property>
-            <property name="relief">none</property>
-            <property name="direction">left</property>
-            <property name="popover">dlc_popover</property>
+            <property name="use-popover">False</property>
+            <property name="popover">menu</property>
             <child>
-              <object class="GtkLabel" id="label_button_dlc">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">DLC</property>
-              </object>
+              <placeholder/>
             </child>
+            <style>
+              <class name="button-right"/>
+            </style>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -210,52 +270,15 @@
             <property name="position">1</property>
           </packing>
         </child>
-        <child>
-          <object class="GtkModelButton" id="menu_button_uninstall">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="text" translatable="yes">Uninstall</property>
-            <property name="centered">True</property>
-            <signal name="clicked" handler="on_menu_button_uninstall_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="menu_button_information">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="text" translatable="yes">Information</property>
-            <property name="centered">True</property>
-            <signal name="clicked" handler="on_menu_button_information_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="menu_button_properties">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes">Properties</property>
-            <property name="centered">True</property>
-            <signal name="clicked" handler="on_menu_button_properties_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
-          </packing>
-        </child>
       </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
     </child>
-  </object>
+    <child>
+      <placeholder/>
+    </child>
+  </template>
 </interface>

--- a/data/ui/gametilelist.ui
+++ b/data/ui/gametilelist.ui
@@ -1,49 +1,169 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface domain="minigalaxy">
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkPopover" id="dlc_popover">
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkScrolledWindow" id="dlc_scroll_panel">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="vscrollbar-policy">never</property>
+        <child>
+          <object class="GtkViewport">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkFlowBox" id="dlc_horizontal_box">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="min-children-per-line">4</property>
+                <property name="max-children-per-line">10</property>
+                <property name="selection-mode">none</property>
+                <property name="activate-on-single-click">False</property>
+                <signal name="map" handler="recalculate_dlc_list_size" swapped="no"/>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkPopover" id="menu">
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkMenuButton" id="menu_button_dlc">
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <property name="direction">left</property>
+            <property name="popover">dlc_popover</property>
+            <child>
+              <object class="GtkLabel" id="label_button_dlc">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">DLC</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="menu_button_update">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Update</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_menu_button_update_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="menu_button_uninstall">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Uninstall</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_menu_button_uninstall_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="menu_button_information">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Information</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_menu_button_information_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="menu_button_properties">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Properties</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_menu_button_properties_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
   <template class="GameTileList" parent="GtkBox">
-    <property name="width_request">196</property>
+    <property name="width-request">196</property>
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="valign">start</property>
     <property name="hexpand">False</property>
     <property name="vexpand">False</property>
     <property name="orientation">vertical</property>
     <child>
+      <!-- n-columns=3 n-rows=3 -->
       <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="GtkOverlay">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkImage" id="image">
-                <property name="width_request">196</property>
-                <property name="height_request">110</property>
+                <property name="width-request">196</property>
+                <property name="height-request">110</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">dialog-warning-symbolic</property>
+                <property name="can-focus">False</property>
+                <property name="icon-name">dialog-warning-symbolic</property>
                 <property name="icon_size">0</property>
               </object>
               <packing>
-                <property name="pass_through">True</property>
+                <property name="pass-through">True</property>
                 <property name="index">-1</property>
               </packing>
             </child>
             <child type="overlay">
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">start</property>
                 <child>
                   <object class="GtkButton" id="button_cancel">
-                    <property name="can_focus">True</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="receives_default">True</property>
-                    <property name="no_show_all">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="focus-on-click">False</property>
+                    <property name="receives-default">True</property>
+                    <property name="no-show-all">True</property>
                     <property name="halign">end</property>
                     <property name="valign">start</property>
                     <property name="relief">none</property>
@@ -51,8 +171,8 @@
                     <child>
                       <object class="GtkImage" id="cancel_icon">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">process-stop</property>
+                        <property name="can-focus">False</property>
+                        <property name="icon-name">process-stop</property>
                       </object>
                     </child>
                   </object>
@@ -64,22 +184,22 @@
                 </child>
                 <child>
                   <object class="GtkMenuButton" id="menu_button">
-                    <property name="can_focus">True</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="receives_default">True</property>
-                    <property name="no_show_all">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="focus-on-click">False</property>
+                    <property name="receives-default">True</property>
+                    <property name="no-show-all">True</property>
                     <property name="halign">end</property>
                     <property name="valign">start</property>
                     <property name="relief">none</property>
-                    <property name="use_popover">False</property>
+                    <property name="use-popover">False</property>
                     <property name="popover">menu</property>
                     <child>
                       <object class="GtkImage" id="menu_icon">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">center</property>
                         <property name="valign">center</property>
-                        <property name="icon_name">applications-system-symbolic</property>
+                        <property name="icon-name">applications-system-symbolic</property>
                         <property name="icon_size">3</property>
                       </object>
                     </child>
@@ -94,11 +214,11 @@
             </child>
             <child type="overlay">
               <object class="GtkImage" id="wine_icon">
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">start</property>
                 <property name="valign">start</property>
-                <property name="margin_start">2</property>
-                <property name="margin_top">2</property>
+                <property name="margin-start">2</property>
+                <property name="margin-top">2</property>
               </object>
               <packing>
                 <property name="index">2</property>
@@ -106,11 +226,11 @@
             </child>
             <child type="overlay">
               <object class="GtkImage" id="update_icon">
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">start</property>
                 <property name="valign">start</property>
-                <property name="margin_start">2</property>
-                <property name="margin_top">2</property>
+                <property name="margin-start">2</property>
+                <property name="margin-top">2</property>
               </object>
               <packing>
                 <property name="index">3</property>
@@ -118,39 +238,57 @@
             </child>
           </object>
           <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">0</property>
+            <property name="left-attach">0</property>
+            <property name="top-attach">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkButton" id="button">
-            <property name="width_request">196</property>
+            <property name="width-request">196</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
             <signal name="clicked" handler="on_button_clicked" swapped="no"/>
           </object>
           <packing>
-            <property name="left_attach">2</property>
-            <property name="top_attach">0</property>
+            <property name="left-attach">2</property>
+            <property name="top-attach">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkLabel" id="game_label">
-            <property name="height_request">110</property>
+            <property name="height-request">110</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="halign">start</property>
             <property name="valign">center</property>
+            <property name="margin-start">15</property>
             <property name="hexpand">True</property>
-            <property name="margin_start">15</property>
           </object>
           <packing>
-            <property name="left_attach">1</property>
-            <property name="top_attach">0</property>
+            <property name="left-attach">1</property>
+            <property name="top-attach">0</property>
           </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
       </object>
       <packing>
@@ -160,108 +298,4 @@
       </packing>
     </child>
   </template>
-  <object class="GtkPopover" id="dlc_popover">
-    <property name="can_focus">False</property>
-    <child>
-      <object class="GtkBox" id="dlc_horizontal_box">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <placeholder/>
-        </child>
-      </object>
-    </child>
-  </object>
-  <object class="GtkPopover" id="menu">
-    <property name="can_focus">False</property>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkMenuButton" id="menu_button_dlc">
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="relief">none</property>
-            <property name="direction">left</property>
-            <property name="popover">dlc_popover</property>
-            <child>
-              <object class="GtkLabel" id="label_button_dlc">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">DLC</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="menu_button_update">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes">Update</property>
-            <property name="centered">True</property>
-            <signal name="clicked" handler="on_menu_button_update_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="menu_button_uninstall">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes">Uninstall</property>
-            <property name="centered">True</property>
-            <signal name="clicked" handler="on_menu_button_uninstall_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="menu_button_information">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes">Information</property>
-            <property name="centered">True</property>
-            <signal name="clicked" handler="on_menu_button_information_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="menu_button_properties">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="text" translatable="yes">Properties</property>
-            <property name="centered">True</property>
-            <signal name="clicked" handler="on_menu_button_properties_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-  </object>
 </interface>

--- a/minigalaxy/ui/gametile.py
+++ b/minigalaxy/ui/gametile.py
@@ -19,6 +19,7 @@ class GameTile(LibraryEntry, Gtk.Box):
     menu_button_update = Gtk.Template.Child()
     menu_button_dlc = Gtk.Template.Child()
     menu_button_uninstall = Gtk.Template.Child()
+    dlc_scroll_panel = Gtk.Template.Child()
     dlc_horizontal_box = Gtk.Template.Child()
     menu_button_information = Gtk.Template.Child()
     menu_button_properties = Gtk.Template.Child()
@@ -56,6 +57,10 @@ class GameTile(LibraryEntry, Gtk.Box):
     @Gtk.Template.Callback("on_menu_button_update_clicked")
     def on_menu_button_update(self, widget):
         super().run_update(widget)
+
+    @Gtk.Template.Callback("recalculate_dlc_list_size")
+    def recalc_dlc_list_size(self, widget, *data):
+        super().recalc_dlc_list_size(self.dlc_scroll_panel, self.dlc_horizontal_box)
 
     def state_installed(self):
         self.menu_button.get_style_context().add_class("suggested-action")

--- a/minigalaxy/ui/gametilelist.py
+++ b/minigalaxy/ui/gametilelist.py
@@ -20,6 +20,7 @@ class GameTileList(LibraryEntry, Gtk.Box):
     menu_button_update = Gtk.Template.Child()
     menu_button_dlc = Gtk.Template.Child()
     menu_button_uninstall = Gtk.Template.Child()
+    dlc_scroll_panel = Gtk.Template.Child()
     dlc_horizontal_box = Gtk.Template.Child()
     menu_button_information = Gtk.Template.Child()
     menu_button_properties = Gtk.Template.Child()
@@ -76,3 +77,7 @@ class GameTileList(LibraryEntry, Gtk.Box):
     @Gtk.Template.Callback("on_menu_button_update_clicked")
     def on_menu_button_update(self, widget):
         super().run_update(widget)
+
+    @Gtk.Template.Callback("recalculate_dlc_list_size")
+    def recalc_dlc_list_size(self, widget, *data):
+        super().recalc_dlc_list_size(self.dlc_scroll_panel, self.dlc_horizontal_box)

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -217,6 +217,9 @@ def get_installed_windows_games(full_path, game_categories_dict=None):
         if re.match(r'^goggame-[0-9]*\.info$', file):
             with open(os.path.join(full_path, file), 'rb') as info_file:
                 info = json.loads(info_file.read().decode('utf-8-sig'))
+                if not info.get('playTasks', []):
+                    continue
+
                 game = Game(
                     name=info["name"],
                     game_id=int(info["gameId"]),

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -176,10 +176,6 @@ class LibraryEntry:
             self.update_to_state(cancel_to_state)
 
     def __download_dlc(self, dlc_installers) -> None:
-
-        def finish_func(save_location):
-            self.__install_dlc(save_location, dlc_title=dlc_title)
-
         download_info = self.api.get_download_info(self.game, dlc_installers=dlc_installers)
         dlc_title = self.game.name
         dlc_icon = None
@@ -188,6 +184,9 @@ class LibraryEntry:
                 dlc_id = dlc.get('id', None)
                 dlc_icon = self.game.get_cached_icon_path(dlc_id)
                 dlc_title = dlc["title"]
+
+        def finish_func(save_location):
+            self.__install_dlc(save_location, dlc_title=dlc_title)
 
         cancel_to_state = State.INSTALLED
         result = self.__download(download_info, DownloadType.GAME_DLC, finish_func,

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -397,6 +397,29 @@ class LibraryEntry:
 
     '''----- UI REPRESENTATION UTILITIES -----'''
 
+    def recalc_dlc_list_size(self, scrollable_window, dlc_flowbox):
+        '''Adjusts the DLC list size when the DLC button is clicked.
+        Must be called from child class instances where needed.
+
+        Algorithm:
+        1. Take half window height and divide by dlc item height.
+        2. Set result as max items per column
+        3. DLC list will open more columns horizontally as needed
+        4. Configure fixed with for scrollable container to be 80% of window
+
+        => This results in a table-like layout of all DLCs at roughly the size [window_width * 0.8, window_height / 2]
+        '''
+
+        max_height = int(self.parent_window.get_allocated_height() / 2)
+        max_width = int(self.parent_window.get_allocated_width() * 0.8)
+        first_dlc = dlc_flowbox.get_child_at_index(0)
+        item_height = first_dlc.get_preferred_height()[1]
+        num_vertical_items = int(max_height / item_height)
+
+        dlc_flowbox.set_max_children_per_line(num_vertical_items)
+        preferred_width = dlc_flowbox.get_preferred_width()[1]
+        scrollable_window.set_size_request(min(preferred_width, max_width), dlc_flowbox.get_preferred_height()[1])
+
     def update_gtk_box_for_dlc(self, dlc_info):
         title = dlc_info['title']
         if title not in self.dlc_dict:
@@ -607,7 +630,7 @@ class DlcListEntry(Gtk.Box):
         self.install_button.connect("clicked", self.__dlc_button_clicked)
         self.pack_start(self.install_button, False, True, 0)
 
-        parent_entry.dlc_horizontal_box.pack_start(self, False, True, 0)
+        parent_entry.dlc_horizontal_box.add(self)
         self.show_all()
         self.get_async_image_dlc_icon(dlc_info['id'], dlc_info["images"]["sidebarIcon"])
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -165,15 +165,20 @@ class Test(TestCase):
         "rootGameId": "1407287452",
         "version": 1
         }"""
-        handlers = (
-            mock_open(read_data=goggame_1414471894_info_content).return_value,
-            mock_open(read_data=goggame_1407287452_info_content).return_value,
-        )
-        mo.side_effect = handlers
+
+        def open_file(filename, mode):
+            if filename.endswith("goggame-1414471894.info"):
+                return mock_open(read_data=goggame_1414471894_info_content).return_value
+            elif filename.endswith("goggame-1407287452.info"):
+                return mock_open(read_data=goggame_1407287452_info_content).return_value
+            else:
+                print('open called with '+filename)
+                pass
+        mo.side_effect = open_file
         mock_exists.return_value = True
         files = ['thumbnail.jpg', 'docs', 'support', 'game', 'minigalaxy-dlc.json', 'MetroExodus.exe', 'unins000.exe',
                  'goggame-1407287452.info', 'goggame-1414471894.info']
-        game = Game("Test Game", install_dir="/test/install/dir")
+        game = Game("Test Game", install_dir="/test/install/dir", game_id=1407287452)
         exp = ['env', 'WINEPREFIX=/test/install/dir/prefix', 'wine', 'start', '/b', '/wait', '/d', 'c:\\game\\.',
                'c:\\game\\MetroExodus.exe']
         obs = launcher.get_windows_exe_cmd(game, files)

--- a/tests/test_ui_library.py
+++ b/tests/test_ui_library.py
@@ -192,7 +192,8 @@ class TestLibrary(TestCase):
     @mock.patch('os.listdir')
     def test1_get_installed_windows_game(self, mock_listdir):
         mock_listdir.return_value = ["goggame-1207665883.info"]
-        game_json_data = '{ "gameId": "1207665883", "name": "Aliens vs Predator Classic 2000" }'.encode('utf-8')
+        # none-empty list of playTasks needed so that library recognizes it as installed game
+        game_json_data = '{ "gameId": "1207665883", "name": "Aliens vs Predator Classic 2000", "playTasks":[{}]}'.encode('utf-8')
         with patch("builtins.open", mock_open(read_data=game_json_data)):
             games = get_installed_windows_games("/example/path")
         exp = "Aliens vs Predator Classic 2000"
@@ -202,7 +203,8 @@ class TestLibrary(TestCase):
     @mock.patch('os.listdir')
     def test2_get_installed_windows_game(self, mock_listdir):
         mock_listdir.return_value = ["goggame-1207665883.info"]
-        game_json_data = '{ "gameId": "1207665883", "name": "Aliens vs Predator Classic 2000" }'.encode('utf-8-sig')
+        # none-empty list of playTasks needed so that library recognizes it as installed game
+        game_json_data = '{ "gameId": "1207665883", "name": "Aliens vs Predator Classic 2000", "playTasks":[{}]}'.encode('utf-8-sig')
         with patch("builtins.open", mock_open(read_data=game_json_data)):
             games = get_installed_windows_games("/example/path")
         exp = "Aliens vs Predator Classic 2000"


### PR DESCRIPTION
1. Only recognize files with none-empty `playTasks` for finding installed games

2. launcher.py:get_windows_exe_cmd: Don't iterate over all `goggame*.info` files in a game directory to search the launch command, only use the one holding the current game's id.  
This becomes important when multiple files contain playTasks, e.g. when there is something like a stand-alone extension for a game that requires another executable. The extension's game id could be sorted alphabetically after the base game. In that case, launching the stand-alone extension would still pull out the executable from the base game's `goggame*.info` file, which would be wrong.  
Additional fallback: If there is a goggame.info file, but it's not valid, then first check if there is an `*.lnk` file. This is only a slight addition to the previous logic which used  
`if goggame_file: ... elif link_file else find_first_exec` where an invalid, but existing goggame.info file would prevent the fallback logic from being used and result in returning just `env WINEPREFIX="prefix-path"`
Generally simplified the if logic by using `dict.get('key', defaultValue)` patterns for access to potentially empty json values.

3. launcher.py:get_windows_exe_cmd_from_goggame_info: Simplified branch nesting and ifs. Removed unnecessary check for `category=game` - we should also use `category=launcher` if it is marked as `isPrimary=true`

4. small bugfix in LibraryEntry.__download_dlc: the inner function finish_func must be defined after dlc_title variable or it won't be visible/set.

Fixes #674
Fixes for #675: The part were the DLCs are listed as their own games. And DLC list can now scroll and change layout dynamically as required.
Fixes some of the games mentioned in #619

**Edit:**
I've added some code to handle large dlc lists as well. The 'list' is now a FlowBox. I'm dynamically adjusting the size and max items per column and have it scroll horizontally.
The size calculations are not perfect, there are some border cases with **very** small windows and large DLC lists where a part of the DLC Popover is cropped. After a few hours of trial and error and different, much more complicated size and position calculations, i figured it's just not worth it.

I'm going to add a few screenshots how that effectively looks:
![dlc_list_default](https://github.com/user-attachments/assets/356e9ad6-4830-422c-a3ca-0299ef922ee7)
![dlc_list_1](https://github.com/user-attachments/assets/75221bcc-5c18-4209-a476-5fd926bf07eb)
![dlc_list_2](https://github.com/user-attachments/assets/6b4bc7ce-93ae-45eb-80e2-3eec642f3377)
![dlc_list_3](https://github.com/user-attachments/assets/86e7235b-efc5-4fe6-bf01-530b398de162)

 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
