### PR TITLE
several bugs in DownloadManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a bug that would lead to DLCs being recognized as stand-alone games (thanks to GB609)
 - Allow more games to be launched via information from goggame.info (thanks to GB609)
 - The DLC list will now show a table-like multi-column view where necessary. This fixes issues with games having a high number of DLCs. (thanks to GB609)
+- Some bug fixes in DownloadManager related to canceling active and queued downloads (thanks to GB609)
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -96,7 +96,7 @@ class DownloadManager:
         DownloadState.CANCELED: lambda d, *a: d.cancel(),
         DownloadState.FAILED: lambda d, *a: d.cancel(),
         DownloadState.STOPPED: lambda d, *a: d.cancel(),
-        DownloadState.PROGRESS: lambda d, percent: d.set_progress(percent)
+        DownloadState.PROGRESS: lambda d, state, percent: d.set_progress(percent)
     }
 
     def __init__(self, session: Session, config: Config):
@@ -362,9 +362,7 @@ class DownloadManager:
 
                     # Test a Download against a QueuedDownloadItem
                     should_cancel = download == queued_download.item
-                    # test for games
-                    if not should_cancel:
-                        should_cancel = (download.game is not None) and (download.game == queued_download.item.game)
+
                     # test for other assets
                     if not should_cancel:
                         should_cancel = download.save_location == queued_download.item.save_location
@@ -413,7 +411,7 @@ class DownloadManager:
             return
 
         for d in downloads:
-            if os.path.exists(d.save_location):
+            if os.path.exists(d.save_location) and self.__get_cancel_state(d) is DownloadState.STOPPED:
                 self.__request_download_cancel(d, cancel_state)
                 self.__notify_listeners(cancel_state, d)
 
@@ -445,7 +443,8 @@ class DownloadManager:
                 # Mark the task as done to keep counts correct so
                 # we can use join() or other functions later
                 download_queue.task_done()
-            time.sleep(0.02)
+
+            time.sleep(0.5)
 
     def __download_file(self, download, download_queue):
         """
@@ -457,29 +456,26 @@ class DownloadManager:
             The Download to download
         """
         self.__prepare_location(download.save_location)
-        download_max_attempts = 5
-        download_attempt = 0
+        # clear flags from previous attempts
+        self.__clear_cancel_state(download)
+
+        download_attempts = 5
         result = None
-        additional_info = []
-        last_error = None
-        while download_attempt < download_max_attempts:
+        while 0 < download_attempts:
             try:
                 start_point, download_mode = self.__get_start_point_and_download_mode(download)
                 result = self.__download_operation(download, start_point, download_mode)
+                self.logger.debug("Returning result from _download_operation: {}".format(result))
                 break
             except RequestException as e:
+                result = DownloadState.FAILED
                 self.logger.error("Received error downloading file [%s]: %s", download.url, e)
                 last_error = str(e)  # FIXME: need a way to remove token from error
-                download_attempt += 1
                 # TODO: maybe add an incrementally growing sleep time instead
-                if download_attempt < download_max_attempts:
+                if download_attempts > 0:
                     # only sleep when there are retries left
                     time.sleep(10)  # don't immediately use up all retries
-
-        if download_attempt == download_max_attempts:
-            result = DownloadState.FAILED
-            if last_error:
-                additional_info.append(last_error)
+            download_attempts -= 1
 
         # Successful downloads
         if result is DownloadState.COMPLETED:
@@ -492,6 +488,7 @@ class DownloadManager:
         if not result:
             result = DownloadState.FAILED
 
+        additional_info = [last_error] if last_error else []
         self.__notify_listeners(result, download, additional_params=additional_info)
         self._remove_from_active_downloads(download)
         self.__cleanup_meta(download, result)
@@ -642,13 +639,13 @@ class DownloadManager:
 
     def __download_callback(self, download, state, *params, forked=False):
         '''encapsulates invocation of callbacks on Download to assure uniform threading and
-        error safeguarding to not kill downloads threads by uncaught exceptions'''
+        error safeguarding to not kill download threads by uncaught exceptions'''
         if state in DownloadManager.STATE_DOWNLOAD_CALLBACKS:
-            callback = DownloadManager.STATE_DOWNLOAD_CALLBACKS[state]
             if forked:
-                self.__call_listener_failsafe(callback, download, *params)
+                callback = DownloadManager.STATE_DOWNLOAD_CALLBACKS[state]
+                self.__call_listener_failsafe(callback, download, state, *params)
             else:
-                self.listener_thread.submit(self.__download_callback, download, state, *params)
+                self.listener_thread.submit(self.__download_callback, download, state, *params, forked=True)
 
     def __is_pending(self, download):
         file = download.save_location
@@ -697,7 +694,6 @@ class DownloadManager:
         '''used to separate data structure of self.__cancel from the logic procedure of flagging a download for cancel'''
         if not self.__is_cancel_type(cancel_type):
             raise ValueError(str(cancel_type) + " is not a valid cancel reason")
-
         is_active = False
         with self.active_downloads_lock:
             if download in self.active_downloads:
@@ -715,6 +711,10 @@ class DownloadManager:
     def __cancel_requested(self, download):
         return download in self.__cancel
 
+    def __clear_cancel_state(self, download):
+        if download in self.__cancel:
+            del self.__cancel.get[download]
+
     def __get_cancel_state(self, download):
         return self.__cancel.get(download, None)
 
@@ -722,10 +722,9 @@ class DownloadManager:
         '''depending on the end state of a download, we might want to keep/remove a different set of state data
         about a download. That is what this method controls'''
         self.logger.debug('Cleaning up meta data for: %s', download.filename())
-        if self.__is_cancel_type(last_state) and download in self.__cancel:
-            del self.__cancel[download]
-
         if last_state in [DownloadState.CANCELED]:
+            if download in self.__cancel:
+                del self.__cancel[download]
             if os.path.isfile(download.save_location):
                 os.remove(download.save_location)
 

--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -461,6 +461,7 @@ class DownloadManager:
 
         download_attempts = 5
         result = None
+        last_error = None
         while 0 < download_attempts:
             try:
                 start_point, download_mode = self.__get_start_point_and_download_mode(download)
@@ -472,7 +473,7 @@ class DownloadManager:
                 self.logger.error("Received error downloading file [%s]: %s", download.url, e)
                 last_error = str(e)  # FIXME: need a way to remove token from error
                 # TODO: maybe add an incrementally growing sleep time instead
-                if download_attempts > 0:
+                if download_attempts > 1:
                     # only sleep when there are retries left
                     time.sleep(10)  # don't immediately use up all retries
             download_attempts -= 1


### PR DESCRIPTION
Time for a few more changes and pull requests. There's more to come later related to multi file downloads, but i need to get a few preconditions out of the way first. Or the PR will be too large again. This is a set of bugs i stumbled across while debugging my current work.

* bugfix in threading handling of __download_callback: __download_callback(forked=False) must also pass forked=True when submitting itself to the listener thread queue or it will lead to an infinite self-trigger
* `__download_file` did not properly handle retry counters
* improve filter logic needed to cancel STOPPED downloads to prevent duplicate events from being fired
* queued downloads will not test for equality of the game property anymore. This breaks the cancel logic for games consisting of multiple files
* reduce complexity

<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

<!-- Describe what was changed -->

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))

resolves #682 
