### PR TITLE
bugfix in DownloadManager

### DIFF
--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -714,7 +714,7 @@ class DownloadManager:
 
     def __clear_cancel_state(self, download):
         if download in self.__cancel:
-            del self.__cancel.get[download]
+            del self.__cancel[download]
 
     def __get_cancel_state(self, download):
         return self.__cancel.get(download, None)
@@ -724,8 +724,7 @@ class DownloadManager:
         about a download. That is what this method controls'''
         self.logger.debug('Cleaning up meta data for: %s', download.filename())
         if last_state in [DownloadState.CANCELED]:
-            if download in self.__cancel:
-                del self.__cancel[download]
+            self.__clear_cancel_state(download)
             if os.path.isfile(download.save_location):
                 os.remove(download.save_location)
 


### PR DESCRIPTION
I introduced another syntax error with my previous changes. Sorry about that.
I discovered it while testing where i received the following exception:

```
Traceback (most recent call last):
  File "/usr/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/usr/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karsten/git/minigalaxy/minigalaxy/download_manager.py", line 156, in <lambda>
    download_thread = threading.Thread(target=lambda: self.__download_thread(queue))
                                                      ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/home/karsten/git/minigalaxy/minigalaxy/download_manager.py", line 443, in __download_thread
    self.__download_file(download, download_queue)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/karsten/git/minigalaxy/minigalaxy/download_manager.py", line 461, in __download_file
    self.__clear_cancel_state(download)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/karsten/git/minigalaxy/minigalaxy/download_manager.py", line 718, in __clear_cancel_state
    del self.__cancel.get[download]
        ~~~~~~~~~~~~~~~~~^^^^^^^^^^
TypeError: 'builtin_function_or_method' object does not support item deletion

```

__clear_cancel_state had a syntax error because it tried to use `del dict.get[]` which does not work.

<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

<!-- Describe what was changed -->

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username)) (basically a bugfix of a bugfix which is already mentioned)
