### PR TITLE
Bugfix: Maintaining downloaded installers (cache and keep_installers option)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Allow more games to be launched via information from goggame.info (thanks to GB609)
 - The DLC list will now show a table-like multi-column view where necessary. This fixes issues with games having a high number of DLCs. (thanks to GB609)
 - Some bug fixes in DownloadManager related to canceling active and queued downloads (thanks to GB609)
+- Fix deletion logic of downloaded installation files. Base installers and DLC will not interfere with each other anymore. (thanks to GB609)
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -104,15 +104,6 @@ class Config:
         self.__write()
 
     @property
-    def keep_installer_history(self) -> bool:
-        return self.__config.get("keep_installer_history", False)
-
-    @keep_installer_history.setter
-    def keep_installer_history(self, new_value: bool) -> None:
-        self.__config["keep_installer_history"] = new_value
-        self.__write()
-
-    @property
     def stay_logged_in(self) -> bool:
         return self.__config.get("stay_logged_in", True)
 

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -104,6 +104,15 @@ class Config:
         self.__write()
 
     @property
+    def keep_installer_history(self) -> bool:
+        return self.__config.get("keep_installer_history", False)
+
+    @keep_installer_history.setter
+    def keep_installer_history(self, new_value: bool) -> None:
+        self.__config["keep_installer_history"] = new_value
+        self.__write()
+
+    @property
     def stay_logged_in(self) -> bool:
         return self.__config.get("stay_logged_in", True)
 

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -21,10 +21,10 @@ class Game:
         self.status_file_path = self.get_status_file_path()
 
     def get_stripped_name(self, to_path=False):
-        return self.__strip_string(self.name, to_path)
+        return self.strip_string(self.name, to_path)
 
     def get_install_directory_name(self):
-        return self.__strip_string(self.name, to_path=True)
+        return self.strip_string(self.name, to_path=True)
 
     def get_cached_icon_path(self, dlc_id=None):
         if dlc_id:
@@ -54,8 +54,9 @@ class Game:
             json.dump(json_dict, status_file)
 
     @staticmethod
-    def __strip_string(string, to_path=False):
-        return re.sub('[^A-Za-z0-9]+', '', string) if not to_path else re.sub('[^A-Za-z0-9 ]+', '', string)
+    def strip_string(string, to_path=False):
+        cleaned_string = re.sub('[^A-Za-z0-9]+', '', string) if not to_path else re.sub('[^A-Za-z0-9 ]+', '', string)
+        return cleaned_string.strip()  # make sure the directory does not start or end with any whitespace
 
     def is_installed(self, dlc_title="") -> bool:
         installed = False

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -21,7 +21,7 @@ class Game:
         self.status_file_path = self.get_status_file_path()
 
     def get_stripped_name(self, to_path=False):
-        return Game.strip_string(self.name, to_path)
+        return Game.strip_string(self.name, to_path=to_path)
 
     def get_install_directory_name(self):
         return Game.strip_string(self.name, to_path=True)

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -21,10 +21,10 @@ class Game:
         self.status_file_path = self.get_status_file_path()
 
     def get_stripped_name(self, to_path=False):
-        return self.strip_string(self.name, to_path)
+        return Game.strip_string(self.name, to_path)
 
     def get_install_directory_name(self):
-        return self.strip_string(self.name, to_path=True)
+        return Game.strip_string(self.name, to_path=True)
 
     def get_cached_icon_path(self, dlc_id=None):
         if dlc_id:

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -378,7 +378,7 @@ def remove_installer(game: Game, installer: str, keep_installers_dir: str, keep_
         # walk up and delete empty directories, but stop if the parent is one of the roots used by MG
         # this is just maintenance to prevent aggregating empty directories in cache
         remove_empty_dirs_upwards(installer_dir, installer_root_dirs)
-    except BaseException as e:
+    except Exception as e:
         logger.error(e)
         return str(e)
 

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -305,7 +305,7 @@ class LibraryEntry:
             download_dir = self.keep_path
 
         # DLC download go into subfolder of their own
-        cleaned_name = self.game.strip_string(download_info['name'], True)
+        cleaned_name = Game.strip_string(download_info['name'], True)
         if not download_dir.endswith(cleaned_name):
             download_dir = os.path.join(download_dir, cleaned_name)
 

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -136,6 +136,9 @@ class LibraryEntry:
         if os.path.isdir(self.keep_path):
             for dir_content in os.listdir(self.keep_path):
                 kept_file = os.path.join(self.keep_path, dir_content)
+                if not os.path.isfile(kept_file):
+                    continue
+
                 if os.access(kept_file, os.X_OK) or os.path.splitext(kept_file)[-1] in [".exe", ".sh"]:
                     exes_by_creation_date[int(os.path.getmtime(kept_file))] = kept_file
 
@@ -305,8 +308,9 @@ class LibraryEntry:
             download_dir = self.keep_path
 
         # DLC download go into subfolder of their own
-        cleaned_name = Game.strip_string(download_info['name'], True)
-        if not download_dir.endswith(cleaned_name):
+        last_dir = os.path.basename(download_dir)  # basename to avoid issues with trailing slashes
+        cleaned_name = Game.strip_string(download_info['name'], to_path=True)
+        if last_dir != cleaned_name:
             download_dir = os.path.join(download_dir, cleaned_name)
 
         return download_dir

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -132,12 +132,18 @@ class LibraryEntry:
 
     def get_keep_executable_path(self):
         keep_path = ""
+        exes_by_creation_date = {}
         if os.path.isdir(self.keep_path):
             for dir_content in os.listdir(self.keep_path):
                 kept_file = os.path.join(self.keep_path, dir_content)
                 if os.access(kept_file, os.X_OK) or os.path.splitext(kept_file)[-1] in [".exe", ".sh"]:
-                    keep_path = kept_file
-                    break
+                    exes_by_creation_date[int(os.path.getmtime(kept_file))] = kept_file
+
+        if exes_by_creation_date:
+            ctimes_sorted = [*exes_by_creation_date.keys()]
+            ctimes_sorted.sort()
+            keep_path = exes_by_creation_date[ctimes_sorted[-1]]
+
         return keep_path
 
     def get_download_info(self, platform="linux"):
@@ -185,8 +191,8 @@ class LibraryEntry:
                 dlc_icon = self.game.get_cached_icon_path(dlc_id)
                 dlc_title = dlc["title"]
 
-        def finish_func(save_location):
-            self.__install_dlc(save_location, dlc_title=dlc_title)
+        def finish_func(save_location, file_list=None):
+            self.__install_dlc(save_location, dlc_title=dlc_title, file_list=file_list)
 
         cancel_to_state = State.INSTALLED
         result = self.__download(download_info, DownloadType.GAME_DLC, finish_func,
@@ -218,6 +224,7 @@ class LibraryEntry:
     def __download(self, download_info, download_type, finish_func, cancel_to_state, download_icon=None):  # noqa: C901
         download_success = True
         self.game.set_install_dir(self.config.install_dir)
+        target_download_dir = self.__determine_download_dir(download_info)
         self.update_to_state(State.QUEUED)
 
         if not download_icon:
@@ -239,7 +246,10 @@ class LibraryEntry:
                 if self.download_finished == number_of_files:
                     # Assume the first item in download_info['files] is the executable
                     # This item ends up last in self.download_list because it's reversed
-                    finish_func(self.download_list[-1].save_location)
+                    save_locations = []
+                    for d in download_files:
+                        save_locations.append(d.save_location)
+                    finish_func(self.download_list[-1].save_location, file_list=save_locations)
 
             if func is not None:
                 return wrapper
@@ -259,7 +269,7 @@ class LibraryEntry:
             # Extract the filename from the download url
             filename = urllib.parse.unquote(urllib.parse.urlsplit(download_url).path)
             filename = filename.split("/")[-1]
-            download_path = os.path.join(self.download_dir, filename)
+            download_path = os.path.join(target_download_dir, filename)
             if info.md5:
                 self.game.md5sum[os.path.basename(download_path)] = info.md5
             download = Download(
@@ -289,23 +299,35 @@ class LibraryEntry:
 
         return download_success
 
+    def __determine_download_dir(self, download_info):
+        download_dir = self.download_dir
+        if self.config.keep_installers:
+            download_dir = self.keep_path
+
+        # DLC download go into subfolder of their own
+        cleaned_name = self.game.strip_string(download_info['name'], True)
+        if not download_dir.endswith(cleaned_name):
+            download_dir = os.path.join(download_dir, cleaned_name)
+
+        return download_dir
+
     '''----- END DOWNLOAD ACTIONS -----'''
 
     '''----- INSTALL ACTIONS -----'''
 
-    def __install_game(self, save_location):
+    def __install_game(self, save_location, file_list=None):
         self.config.remove_ongoing_download(self.game.id)
         self.download_list = []
         self.game.set_install_dir(self.config.install_dir)
-        install_success = self.__install(save_location)
+        install_success = self.__install(save_location, file_list=file_list)
         if install_success:
             popup = Notify.Notification.new("Minigalaxy", _("Finished downloading and installing {}")
                                             .format(self.game.name), "dialog-information")
             popup.show()
             self.__check_for_dlc(self.api.get_info(self.game))
 
-    def __install_update(self, save_location):
-        install_success = self.__install(save_location, update=True)
+    def __install_update(self, save_location, file_list=None):
+        install_success = self.__install(save_location, update=True, file_list=file_list)
         if install_success:
             if self.game.platform == "windows":
                 self.image.set_tooltip_text("{} (Wine)".format(self.game.name))
@@ -316,13 +338,13 @@ class LibraryEntry:
             if self.game.is_update_available(version_from_api=download_info["version"], dlc_title=dlc["title"]):
                 self.__download_dlc(dlc["downloads"]["installers"])
 
-    def __install_dlc(self, save_location, dlc_title):
-        install_success = self.__install(save_location, dlc_title=dlc_title)
+    def __install_dlc(self, save_location, dlc_title, file_list=None):
+        install_success = self.__install(save_location, dlc_title=dlc_title, file_list=file_list)
         if not install_success:
             self.update_to_state(State.INSTALLED)
         self.__check_for_update_dlc()
 
-    def __install(self, save_location, update=False, dlc_title=""):
+    def __install(self, save_location, update=False, dlc_title="", file_list=None):
         if update:
             processing_state = State.UPDATING
             failed_state = State.INSTALLED
@@ -337,7 +359,8 @@ class LibraryEntry:
             self.config.lang,
             self.config.install_dir,
             self.config.keep_installers,
-            self.config.create_applications_file
+            self.config.create_applications_file,
+            file_list=file_list
         )
 
         if not err_msg:

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, mock_open, MagicMock
 from minigalaxy.game import Game
 from minigalaxy import installer
 from minigalaxy.translation import _
+import minigalaxy
 
 
 class Test(TestCase):
@@ -339,82 +340,106 @@ class Test(TestCase):
         exp = "No installer directory is present: /home/i/.cache/minigalaxy/download/Beneath a Steel Sky"
         self.assertEqual(obs, exp)
 
-    @mock.patch('os.path.isdir')
-    @mock.patch('minigalaxy.installer.compare_directories')
-    @mock.patch('shutil.rmtree')
+    @mock.patch("os.path.isdir")
+    @mock.patch("os.path.realpath")
+    @mock.patch("minigalaxy.installer.is_empty_dir")
     @mock.patch('os.remove')
+    @mock.patch("os.path.isfile")
+    @mock.patch('os.rmdir')
     @mock.patch('os.listdir')
-    def test_remove_installer_no_keep(self, mock_list_dir, mock_os_remove, mock_shutil_rmtree, mock_compare_directories, mock_os_path_isdir):
-        """
-        Disabled keep_installer
-        """
-        mock_os_path_isdir.return_value = True
-        mock_compare_directories.return_value = False
-        mock_list_dir.return_value = ["beneath_a_steel_sky_en_gog_2_20150.sh"]
+    def test_remove_installer_no_keep(self, mock_listdir, mock_rmdir, mock_isfile, mock_remove, mock_isempty, mock_realpath, mock_isdir):
+        """Disabled keep_installer"""
+        DL_DIR = "/home/i/.cache/minigalaxy/download"
+        mock_realpath.side_effect = lambda p: DL_DIR if p == minigalaxy.paths.DOWNLOAD_DIR else p
+        list_dir_returns = {
+            "/home/i/.cache/minigalaxy": ["download", "icons"],
+            DL_DIR: ["Beneath a Steel Sky"],
+            "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky": ["beneath_a_steel_sky_en_gog_2_20150.sh"],
+        }
+
+        self.setup_os_mocks(list_dir_returns, mock_listdir, mock_rmdir, mock_isfile, mock_remove, mock_isempty, mock_isdir)
 
         game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
         installer_path = "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         obs = installer.remove_installer(game1, installer_path, "/some/directory/test", False)
-        assert mock_os_remove.called
-        assert not mock_shutil_rmtree.called
+
+        assert mock_remove.called
         self.assertEqual(obs, "")
 
+    @mock.patch("os.path.isdir")
     @mock.patch('os.remove')
-    @mock.patch('shutil.rmtree')
-    @mock.patch('minigalaxy.installer.compare_directories')
-    @mock.patch('os.path.isdir')
-    def test_remove_installer_same_content(self, mock_os_path_isdir, mock_compare_directories, mock_shutil_rmtree, mock_os_remove):
-        """
-        Same content of installer and keep dir
-        """
-        mock_os_path_isdir.return_value = True
-        mock_compare_directories.return_value = True
+    @mock.patch("os.path.isfile")
+    @mock.patch('os.rmdir')
+    @mock.patch('os.listdir')
+    def test_remove_installer_keep(self, mock_listdir, mock_rmdir, mock_isfile, mock_remove, mock_isdir):
+        """Keep installer dir"""
+
+        list_dir_returns = {
+            "/home/i/GOG Games/installer": ["Beneath a Steel Sky"],
+            "/home/i/GOG Games/installer/Beneath a Steel Sky": ["beneath_a_steel_sky_en_gog_2_20150.sh"]
+        }
+
+        mock_listdir.side_effect = lambda path: list_dir_returns.get(path, [])
+        mock_isfile.return_value = True
+        mock_isdir.return_value = True
 
         game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
-        installer_path = "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
+        installer_path = "/home/i/GOG Games/installer/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         obs = installer.remove_installer(game1, installer_path, "/home/i/GOG Games/installer", True)
-        assert not mock_shutil_rmtree.called
-        assert not mock_os_remove.called
+        assert not mock_remove.called
+        assert not mock_rmdir.called
         self.assertEqual(obs, "")
 
+    @mock.patch("os.path.isdir")
+    @mock.patch("os.path.realpath")
+    @mock.patch("minigalaxy.installer.is_empty_dir")
     @mock.patch('os.remove')
-    @mock.patch('shutil.move')
-    @mock.patch('shutil.rmtree')
-    @mock.patch('minigalaxy.installer.compare_directories')
-    @mock.patch('os.path.isdir')
-    def test_remove_installer_keep(self, mock_os_path_isdir, mock_compare_directories, mock_shutil_rmtree, mock_shutil_move, mock_os_remove):
-        """
-        Keep installer dir
-        """
-        mock_os_path_isdir.return_value = True
-        mock_compare_directories.return_value = False
+    @mock.patch("os.path.isfile")
+    @mock.patch('os.rmdir')
+    @mock.patch('os.listdir')
+    def test_remove_installer_from_keep(self, mock_listdir, mock_rmdir, mock_isfile, mock_remove, mock_isempty, mock_realpath, mock_isdir):
+        """ Called from keep dir"""
 
-        game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath a Steel Sky", platform="linux")
-        installer_path = "/home/i/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
-        obs = installer.remove_installer(game1, installer_path, "/home/i/GOG Games/installer", True)
-        assert mock_shutil_rmtree.called
-        assert mock_shutil_move.called
-        assert not mock_os_remove.called
-        self.assertEqual(obs, "")
+        DL_DIR = "/home/i/.cache/minigalaxy/download"
+        mock_realpath.side_effect = lambda p: DL_DIR if p == minigalaxy.paths.DOWNLOAD_DIR else p
+        list_dir_returns = {
+            "/home/i/GOG Games": ["installer"],
+            "/home/i/GOG Games/installer": ["Beneath A Steel Sky"],
+            "/home/i/GOG Games/installer/Beneath A Steel Sky": []
+        }
 
-    @patch("os.listdir")
-    @mock.patch('os.remove')
-    @mock.patch('shutil.move')
-    @mock.patch('shutil.rmtree')
-    @mock.patch('minigalaxy.installer.compare_directories')
-    @mock.patch('os.path.isdir')
-    def test_remove_installer_from_keep(self, mock_os_path_isdir, mock_compare_directories, mock_shutil_rmtree, mock_shutil_move, mock_os_remove, mock_os_listdir):
-        """
-        Called from keep dir
-        """
-        mock_os_path_isdir.return_value = True
-        mock_compare_directories.return_value = False
-        mock_os_listdir.return_value = []
+        self.setup_os_mocks(list_dir_returns, mock_listdir, mock_rmdir, mock_isfile, mock_remove, mock_isempty, mock_isdir)
 
         game1 = Game("Beneath A Steel Sky", install_dir="/home/test/GOG Games/Beneath A Steel Sky", platform="linux")
         installer_path = "/home/i/GOG Games/installer/Beneath A Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         obs = installer.remove_installer(game1, installer_path, "/home/i/GOG Games/installer", False)
-        assert not mock_shutil_rmtree.called
-        assert not mock_shutil_move.called
-        assert not mock_os_remove.called
+
+        assert not mock_remove.called
         self.assertEqual(obs, "")
+
+    def setup_os_mocks(self, file_structure, mock_listdir, mock_rmdir, mock_isfile, mock_remove, mock_isempty, mock_isdir):
+
+        def rmdir_fake(path):
+            if path in file_structure and len(file_structure[path]) == 0:
+                # remove dir content listing itself
+                del file_structure[path]
+                # remove entry from parent list
+                remove_fake(path)
+            else:
+                raise IOError("Directory not empty")
+
+        def remove_fake(path):
+            from os.path import dirname, basename
+            filedir = dirname(path)
+            filename = basename(path)
+            if filedir in file_structure and filename in file_structure[filedir]:
+                file_structure[filedir].remove(filename)
+            else:
+                raise FileNotFoundError(path)
+
+        mock_isfile.side_effect = lambda path: path.endswith(".sh")
+        mock_isdir.return_value = lambda path: path in file_structure
+        mock_listdir.side_effect = lambda path: file_structure.get(path, [])
+        mock_isempty.side_effect = lambda path: len(file_structure.get(path)) == 0
+        mock_rmdir.side_effect = rmdir_fake
+        mock_remove.side_effect = remove_fake

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -9,8 +9,9 @@ import minigalaxy
 
 
 class Test(TestCase):
+    @mock.patch('os.listdir')
     @mock.patch('os.path.exists')
-    def test_install_game(self, mock_exists):
+    def test_install_game(self, mock_exists, mock_listdir):
         """[scenario: unhandled error]"""
         mock_exists.side_effect = FileNotFoundError("Testing unhandled errors during install")
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
@@ -33,7 +34,7 @@ class Test(TestCase):
                          "Beneath a Steel Sky/{}".format(installer_name)
         exp = ""
         with patch("builtins.open", mock_open(read_data=b"")):
-            obs = installer.verify_installer_integrity(game, installer_path)
+            obs = installer.verify_installer_integrity(game, [installer_path])
         self.assertEqual(exp, obs)
 
     @mock.patch('os.path.exists')
@@ -52,7 +53,7 @@ class Test(TestCase):
                          "Beneath a Steel Sky/{}".format(installer_name)
         exp = _("{} was corrupted. Please download it again.").format(installer_name)
         with patch("builtins.open", mock_open(read_data=b"aaaa")):
-            obs = installer.verify_installer_integrity(game, installer_path)
+            obs = installer.verify_installer_integrity(game, [installer_path])
         self.assertEqual(exp, obs)
 
     @mock.patch('os.path.exists')


### PR DESCRIPTION
This PR fixes a list of long-standing bugs related to the keep_installers option, but also related to the issues with parallel DLC installations interfering with each other by file deletions.

This might not appear to be related to my current main work - the download issues - at first glance, yet it is very much related. I can't really fully fix parallel dlc downloads when the installations keep interfering with each other. There's no point if the downloads succeed and can be done in parallel but they can't be applied because of misbehaving installs.

## General assumption/approach of the new behaviour:
* Downloads will go to the final target directory directly - no post-install moving from cache anymore.
* A fixed directory structure. Basically everything that has its own id on gog gets its own directory, dlcs and base game files will not be in the same directory anymore, not even in cache. Dlcs installers will go into subdirs of the base game installers dir 
  * Base games: `[download_target_dir]/[game_name]/[installer_name][.extension=(.exe, .sh, -n.bin...)]`
  * DLCs: `[download_target_dir]/[game_name]/[dlc_name]/[installer_name][.extension=(.exe, .sh, -n.bin...)]`
  * `[download_target_dir]`: either `config.install_dir/installer` or `.cache/minigalaxy/download`
  * `[game_name]` and `[dlc_name]`: as returned from gog api, stripped of problematic characters. While i added this, i also fixed #679
  * `[installer_name]`: currently seems to be something like `setup_gamename_version.extension`. As long as that is given, it's theoretically possibly to hold several versions in parallel in the same directory (which isn't supported yet). When there are name collisions because the names are generic, new version downloads will overwrite old, leading to less deletions of old files afterwards (basically only when the previous version had more files than the more recent version)
 * A game download consisting of multiple files will place all of its files in the same directory, not litter them across multiple dirs.

## With the assumptions above, the following was implemented:
1. Game downloads go to real target directly: when `keep_installers=True`, `LibraryEntry.__download` will set up save_locations to be under `config.install_dir/installers`, according to the fixed directory structure described above. This has the added benefit, that already downloaded files do not have to be moved around after installation which saves a lot of IO, especially for large games. 
2. Improved directory structure: When downloading a DLC, the save_location will additionally be placed under a directory named after the DLC. This prevents deletion of too many files when a dlc is downloaded and installed.
3. All download finish callbacks get a list of file name, which is passed to install_game
4. `installer.py:remove_installer` builds a list of files to keep depending on the value of keep_installers and the passed in file list:
 * if keep_installers=False, `keep_list=[]` - all direct child files (**not** directories) in the current directory are removed.
 * if keep_installers=True and `keep_list != None`, use that list and delete other not in that list
 * if keep_installers=True and `keep_list == None or empty`, use `installer_name` without extension as filter for files to keep. This case is necessary when the install is started from an already downloaded file.
 * The clean up will not recurse down into subfolders because subfolders would be dlcs. And only files, not directories, will be deleted when not on the keep_list. Directories are only deleted when they are empty after they were processed by the filtered file deletion.
5. Additional maintenance code: remove_installer will walk the directory tree upwards after deleting all files it should delete and remove parent directories in the path of game download files that have become empty. This is mostly used to wipe sub-directories under `.cache/minigalaxy/downloads` when installing a DLC and then remove the now-empty parent dir named after the game.
Walking upwards stops at `config.install_dir/installer` and `.cache/minigalaxy/downloads`, so these root directories are not deleted.
Constructed example: `.cache/download/Rayman/Rayman-inAppPurchase/dlc_installer.exe`. With `keep_installers=False`, `dlc_installer.exe` will be deleted, leaving `Rayman-inAppPurchase` as an empty dir, which is deleted afterwards. Then the parent of `Rayman-inAppPurchase`=`Rayman` is checked, if it is empty and will be deleted if it is. The next parent is `downloads`, which is in the list of iteration stopping dir names. Therefore the check and recursion will stop there.
6. When installing from pre-downloaded files in `LibraryEntry:get_keep_executable_path()`, local executables in the keep directory are sorted after modification time and the most recent is picked for now (in case there are several due to some previous error with deletions).

## Open points:
1. The UI does not yet permit to install pre-downloaded DLCs. The download would be restarted either way, BUT - if DownloadManager determines the files to be identical to what is in the `installer` dir - would complete almost instantly. So we can then still avoid a full redownload of something that's already there.
2. This fix and approach can basically support keeping several old versions in parallel. For this, another setting, like `keep_installer_history` would be required to prevent deletions of old versions in `remove_installer`, and some kind of UI support would have to be added.
3. The current assumption for pre-downloaded installers that all related files share a common name prefix might not necessarily hold in the future. To fix this we could write simple inventory json files when downloads are finished. This would also make maintaining multiple version easier.

## Issues
- fixes #677
- fixes #579
- fixes #513

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
