### PR TITLE
DownloadList: Update download instance held by entry

### DIFF
--- a/minigalaxy/download_manager.py
+++ b/minigalaxy/download_manager.py
@@ -411,7 +411,7 @@ class DownloadManager:
             return
 
         for d in downloads:
-            if os.path.exists(d.save_location) and self.__get_cancel_state(d) is DownloadState.STOPPED:
+            if self.__get_cancel_state(d) is DownloadState.STOPPED:
                 self.__request_download_cancel(d, cancel_state)
                 self.__notify_listeners(cancel_state, d)
 
@@ -695,11 +695,10 @@ class DownloadManager:
         '''used to separate data structure of self.__cancel from the logic procedure of flagging a download for cancel'''
         if not self.__is_cancel_type(cancel_type):
             raise ValueError(str(cancel_type) + " is not a valid cancel reason")
-        is_active = False
+
+        self.__cancel[download] = cancel_type
         with self.active_downloads_lock:
-            if download in self.active_downloads:
-                self.__cancel[download] = cancel_type
-                is_active = True
+            is_active = download in self.active_downloads
 
         # active downloads are taken care of in __download_file
         if not is_active and self.__is_cancel_type(cancel_type):

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -113,10 +113,12 @@ class DownloadManagerList(Gtk.ScrolledWindow):
         download_entry.update_progress(download.current_progress)
 
     def __get_create_entry(self, change, download):
+        location = download.save_location
         if download.save_location not in self.downloads:
-            self.downloads[download.save_location] = OngoingDownloadListEntry(self, download, change)
+            self.downloads[location] = OngoingDownloadListEntry(self, download, change)
 
-        return self.downloads[download.save_location]
+        self.downloads[location].update_download_instance(download)
+        return self.downloads[location]
 
     def __move_to_section(self, flowbox, entry, new_state: DownloadState):
         in_done_section = entry.flowbox == self.flowbox_done
@@ -193,18 +195,33 @@ class OngoingDownloadListEntry(Gtk.Box):
     def __init__(self, parent_manager, download: Download, initial_state: DownloadState):
         Gtk.Box.__init__(self)
         self.manager = parent_manager
-        self.download = download
         self.flowbox = None
         self.label_color_change = None
-        self.game_title.set_text(f'{download.game.name}:\n{os.path.basename(download.save_location)}')
         self.buttons = DownloadActionButtons(download, initial_state,
                                              download_manager=parent_manager.download_manager,
                                              remove_panel_action=self.remove_from_current_box,
                                              logger=self.manager.logger)
+        self.download = None
+        self.update_download_instance(download)
         self.update_state(initial_state)
 
-        self.manager.logger.debug("trying to pull icon from: %s", download.download_icon)
-        if download.download_icon:
+        self.pack_start(self.buttons, False, False, 0)
+
+    def update_download_instance(self, download: Download):
+        '''
+        A download might be re-triggered with a new download instance which has the same save_location.
+        Update and keep the list entry for it to make sure all buttons keep working and
+        pass the correct instance to DownloadManager.
+        '''
+        if download is self.download:
+            return
+        print("updating download instance:", download.save_location)
+        self.game_title.set_text(f'{download.game.name}:\n{os.path.basename(download.save_location)}')
+        self.buttons.download = download
+
+        current_icon = self.download.download_icon if self.download else None
+        if download.download_icon and download.download_icon != current_icon:
+            self.manager.logger.debug("trying to pull icon from: %s", download.download_icon)
             if os.path.exists(download.download_icon):
                 self.set_icon_from_file(download.download_icon)
             else:
@@ -212,7 +229,7 @@ class OngoingDownloadListEntry(Gtk.Box):
                 awaiting_entries.append(self)
                 self.manager.pending_icons[download.download_icon] = awaiting_entries
 
-        self.pack_start(self.buttons, False, False, 0)
+        self.download = download
 
     def update_progress(self, percentage):
         self.download_progress.set_fraction(percentage / 100)

--- a/minigalaxy/ui/download_list.py
+++ b/minigalaxy/ui/download_list.py
@@ -215,7 +215,6 @@ class OngoingDownloadListEntry(Gtk.Box):
         '''
         if download is self.download:
             return
-        print("updating download instance:", download.save_location)
         self.game_title.set_text(f'{download.game.name}:\n{os.path.basename(download.save_location)}')
         self.buttons.download = download
 


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This is a small fix for the bug i described here: https://github.com/sharkwouter/minigalaxy/issues/684#issuecomment-2862303749. I did say that it's not as high in priority as others, but it seems we do run into it frequently while testing other changes. So it needs a fix if only to not obstruct other tests.

I've also fixed the issue with stopping/deleting not working in all cases (hopefully).
Main problem was going from queued (not active) downloads to stop did not update states in download manager correctly.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (the implementation of the download list ui is already in the changelog, i'm just fixing a bug in my own code)
