### PR TITLE
Feature/async install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - The DLC list will now show a table-like multi-column view where necessary. This fixes issues with games having a high number of DLCs. (thanks to GB609)
 - Some bug fixes in DownloadManager related to canceling active and queued downloads (thanks to GB609)
 - Fix deletion logic of downloaded installation files. Base installers and DLC will not interfere with each other anymore. (thanks to GB609)
+- Failed installs will try to keep as many downloaded parts as possible, even without the keep_installers option enabled. (thanks to GB609)
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/tests/test_installer_queue.py
+++ b/tests/test_installer_queue.py
@@ -1,0 +1,140 @@
+import time
+
+from unittest import TestCase, mock
+from unittest.mock import MagicMock
+from threading import RLock, Thread
+
+from minigalaxy.game import Game
+from minigalaxy import installer
+
+
+class Test(TestCase):
+
+    def test_no_duplicates(self):
+        '''[scenario: InstallerQueue.put() must ignore items which are equal to already placed items.]'''
+        lock = RLock()  # use inserted lock to prevent the installer thread from picking items
+        test_queue = installer.InstallerQueue(lock)
+
+        # use try-finally because of queue.clear() to stop worker
+        try:
+            items_to_put = [32, "something", 32, "another", "another"]
+            lock.acquire()
+
+            for i in items_to_put:
+                test_queue.put(i)
+
+            self.assertEqual(3, len(test_queue.queue), "There should be 3 items with no duplicates on the queue")
+            self.assertEqual([32, "something", "another"], [*test_queue.queue])
+        finally:
+            test_queue.queue.clear()
+            lock.release()
+
+    def test_install_thread_lifecycle(self):
+        '''[scenario: The install worker thread of InstallerQueue must only run when there are items on the queue]'''
+        lock = RLock()  # use inserted lock to prevent the installer thread from picking items
+        test_queue = installer.InstallerQueue(lock)
+        self.assertIsNone(test_queue.worker, "Worker thread should not be spawned by default")
+
+        # use try-finally because of queue.clear() to stop worker
+        try:
+            lock.acquire()
+            item = MagicMock()
+            test_queue.put(item)
+            self.assertIsInstance(test_queue.worker, Thread)
+            self.assertTrue(test_queue.worker.is_alive(), "worker thread should be assigned and alive after put")
+            spawned_worker = test_queue.worker
+
+            # let the worker thread do its work
+            lock.release()
+            time.sleep(0.5)
+
+            # then take the lock again
+            lock.acquire()
+
+            item.execute.assert_called_once()
+
+            # worker must be dead and gone
+            self.assertTrue(test_queue.empty(), "Queue should be empty again")
+            self.assertFalse(spawned_worker.is_alive(), "Worker thread should be dead when the queue is empty")
+            self.assertIsNone(test_queue.worker, "Worker thread should be gone")
+        finally:
+            test_queue.queue.clear()
+            lock.release()
+
+    @mock.patch('minigalaxy.installer.InstallerQueue')
+    def test_enqueue_game_install_lazy_init(self, mock_queue_class):
+        '''[scenario: The very first invocation of installer.enqueue_game_install creates the global InstallerQueue]'''
+
+        installer.INSTALL_QUEUE = None
+
+        queue_instance = MagicMock()
+        mock_queue_class.return_value = queue_instance
+
+        self.assertIsNone(installer.INSTALL_QUEUE, "Global INSTALL_QUEUE must not exist yet")
+        game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
+        installer.enqueue_game_install("42", MagicMock(), game, "/path/to/installer")
+
+        self.assertIs(queue_instance, installer.INSTALL_QUEUE)
+        queue_instance.put.assert_called_once()
+
+    @mock.patch('minigalaxy.installer.install_game')
+    def test_enqueue_game(self, mock_install):
+        """[scenario: Game gets queued and ultimately runs into install_game]"""
+
+        installer.INSTALL_QUEUE = None
+        result_callback = MagicMock()
+
+        game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
+        installer.enqueue_game_install(12345, result_callback,
+                                       game, installer="adrift.exe", language="", install_dir="",
+                                       keep_installers=False, create_desktop_file=True)
+        time.sleep(0.5)
+        lock = installer.INSTALL_QUEUE.state_lock
+        with lock:
+            mock_install.assert_called_once()
+            result_callback.assert_called_once_with(installer.InstallResult(
+                12345, installer.InstallResultType.SUCCESS, "/home/makson/GOG Games/Absolute Drift"
+            ))
+
+    @mock.patch('minigalaxy.installer.install_game')
+    def test_enqueue_game_failure(self, mock_install):
+        """[scenario: Game gets queued and ultimately runs into install_game]"""
+
+        installer.INSTALL_QUEUE = None
+        result_callback = MagicMock()
+        mock_install.side_effect = installer.InstallException("error")
+
+        game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
+        installer.enqueue_game_install(12345, result_callback,
+                                       game, installer="adrift.exe", language="", install_dir="",
+                                       keep_installers=False, create_desktop_file=True)
+        time.sleep(0.5)
+        lock = installer.INSTALL_QUEUE.state_lock
+        with lock:
+            mock_install.assert_called_once()
+            result_callback.assert_called_once_with(installer.InstallResult(
+                12345, installer.InstallResultType.FAILURE, "error"
+            ))
+
+    def test_InstallTask_init_requires_callback(self):
+        '''[scenario: InstallTask__init__ enforces result_callback to be a callable]'''
+
+        game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
+        with self.assertRaises(ValueError) as cm:
+            installer.InstallTask(815, "not-a-callable", game)
+        # the search for a Game instance happens before the check of callback, so assert the message as well
+        self.assertEqual("result_callback is required", str(cm.exception))
+
+    def test_InstallTask_init_requires_Game(self):
+        '''[scenario: InstallTask__init__ must have received a Game instance as part of *args or **kwargs]'''
+
+        def callback(): pass
+
+        game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
+
+        with self.assertRaises(ValueError) as cm:
+            installer.InstallTask(815, callback)
+        self.assertEqual("No instance of Game in InstallTask constructor arguments", str(cm.exception))
+
+        # counter-test: pass game as part of kwargs, it should not raise an exception
+        installer.InstallTask(815, callback, game=game)


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This is a part of #690, created in an attempt to reduce review efforts.

I've split out the new capabilities of `installer.py` for async installations into the new PR.
It only contains the additions in `installer.py`, plus changes in tests to make sure it is working. The async install is NOT used by `LibraryEntry` yet.

Some minor changes in this PR might have an impact on installations (and the UI), even now:
1. I've re-ordered the installation steps to something that made more sense to me. Most notable: Deleting installer files is NOT a guaranteed quasi-finally step after the installation. It is part of it. As such, an installation that might fail because of disk size issues will NOT delete downloaded installers. Exception to this are failures because of checksums. Even then i've tried to only delete the files which are actually invalid.
2. I've increased the chunk size used when reading files for checksum calculations from 4KB to 8KB. My PC is pretty old and that gave a noticeable speed increase (around 0.7 less time taken for the installer of Coromon, which is one file of about 900MB, think about games of 10+ files with 4GB in size). I plan to do a bit of experimentation and time measurement because i think we can increase it some more, to 16k or 32k. The larger the buffer, the less often python needs to switch context/threads between io and the python process (which also has a cost). It also means longer slices of time where other threads like the UI/Main thread can run. [Python hashlib](https://docs.python.org/3/library/hashlib.html) docs state that it releases the gil when data > 2047 bytes is passed. As such, increasing the buffer mostly means less reads, less context changes and opens up the GIL much more. We're generally reading files with hundreds of megabytes or even gigabytes in size. Reading them in baby steps of 4K on modern computers seems like overkill.

## Open points
1. To properly handle incomplete/invalid downloads and partial re-download on errors, we need a bit more code and persistent data from `LibraryEntry._download` to correctly detect that all parts of a game have been downloaded. This mostly concerns situations with resuming downloads after restart when `keep_installers` is enabled.
I haven't touched that yet.

2. Graceful shutdown: For this, some additions to the `InstallerQueue` class are required. I'll introduce this the moment we update `LibraryEntry` to use async installations. For now, it wouldn't make a difference anyway and just increase the code to review.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
