### PR TITLE
move DLC install/update logic to DlcListEntry

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -150,10 +150,20 @@ class Api:
         response = self.__request(request_url)
         return response
 
+    def get_dlc_info(self, game: Game, dlc_id):
+        full_info = self.get_info(game)
+        dlc_infos = full_info.get("expanded_dlcs", [])
+        for dlc in dlc_infos:
+            if dlc.get('id', -1) == dlc_id:
+                return dlc
+
     # This returns a unique download url and a link to the checksum of the download
-    def get_download_info(self, game: Game, operating_system="linux", dlc_installers="") -> dict:
+    def get_download_info(self, game: Game, operating_system="linux", dlc_installers="", dlc_id="") -> dict:
         if dlc_installers:
             installers = dlc_installers
+        elif dlc_id:
+            response = self.get_dlc_info(game, dlc_id)
+            installers = response["downloads"]["installers"]
         else:
             response = self.get_info(game)
             installers = response["downloads"]["installers"]

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -2,7 +2,7 @@ import os
 import re
 import json
 
-from minigalaxy.paths import CONFIG_GAMES_DIR, ICON_DIR
+from minigalaxy.paths import CONFIG_GAMES_DIR, ICON_DIR, THUMBNAIL_DIR
 
 
 class Game:
@@ -31,6 +31,29 @@ class Game:
             return os.path.join(ICON_DIR, f"{dlc_id}.jpg")
         else:
             return os.path.join(ICON_DIR, f'{self.id}.png')
+
+    def get_thumbnail_path(self, use_fallback=True):
+        """
+        Returns path to thumbnail file. Has 2 ways to use:
+        1. As a file name/path factory - files don't have to exist
+        2. To find the actually existing file
+        Looks in 2 locations:
+        - game.install_dir: When game is installed and file exists.
+          use_fallback=False enforces returning this path even when the file
+          does not exist. But the game must still be installed.
+        - global thumbnail dir as denoted by minigalaxy.paths.THUMBNAIL_DIR
+        """
+
+        if self.is_installed():
+            thumbnail_file = os.path.join(self.install_dir, "thumbnail.jpg")
+            if os.path.isfile(thumbnail_file) or not use_fallback:
+                return thumbnail_file
+
+        thumbnail_file = os.path.join(THUMBNAIL_DIR, f"{self.id}.jpg")
+        if os.path.isfile(thumbnail_file) or use_fallback:
+            return thumbnail_file
+
+        return ""
 
     def get_status_file_path(self):
         if self.install_dir:


### PR DESCRIPTION
This is another split part of #690, mostly consisting of refactoring and some bug fixes.

~~Since i'm currently working at a PC where i can't properly perform manual tests, i've put it up as a draft PR first. I'll go through that as soon as i can tonight.~~
(Edit: Works well enough for an intermediate commit)

Changes included here:
- Moved some download/install methods to `DlcListEntry`
- A bit of refactoring regarding the handling of thumbnails:
  * redundant retry loop removed
  * logic in `__set_image` simplified
  * building of thumbnail path moved to helper `Game.get_thumbnail_path`
- editorials like changing `'''` in docstring to `"""` according to recommendation from IDE
- resuming DLCs downloads was triggered in the wrong location and didn't work before
- some changes to get the state of `LibraryEntry` updated correctly again

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
