### PR TITLE
Disable webkit compositing mode by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Large DLC downloads will be resumed automatically on restart. (thanks to GB609)
 - Improved shutdown logic of Minigalaxy. If there is an installation running, it will be finished. (thanks to GB609)
 - Simple fix progress bar for games consisting of multiple files. (thanks to GB609)
+- Fix log in screen remaining blank on some distributions
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/bin/minigalaxy
+++ b/bin/minigalaxy
@@ -56,7 +56,7 @@ def main():
     if cli_args.reset: conf_reset()
 
     # Disable webkit compositing, ensuring the login screen shows
-    os.environ["WEBKIT_DISABLE_COMPOSITING_MODE"] = 1
+    os.environ["WEBKIT_DISABLE_COMPOSITING_MODE"] = "1"
 
     # Import the gi module after parsing arguments
     import signal

--- a/bin/minigalaxy
+++ b/bin/minigalaxy
@@ -55,6 +55,9 @@ def main():
 
     if cli_args.reset: conf_reset()
 
+    # Disable webkit compositing, ensuring the login screen shows
+    os.environ["WEBKIT_DISABLE_COMPOSITING_MODE"] = 1
+
     # Import the gi module after parsing arguments
     import signal
     from minigalaxy import installer
@@ -62,7 +65,7 @@ def main():
     from minigalaxy.ui import Window
     from minigalaxy.config import Config
     from minigalaxy.api import Api
-    from minigalaxy.download_manager import DownloadManager, DownloadState
+    from minigalaxy.download_manager import DownloadManager
     from minigalaxy.css import load_css
 
     # Start the application


### PR DESCRIPTION
Otherwise OpenSUSE, Fedora and Arch will not display the login screen.

<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

I'm still not 100% sure if this is the way to go, but I do think it would solve the issue. Now I just need to test it to make sure it does. Any opinions on this solution?
<!-- Describe what was changed -->

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
