### PR TITLE
Fix #698

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Improved shutdown logic of Minigalaxy. If there is an installation running, it will be finished. (thanks to GB609)
 - Simple fix progress bar for games consisting of multiple files. (thanks to GB609)
 - Fix log in screen remaining blank on some distributions
+- Fix Minigalaxy not launching on some setups with older Nvidia cards
 
 **1.3.2**
 - Completely reworked windows wine installation. This should solve a lot of problems with failing game installs. Innoextract (if installed) is only used to detect and configure the installation language. (thanks to GB609)

--- a/bin/minigalaxy
+++ b/bin/minigalaxy
@@ -58,6 +58,9 @@ def main():
     # Disable webkit compositing, ensuring the login screen shows
     os.environ["WEBKIT_DISABLE_COMPOSITING_MODE"] = "1"
 
+    # Disable DMABUF because it causes issues with older Nvidia cards
+    os.environ["WEBKIT_DISABLE_DMABUF_RENDERER"] = "1"
+
     # Import the gi module after parsing arguments
     import signal
     from minigalaxy import installer


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

<!-- Describe what was changed -->
On some older Nvidia cards, the dmbuf renderer does not work, so if we want Minigalaxy to launch on these systems we should disable it.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
