### PR TITLE
Fix build and installation issues on Gentoo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ dynamic= [
 ]
 
 [build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta:__legacy__"
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ from setuptools import setup, find_packages
 from glob import glob
 import subprocess
 import os
-from minigalaxy.version import VERSION
+import sys
+
+sys.path.insert(0, os.getcwd())
+from minigalaxy.version import VERSION  # noqa: E402
 
 # Generate the translations
 subprocess.run(['bash', 'scripts/compile-translations.sh'])
@@ -15,7 +18,7 @@ for language_file in glob("data/mo/*/*/*.mo"):
 setup(
     name="minigalaxy",
     version=VERSION,
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     scripts=['bin/minigalaxy'],
 
     data_files=[


### PR DESCRIPTION
## Description

Make minigalaxy successfully install by running either `pip install .` or by running setup.py directly.

Make sure all test packages are excluded from the installation process [1].

Use the regular build backend instead of the fallback [2]. Make the regular backend work by appending the current directory to Python PATH. This way we can pass the package version to setuptools [3].

[1]: https://projects.gentoo.org/python/guide/qawarn.html#example-for-test-packages-installed-by-setuptools
[2]: https://projects.gentoo.org/python/guide/qawarn.html#setuptools-build-meta-legacy
[3]: https://github.com/pypa/setuptools/issues/3939#issuecomment-1573619382

## Checklist
 
 - [ ] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
