### PR TITLE
Credits for weblate contributions

### DIFF
--- a/scripts/credit-weblate-translators.sh
+++ b/scripts/credit-weblate-translators.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+cd "$(dirname "$0")"/..
+
+TRANSLATORS_FILE="weblate-translators.md"
+
+function fileHeader {
+  echo "# Weblate translations"
+  echo -e "Special thanks to Weblate and the following users:\n"
+}
+
+function createTranslationCredits {
+  declare -A translators
+
+  while read; do
+    author="${REPLY#Author: }"
+    author="${author%% <*>}"
+
+    read language
+    language="${language#Translated using Weblate (}"
+    language="${language%)}"
+
+    thanksLine="$author for translating to $language"
+    translators+=(["$thanksLine"]=true)
+  done
+
+  fileHeader
+  for ty in "${!translators[@]}"; do
+    echo " * $ty"
+  done
+  return 0
+}
+
+git log --no-merges --sparse --committer=weblate \
+  | grep -E "Author: .*|Translated" \
+  | createTranslationCredits | tee "$TRANSLATORS_FILE"

--- a/scripts/credit-weblate-translators.sh
+++ b/scripts/credit-weblate-translators.sh
@@ -31,5 +31,5 @@ function createTranslationCredits {
 }
 
 git log --no-merges --sparse --committer=weblate \
-  | grep -E "Author: .*|Translated" \
+  | grep -E "^Author: .*|^\s*Translated using" \
   | createTranslationCredits | tee "$TRANSLATORS_FILE"


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description
This PR is related to #715.

Up to now, i've only prepared a very basic script/logic that just searches git log for all commits commited by Weblate, then extracts the author names. With a bit of logic to prevent duplication.

This input is used to generate a simple name listing file - `weblate-translators.md`, overwriting the previous one, if any.
It is not yet included into any workflow.

I'd like to discuss on how to proceed.
The simplest solution would be just add a link to the end of `README.md` that points to this file and update it with a bit of scripting during releases.

For now, that file makes no difference about when a contribution happened.
I could also change the code to only look at all commits between the currently running release and the previous one (i'd go by git tag for that) and instead just append the new constributions as a new section.
I could also enhance the script to take arguments, like commit ranges, file text prefixes etc. Whatever we might need.

## Checklist
 
 - [ ] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
