### PR TITLE
improve weblate contribution script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     - name: Prepare release files
       id: tag
       run: |
+        ./scripts/credit-weblate-translators.sh
         ./scripts/create-release.sh
       env:
         DEBFULLNAME: ${{ secrets.DEBFULLNAME }}
@@ -29,6 +30,7 @@ jobs:
         git config --global user.name 'Wouter Wijsman'
         git config --global user.email 'sharkwouter@users.noreply.github.com'
         git add pyproject.toml data/io.github.sharkwouter.Minigalaxy.metainfo.xml debian/changelog minigalaxy/version.py
+        git add README.md data/ui/about.ui
         git commit -m "Add new release"
         git push
     - name: Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 **1.4.1**
 - Fix an issue where CJK characters in game library path prevents the config file from being loaded properly. (thanks to kyle-zhang-42)
+- Automatically add Weblate contributions to README and About dialog on release. (thanks to GB609)
 
 **1.4.0**
 - Various improvements to the download manager, including a pause function (thanks to GB609)

--- a/scripts/credit-weblate-translators.sh
+++ b/scripts/credit-weblate-translators.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-cd "$(dirname "$0")"/..
 
-TRANSLATORS_FILE="weblate-translators.md"
+_REPO_ROOT=$(dirname "$(readlink -f "$0")")
+_REPO_ROOT=$(realpath "$_REPO_ROOT"/..)
 
-function fileHeader {
-  echo "# Weblate translations"
-  echo -e "Special thanks to Weblate and the following users:\n"
-}
+cd "$_REPO_ROOT"
 
 function createTranslationCredits {
   declare -A translators
+  local author
+  local language
+  local thanksLine
 
   while read; do
     author="${REPLY#Author: }"
@@ -19,17 +19,103 @@ function createTranslationCredits {
     language="${language#Translated using Weblate (}"
     language="${language%)}"
 
-    thanksLine="$author for translating to $language"
-    translators+=(["$thanksLine"]=true)
+    #text matches what is in readme
+    thanksLine="- $author for translating to $language"
+    # assign author as value for about.ui patching
+    translators+=(["$thanksLine"]="$author")
   done
 
-  fileHeader
-  for ty in "${!translators[@]}"; do
-    echo " * $ty"
-  done
-  return 0
+  declare -p translators
 }
 
-git log --no-merges --sparse --committer=weblate \
+function patchAbout {
+  local _STATE=""
+
+  # this loop reads about.ui line-by-line
+  while read; do
+
+    # check the current line if it starts the translator-credits or ends that tag again
+    case "$REPLY" in
+      # just mark the start...
+      *\<property\ name=\"translator-credits\"*)
+        _STATE="BEGIN"
+        ;;
+
+      # ... to be able to recognize the next closing tag as belonging to the start
+      # so we can patch in the weblate listing
+      *\</property\>*)
+        if [ "$_STATE" = "BEGIN" ]; then
+          _STATE="DONE"
+          # the terminating tag might be one the same line as something else
+          _beforeEnd="${REPLY%%\</property\>*}"
+          # whatever follows (if any) after the closing tag might also start a new sibling tag
+          _afterEnd="${REPLY#*\</property\>}"
+
+          # print whats before the closing tag if it is not from Weblate
+          if [ -n "$_beforeEnd" ] && ! [[ "$_beforeEnd" =~ .*"(Weblate)".* ]]; then
+            echo "$_beforeEnd"
+          fi
+
+          for weblate_author in "${translators[@]}"; do
+            echo "$weblate_author (Weblate)"
+          done
+
+          echo "</property>"
+          # change REPLY to whatever came after the closing tag
+          REPLY="$_afterEnd"
+        fi
+        ;;
+    esac
+
+    # ignore previously generated weblate lines to re-create all of them
+    # this is easier than merging
+    if [[ "$REPLY" =~ .*"(Weblate)".* ]] || [ -z "$REPLY" ]; then
+      continue
+    fi
+
+    echo "$REPLY"
+
+  done <"$_REPO_ROOT/data/ui/about.ui"
+}
+
+function patchReadme {
+  local _STATE
+  declare -A alreadyAdded
+
+  # this loop reads README.md line-by-line
+  while read; do
+    if [[ "$REPLY" =~ .*Special\ thanks.* ]]; then
+      _STATE="PARSE"
+    fi
+
+    if [ "$_STATE" = "PARSE" ] && [ -n "$REPLY" ]; then
+      alreadyAdded["$REPLY"]=true || echo "NOT WORKING: [$REPLY]" >2
+    fi
+
+  done <"$_REPO_ROOT/README.md"
+
+  cat "$_REPO_ROOT/README.md"
+  for thanksLine in "${!translators[@]}"; do
+    if [ -z "${alreadyAdded["$thanksLine"]}" ]; then
+      echo "$thanksLine"
+    fi
+  done
+}
+
+# 1. Pull the data from git log and place into an assoc 
+#
+# There is no direct way to return an array from a function.
+# It is also not possible to declare a global one and pass it to the function for manipulation,
+# because local manipulations will not propagate back.
+# So the script re-declares it from the 'declare -p' function output
+source <(git log --no-merges --sparse --committer=weblate \
   | grep -E "^Author: .*|^\s*Translated using" \
-  | createTranslationCredits | tee "$TRANSLATORS_FILE"
+  | createTranslationCredits)
+
+# 2. patch into about
+patchAbout > "$_REPO_ROOT/data/ui/about.ui.tmp"
+mv -f "$_REPO_ROOT/data/ui/about.ui.tmp" "$_REPO_ROOT/data/ui/about.ui"
+
+# 3. patch into readme
+patchReadme > "$_REPO_ROOT/README.md.tmp"
+mv -f "$_REPO_ROOT/README.md.tmp" "$_REPO_ROOT/README.md"


### PR DESCRIPTION
This is a follow up on #716.
I've reworked the script and also included it into the release workflow.

* Contributions are now patched into `about.ui` and `README.md` instead of generating a dedicated file.
* The script `scripts/credit-weblate-translators.sh` will be executed in `release.yml` workflow just before `scripts/create-release.sh` is used.

In `README.md`, I've kept the format of all lines as they are. For the about ui, translations coming from Weblate are listed differently. There's no real, reliable way to get a link to the contributors, because they are effectively coming from Weblate, they theoretically don't even need to have a github account.
So, weblate contributions are appended in the following format:

```
Author name (Weblate)
```

Small gotcha: There's no filter for names (yet), so all weblate contributions are listed, including `Wouter Wissman`.

In `about.ui` i'm using `(Weblate)` as a filter to detect pre-added lines. With that, all entries are recreated here.
In `README.md` i'm parsing the current content first to find lines that have been added before. Afterwards, the new lines are appended to the end of the file. So i'm assuming that the current format of the file is kept for now. If that ever changes, we could for example use marker comments. But we can think about this when it actually happens.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
