### PR TITLE
fix: resolve test errors and deprecation warnings

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -224,15 +224,14 @@ class Api:
             response = self.session.get(url)
             if response.status_code == http.HTTPStatus.OK and len(response.text) > 0:
                 response_object = ET.fromstring(response.text)
-                if response_object and response_object.attrib:
+                if response_object is not None and response_object.attrib:
                     result = response_object.attrib
             else:
                 logger.error("Couldn't read xml data. Response with code %s received with the following content: %s",
                              response.status_code, response.text, exc_info=1)
         except requests.exceptions.RequestException:
             logger.error("Couldn't read xml data. Received RequestException", exc_info=1)
-        finally:
-            return result
+        return result
 
     def get_user_info(self) -> str:
         username = self.config.username

--- a/minigalaxy/translation.py
+++ b/minigalaxy/translation.py
@@ -29,7 +29,7 @@ os.unsetenv("LANGUAGE")
 os.unsetenv("LANG")
 
 current_locale = Config().locale
-default_locale = locale.getdefaultlocale()[0]
+default_locale = locale.getlocale()[0]
 if current_locale == '':
     if default_locale is None:
         lang = gettext.translation(TRANSLATION_DOMAIN, LOCALE_DIR, languages=['en'], fallback=True)

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -33,7 +33,8 @@ class Library(Gtk.Viewport):
         self.config = config
 
         current_locale = self.config.locale
-        default_locale = locale.getdefaultlocale()[0]
+        locale.setlocale(locale.LC_ALL, '')
+        default_locale = locale.getlocale()[0]
         if current_locale == '':
             locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
         else:

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -62,7 +62,7 @@ class Preferences(Gtk.Dialog):
 
         # Set the active option
         current_locale = self.config.locale
-        default_locale = locale.getdefaultlocale()
+        default_locale = locale.getlocale()
         if current_locale is None:
             locale.setlocale(locale.LC_ALL, default_locale)
         for key in range(len(locales)):
@@ -112,7 +112,7 @@ class Preferences(Gtk.Dialog):
             model = self.combobox_program_language.get_model()
             locale_choice = model[new_locale][-2]
             if locale_choice == '':
-                default_locale = locale.getdefaultlocale()[0]
+                default_locale = locale.getlocale()[0]
                 locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
                 self.config.locale = locale_choice
             else:

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -33,7 +33,8 @@ class Window(Gtk.ApplicationWindow):
 
     def __init__(self, config: Config, api: 'Api', download_manager: DownloadManager, name="Minigalaxy"):
         current_locale = config.locale
-        default_locale = locale.getdefaultlocale()[0]
+        locale.setlocale(locale.LC_ALL, '')
+        default_locale = locale.getlocale()[0]
         if current_locale == '':
             locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ documentation = "https://github.com/sharkwouter/minigalaxy/blob/master/README.md
 [project.gui-scripts]
 minigalaxy = "minigalaxy.minigalaxy:main"
 
+[tool.pytest.ini_options]
+pythonpath = ["tests"]
+
 [tool.setuptools.package-data]
 "minigalaxy.data" = [ "*.css", "*.reg" ]
 "minigalaxy.ui.data" = [ "*.ui", "*.png" ]


### PR DESCRIPTION

<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description
Installing minigalaxy-git on arch fails (`paru -S minigalaxy-git`) with errors and warnings:
```
__________________________________________ ERROR collecting tests/test_ui_library.py __________________________________________
ImportError while importing test module '/home/$USER/.cache/paru/clone/minigalaxy-git/src/minigalaxy/tests/test_ui_library.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_ui_library.py:9: in <module>
    from MockGiRepository import MockGiRepository
E   ModuleNotFoundError: No module named 'MockGiRepository'
__________________________________________ ERROR collecting tests/test_ui_window.py ___________________________________________
ImportError while importing test module '/home/$USER/.cache/paru/clone/minigalaxy-git/src/minigalaxy/tests/test_ui_window.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_ui_window.py:6: in <module>
    from MockGiRepository import MockGiRepository
E   ModuleNotFoundError: No module named 'MockGiRepository'
====================================================== warnings summary =======================================================
minigalaxy/api.py:235
  /home/$USER/.cache/paru/clone/minigalaxy-git/src/minigalaxy/minigalaxy/api.py:235: SyntaxWarning: 'return' in a 'finally' block
    return result

minigalaxy/translation.py:32
  /home/$USER/.cache/paru/clone/minigalaxy-git/src/minigalaxy/minigalaxy/translation.py:32: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    default_locale = locale.getdefaultlocale()[0]
```

- ERROR: Add pytest pythonpath config for test discovery
- WARN: Replace deprecated locale.getdefaultlocale() with getlocale()
- WARN: Use explicit 'is not None' for XML Element check
- WARN: Move return statement out of finally block

Ran `python3 -m pytest -v -W error` to ensure no warnings remain.
Note: Not super confident of locale related testing since I only have English.

<!-- Describe what was changed -->

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
