### PR TITLE
Feature: Improve handling of application configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**1.4.3**
+- Reduce unnecessary writes to the config file. (thanks to GB609)
+
 **1.4.2**
 - Switch to using PEP 302 compliant resources, excluding translations. (thanks to EmperorArthur)
 - Allow installing Minigalaxy via pipx. (thanks to EmperorArthur)

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -207,38 +207,38 @@ class Config:
 
     @current_downloads.setter
     def current_downloads(self, new_value: List[int] = []) -> None:
-        self.__set_and_write("current_downloads", [*new_value])
+        self.__set_and_write("current_downloads", new_value)
 
     def add_ongoing_download(self, download_id):
         '''Adds the given id to the list of active downloads if not contained already. Does nothing otherwise.'''
-        current = self.current_downloads
+        current = [*self.current_downloads]
         if download_id not in current:
             current.append(download_id)
             self.current_downloads = current
 
     def remove_ongoing_download(self, download_id):
         '''Removes the given id from the list of active downloads, if contained. Does nothing otherwise.'''
-        current = self.current_downloads
+        current = [*self.current_downloads]
         if download_id in current:
             current.remove(download_id)
             self.current_downloads = current
 
     @property
-    def paused_downloads(self) -> dict[str, int]:
+    def paused_downloads(self) -> dict:
         return self.__config.get("paused_downloads", {})
 
     @paused_downloads.setter
     def paused_downloads(self, new_value={}) -> None:
         """Ongoing downloads are a dictionary of filename:progress_percentage_int. See Download.current_progress."""
-        self.__set_and_write("paused_downloads", {**new_value})
+        self.__set_and_write("paused_downloads", new_value)
 
     def add_paused_download(self, save_location, current_progress):
-        paused = self.paused_downloads
+        paused = {**self.paused_downloads}
         paused[save_location] = current_progress
         self.paused_downloads = paused
 
     def remove_paused_download(self, save_location):
-        paused = self.paused_downloads
+        paused = {**self.paused_downloads}
         if save_location in paused:
             del paused[save_location]
             self.paused_downloads = paused

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -18,6 +18,7 @@ class Config:
     __config: dict
 
     def __init__(self, config_file: str = CONFIG_FILE_PATH):
+        self.__is_batch_edit = False
         self.__config_file = config_file
         self.__config = {}
         self.__load()
@@ -40,6 +41,24 @@ class Config:
             file.write(json.dumps(self.__config, ensure_ascii=False))
         os.rename(temp_file, self.__config_file)
 
+    def start_batch_edit(self):
+        """
+        Flags config for multiple incoming changes. Normally, every change is written to file immediately.
+        This can lead to a lot redundant writes when several settings are changed in quick succession.
+        This method provides a uniform way to flag Config in a rudimentary type of 'transaction'.
+        Any setter which internally uses '__set_and_write' will honor this flag.
+        Use 'Config.save()' to finalize (remove flag and write to the file to disc).
+        """
+        self.__is_batch_edit = True
+
+    def cancel_batch_edit(self):
+        """
+        The counterpart to 'Config.start_batch_edit()'.
+        Resets the flag and reverts all changes since the last write/save.
+        """
+        self.__is_batch_edit = False
+        self.__load()
+
     def save(self) -> None:
         """
         Config will normally immediately save all changes applied to it to the configuration file automatically.
@@ -48,9 +67,19 @@ class Config:
         So it only works for direct assignments. But there are some properties which returned Lists or might
         return other none-simple types in the future. Changes made to these sub-objects would not be detected
         and thus also not be persisted automatically.
-        In these situations `Config.save`  can be used to avoid having to re-assign the same object reference.
+        In these situations `Config.save()`  can be used to avoid having to re-assign the same object reference.
+        This method is also needed when editing Config in 'batch mode' to finalize the state.
         """
         self.__write()
+        self.__is_batch_edit = False
+
+    def __set_and_write(self, property_name, new_value):
+        if self.__config.get(property_name, None) == new_value:
+            return
+
+        self.__config[property_name] = new_value
+        if not self.__is_batch_edit:
+            self.__write()
 
     @property
     def locale(self) -> str:
@@ -58,8 +87,7 @@ class Config:
 
     @locale.setter
     def locale(self, new_value: str) -> None:
-        self.__config["locale"] = new_value
-        self.__write()
+        self.__set_and_write("locale", new_value)
 
     @property
     def lang(self) -> str:
@@ -67,8 +95,7 @@ class Config:
 
     @lang.setter
     def lang(self, new_value: str) -> None:
-        self.__config["lang"] = new_value
-        self.__write()
+        self.__set_and_write("lang", new_value)
 
     @property
     def view(self) -> str:
@@ -76,8 +103,7 @@ class Config:
 
     @view.setter
     def view(self, new_value: str) -> None:
-        self.__config["view"] = new_value
-        self.__write()
+        self.__set_and_write("view", new_value)
 
     @property
     def install_dir(self) -> str:
@@ -85,8 +111,7 @@ class Config:
 
     @install_dir.setter
     def install_dir(self, new_value: str) -> None:
-        self.__config["install_dir"] = new_value
-        self.__write()
+        self.__set_and_write("install_dir", new_value)
 
     @property
     def username(self) -> str:
@@ -94,8 +119,7 @@ class Config:
 
     @username.setter
     def username(self, new_value: str) -> None:
-        self.__config["username"] = new_value
-        self.__write()
+        self.__set_and_write("username", new_value)
 
     @property
     def refresh_token(self) -> str:
@@ -103,8 +127,7 @@ class Config:
 
     @refresh_token.setter
     def refresh_token(self, new_value: str) -> None:
-        self.__config["refresh_token"] = new_value
-        self.__write()
+        self.__set_and_write("refresh_token", new_value)
 
     @property
     def keep_installers(self) -> bool:
@@ -112,8 +135,7 @@ class Config:
 
     @keep_installers.setter
     def keep_installers(self, new_value: bool) -> None:
-        self.__config["keep_installers"] = new_value
-        self.__write()
+        self.__set_and_write("keep_installers", new_value)
 
     @property
     def stay_logged_in(self) -> bool:
@@ -121,8 +143,7 @@ class Config:
 
     @stay_logged_in.setter
     def stay_logged_in(self, new_value: bool) -> None:
-        self.__config["stay_logged_in"] = new_value
-        self.__write()
+        self.__set_and_write("stay_logged_in", new_value)
 
     @property
     def use_dark_theme(self) -> bool:
@@ -130,8 +151,7 @@ class Config:
 
     @use_dark_theme.setter
     def use_dark_theme(self, new_value: bool) -> None:
-        self.__config["use_dark_theme"] = new_value
-        self.__write()
+        self.__set_and_write("use_dark_theme", new_value)
 
     @property
     def show_hidden_games(self) -> bool:
@@ -139,8 +159,7 @@ class Config:
 
     @show_hidden_games.setter
     def show_hidden_games(self, new_value: bool) -> None:
-        self.__config["show_hidden_games"] = new_value
-        self.__write()
+        self.__set_and_write("show_hidden_games", new_value)
 
     @property
     def show_windows_games(self) -> bool:
@@ -148,8 +167,7 @@ class Config:
 
     @show_windows_games.setter
     def show_windows_games(self, new_value: bool) -> None:
-        self.__config["show_windows_games"] = new_value
-        self.__write()
+        self.__set_and_write("show_windows_games", new_value)
 
     @property
     def keep_window_maximized(self) -> bool:
@@ -157,8 +175,7 @@ class Config:
 
     @keep_window_maximized.setter
     def keep_window_maximized(self, new_value: bool) -> None:
-        self.__config["keep_window_maximized"] = new_value
-        self.__write()
+        self.__set_and_write("keep_window_maximized", new_value)
 
     @property
     def installed_filter(self) -> bool:
@@ -166,8 +183,7 @@ class Config:
 
     @installed_filter.setter
     def installed_filter(self, new_value: bool) -> None:
-        self.__config["installed_filter"] = new_value
-        self.__write()
+        self.__set_and_write("installed_filter", new_value)
 
     @property
     def create_applications_file(self) -> bool:
@@ -175,8 +191,7 @@ class Config:
 
     @create_applications_file.setter
     def create_applications_file(self, new_value: bool) -> None:
-        self.__config["create_applications_file"] = new_value
-        self.__write()
+        self.__set_and_write("create_applications_file", new_value)
 
     @property
     def max_parallel_game_downloads(self) -> int:
@@ -184,17 +199,15 @@ class Config:
 
     @max_parallel_game_downloads.setter
     def max_parallel_game_downloads(self, new_value: int) -> None:
-        self.__config["max_download_workers"] = new_value
-        self.__write()
+        self.__set_and_write("max_download_workers", new_value)
 
     @property
     def current_downloads(self) -> List[int]:
         return self.__config.get("current_downloads", [])
 
     @current_downloads.setter
-    def current_downloads(self, new_value: List[int]) -> None:
-        self.__config["current_downloads"] = new_value
-        self.__write()
+    def current_downloads(self, new_value: List[int] = []) -> None:
+        self.__set_and_write("current_downloads", [*new_value])
 
     def add_ongoing_download(self, download_id):
         '''Adds the given id to the list of active downloads if not contained already. Does nothing otherwise.'''
@@ -211,23 +224,21 @@ class Config:
             self.current_downloads = current
 
     @property
-    def paused_downloads(self) -> List[int]:
+    def paused_downloads(self) -> dict[str, int]:
         return self.__config.get("paused_downloads", {})
 
     @paused_downloads.setter
-    def paused_downloads(self, new_value: {}) -> None:
-        self.__config["paused_downloads"] = new_value
-        self.__write()
+    def paused_downloads(self, new_value={}) -> None:
+        """Ongoing downloads are a dictionary of filename:progress_percentage_int. See Download.current_progress."""
+        self.__set_and_write("paused_downloads", {**new_value})
 
     def add_paused_download(self, save_location, current_progress):
         paused = self.paused_downloads
         paused[save_location] = current_progress
         self.paused_downloads = paused
-        self.__write()
 
     def remove_paused_download(self, save_location):
         paused = self.paused_downloads
         if save_location in paused:
             del paused[save_location]
             self.paused_downloads = paused
-            self.__write()

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -77,7 +77,12 @@ class Config:
         if self.__config.get(property_name, None) == new_value:
             return
 
-        self.__config[property_name] = new_value
+        if new_value is None:
+            del self.__config[property_name]
+            logger.warning("Config setting '%' was deleted (=reset to default)")
+        else:
+            self.__config[property_name] = new_value
+
         if not self.__is_batch_edit:
             self.__write()
 

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -1,6 +1,5 @@
 import os
 import json
-from typing import List
 
 from minigalaxy.logger import logger
 from minigalaxy.paths import CONFIG_FILE_PATH, DEFAULT_INSTALL_DIR
@@ -207,43 +206,51 @@ class Config:
         self.__set_and_write("max_download_workers", new_value)
 
     @property
-    def current_downloads(self) -> List[int]:
-        return self.__config.get("current_downloads", [])
+    def current_downloads(self) -> list:
+        """
+        Returns a list of game ids which are currently being downloaded.
+        The list is a shallow copy of the internal representation to guard Config against changes by side-effects.
+        """
+        return [*self.__config.get("current_downloads", [])]
 
     @current_downloads.setter
-    def current_downloads(self, new_value: List[int] = []) -> None:
+    def current_downloads(self, new_value: list) -> None:
         self.__set_and_write("current_downloads", new_value)
 
     def add_ongoing_download(self, download_id):
         '''Adds the given id to the list of active downloads if not contained already. Does nothing otherwise.'''
-        current = [*self.current_downloads]
+        current = self.current_downloads
         if download_id not in current:
             current.append(download_id)
             self.current_downloads = current
 
     def remove_ongoing_download(self, download_id):
         '''Removes the given id from the list of active downloads, if contained. Does nothing otherwise.'''
-        current = [*self.current_downloads]
+        current = self.current_downloads
         if download_id in current:
             current.remove(download_id)
             self.current_downloads = current
 
     @property
     def paused_downloads(self) -> dict:
-        return self.__config.get("paused_downloads", {})
+        """
+        Returns a dict of 'filename:progress_percent' of files which are currently being downloaded.
+        The ldict is a shallow copy of the internal representation to guard Config against changes by side-effects.
+        """
+        return {**self.__config.get("paused_downloads", {})}
 
     @paused_downloads.setter
-    def paused_downloads(self, new_value={}) -> None:
+    def paused_downloads(self, new_value: dict) -> None:
         """Ongoing downloads are a dictionary of filename:progress_percentage_int. See Download.current_progress."""
         self.__set_and_write("paused_downloads", new_value)
 
     def add_paused_download(self, save_location, current_progress):
-        paused = {**self.paused_downloads}
+        paused = self.paused_downloads
         paused[save_location] = current_progress
         self.paused_downloads = paused
 
     def remove_paused_download(self, save_location):
-        paused = {**self.paused_downloads}
+        paused = self.paused_downloads
         if save_location in paused:
             del paused[save_location]
             self.paused_downloads = paused

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -196,9 +196,9 @@ class Library(Gtk.Viewport):
 
         # try to repair a corrupted list of ongoing downloads
         # if something is considered 'installed', it shouldn't be on the download list anymore
+        self.config.start_batch_edit()
         for game in games:
-            if game.id in self.config.current_downloads:
-                self.config.current_downloads.remove(game.id)
+            self.config.remove_ongoing_download(game.id)
         self.config.save()
 
         return games

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -6,6 +6,7 @@ from minigalaxy.constants import SUPPORTED_DOWNLOAD_LANGUAGES, SUPPORTED_LOCALES
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.ui.gtk import Gtk, load_ui
 from minigalaxy.config import Config
+from minigalaxy.logger import logger
 
 
 @Gtk.Template(string=load_ui("preferences.ui"))
@@ -178,31 +179,40 @@ class Preferences(Gtk.Dialog):
 
     @Gtk.Template.Callback("on_button_save_clicked")
     def save_pressed(self, button):
-        self.__save_locale_choice()
-        self.__save_language_choice()
-        self.__save_view_choice()
-        self.__save_theme_choice()
-        self.config.keep_installers = self.switch_keep_installers.get_active()
-        self.config.stay_logged_in = self.switch_stay_logged_in.get_active()
-        self.config.show_hidden_games = self.switch_show_hidden_games.get_active()
-        self.config.create_applications_file = self.switch_create_applications_file.get_active()
-        self.parent.library.filter_library()
+        try:
+            self.config.start_batch_edit()
 
-        if self.switch_show_windows_games.get_active() != self.config.show_windows_games:
-            if self.switch_show_windows_games.get_active() and not shutil.which("wine"):
-                self.parent.show_error(_("Wine wasn't found. Showing Windows games cannot be enabled."))
-                self.config.show_windows_games = False
-            else:
-                self.config.show_windows_games = self.switch_show_windows_games.get_active()
-                self.parent.reset_library()
+            self.__save_locale_choice()
+            self.__save_language_choice()
+            self.__save_view_choice()
+            self.__save_theme_choice()
+            self.config.keep_installers = self.switch_keep_installers.get_active()
+            self.config.stay_logged_in = self.switch_stay_logged_in.get_active()
+            self.config.show_hidden_games = self.switch_show_hidden_games.get_active()
+            self.config.create_applications_file = self.switch_create_applications_file.get_active()
+            self.parent.library.filter_library()
 
-        # Only change the install_dir is it was actually changed
-        if self.button_file_chooser.get_filename() != self.config.install_dir:
-            if self.__save_install_dir_choice():
-                self.download_manager.cancel_all_downloads()
-                self.parent.reset_library()
-            else:
-                self.parent.show_error(_("{} isn't a usable path").format(self.button_file_chooser.get_filename()))
+            if self.switch_show_windows_games.get_active() != self.config.show_windows_games:
+                if self.switch_show_windows_games.get_active() and not shutil.which("wine"):
+                    self.parent.show_error(_("Wine wasn't found. Showing Windows games cannot be enabled."))
+                    self.config.show_windows_games = False
+                else:
+                    self.config.show_windows_games = self.switch_show_windows_games.get_active()
+                    self.parent.reset_library()
+
+            # Only change the install_dir is it was actually changed
+            if self.button_file_chooser.get_filename() != self.config.install_dir:
+                if self.__save_install_dir_choice():
+                    self.download_manager.cancel_all_downloads()
+                    self.parent.reset_library()
+                else:
+                    self.parent.show_error(_("{} isn't a usable path").format(self.button_file_chooser.get_filename()))
+        except Exception:
+            logger.error("Could not save preferences", exc_info=1)
+            self.config.cancel_batch_edit()
+        finally:
+            self.config.save()
+
         self.destroy()
 
     @Gtk.Template.Callback("on_button_cancel_clicked")

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -179,6 +179,7 @@ class Preferences(Gtk.Dialog):
 
     @Gtk.Template.Callback("on_button_save_clicked")
     def save_pressed(self, button):
+        save_changes = True
         try:
             self.config.start_batch_edit()
 
@@ -207,10 +208,14 @@ class Preferences(Gtk.Dialog):
                     self.parent.reset_library()
                 else:
                     self.parent.show_error(_("{} isn't a usable path").format(self.button_file_chooser.get_filename()))
-        except Exception:
+
+        except Exception as e:
             logger.error("Could not save preferences", exc_info=1)
             self.config.cancel_batch_edit()
-        finally:
+            save_changes = False
+            self.parent.show_error(_("There was an error while saving preferences."), str(e))
+
+        if save_changes:
             self.config.save()
 
         self.destroy()

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -107,7 +107,7 @@ class Preferences(Gtk.Dialog):
                 self.combobox_view.set_active(key)
                 break
 
-    def __save_locale_choice(self) -> None:
+    def __apply_locale_choice(self) -> None:
         new_locale = self.combobox_program_language.get_active_iter()
         if new_locale is not None:
             model = self.combobox_program_language.get_model()
@@ -124,14 +124,14 @@ class Preferences(Gtk.Dialog):
                     self.parent.show_error(_("Failed to change program language. Make sure locale is generated on "
                                              "your system."))
 
-    def __save_language_choice(self) -> None:
+    def __apply_language_choice(self) -> None:
         lang_choice = self.combobox_language.get_active_iter()
         if lang_choice is not None:
             model = self.combobox_language.get_model()
             lang, _ = model[lang_choice][:2]
             self.config.lang = lang
 
-    def __save_view_choice(self) -> None:
+    def __apply_view_choice(self) -> None:
         view_choice = self.combobox_view.get_active_iter()
         if view_choice is not None:
             model = self.combobox_view.get_model()
@@ -140,7 +140,7 @@ class Preferences(Gtk.Dialog):
                 self.parent.reset_library()
             self.config.view = view
 
-    def __save_theme_choice(self) -> None:
+    def __apply_theme_choice(self) -> None:
         settings = Gtk.Settings.get_default()
         self.config.use_dark_theme = self.switch_use_dark_theme.get_active()
         if self.config.use_dark_theme is True:
@@ -183,10 +183,10 @@ class Preferences(Gtk.Dialog):
         try:
             self.config.start_batch_edit()
 
-            self.__save_locale_choice()
-            self.__save_language_choice()
-            self.__save_view_choice()
-            self.__save_theme_choice()
+            self.__apply_locale_choice()
+            self.__apply_language_choice()
+            self.__apply_view_choice()
+            self.__apply_theme_choice()
             self.config.keep_installers = self.switch_keep_installers.get_active()
             self.config.stay_logged_in = self.switch_stay_logged_in.get_active()
             self.config.show_hidden_games = self.switch_show_hidden_games.get_active()

--- a/tests/test_ui_library.py
+++ b/tests/test_ui_library.py
@@ -179,6 +179,7 @@ class TestLibrary(TestCase):
         game_json_data = '{ "gameId": "1207665883", "name": "Aliens vs Predator Classic 2000", "playTasks":[{}]}'
         gog_info_file = "goggame-1207665883.info"
         self.mock_config.current_downloads = [1207665883]
+        self.mock_config.remove_ongoing_download.side_effect = lambda gameid: self.mock_config.current_downloads.remove(gameid)
 
         api_mock = MagicMock()
         test_library = Library(MagicMock(), self.mock_config, api_mock, MagicMock())
@@ -190,6 +191,7 @@ class TestLibrary(TestCase):
                 file.write(game_json_data)
             test_library._Library__get_installed_games()
 
+        self.mock_config.remove_ongoing_download.assert_called_once()
         self.assertEqual([], self.mock_config.current_downloads)
         self.mock_config.save.assert_called_once()
 


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description
I'm currently working at a larger feature that is related to the handling of multiple platforms where i also plan to introduce a couple additional settings.

This PR is a small preparation for that. I'm more or less doing a bit of code maintainance while i'm adding stuff in `preferences.py` and `config.py` anyway.

With this, I'm introducing a reusable private method, `Config.__set_and_write(key, new_value)` that takes care of the ever-repeating lines 

```python
self.__config[prop_name] = new_value
self.__write()
```

The new method does 2 additional things:
1. Check if the new value really is different (or do nothing otherwise)
2. Only write to file directly when `Config` is not edited in 'batch mode'. This is primarily intended for usage from the `Preferences` dialog's `save_pressed`.

Both additions are made to reduce unnecessary file writes when modifying preferences.

<!-- Describe what was changed -->

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
