### PR TITLE
Feature: Prepare new preferences for platform-selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **1.4.3**
+- Some code refactoring for more clarity and to avoid potential coding errors. (thanks to GB609)
 - Reduce unnecessary writes to the config file. (thanks to GB609)
 
 **1.4.2**

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,4 +1,4 @@
-## Logo image (data/minigalaxy.png)
+## Logo image (minigalaxy/ui/data/io.github.sharkwouter.Minigalaxy.png)
 
 **[Copyright 2014 Epic Runes](https://opengameart.org/users/epic-runes)**
 

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -142,6 +142,14 @@ class Config:
         self.__set_and_write("keep_installers", new_value)
 
     @property
+    def keep_installers_per_platform(self) -> bool:
+        return self.__config.get("keep_installers_per_platform", True)
+
+    @keep_installers_per_platform.setter
+    def keep_installers_per_platform(self, new_value: bool) -> None:
+        self.__set_and_write("keep_installers_per_platform", new_value)
+
+    @property
     def stay_logged_in(self) -> bool:
         return self.__config.get("stay_logged_in", True)
 
@@ -172,6 +180,22 @@ class Config:
     @show_windows_games.setter
     def show_windows_games(self, new_value: bool) -> None:
         self.__set_and_write("show_windows_games", new_value)
+
+    @property
+    def preferred_platform(self) -> str:
+        return self.__config.get("preferred_platform", "linux")
+
+    @preferred_platform.setter
+    def preferred_platform(self, new_value: str) -> None:
+        self.__set_and_write("preferred_platform", new_value)
+
+    @property
+    def game_listing_mode(self) -> str:
+        return self.__config.get("game_listing_mode", "linux")
+
+    @game_listing_mode.setter
+    def game_listing_mode(self, new_value: str) -> None:
+        self.__set_and_write("game_listing_mode", new_value)
 
     @property
     def keep_window_maximized(self) -> bool:

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -79,6 +79,17 @@ VIEWS = [
     ["list", _("List")],
 ]
 
+PLATFORMS = [
+    ["linux", _("Linux")],
+    ["windows", _("Windows")]
+]
+
+GAME_LISTING_MODE = [
+    ["preferred", _("Preferred platform only")],
+    ["mixed", _("Highlight preferred")],
+    ["all", _("Show all")]
+]
+
 # Game IDs to ignore when received by the API
 IGNORE_GAME_IDS = [
     1424856371,  # Hotline Miami 2: Wrong Number - Digital Comics

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -2,7 +2,23 @@ import os
 import re
 import json
 
+from enum import Enum
 from minigalaxy.paths import CONFIG_GAMES_DIR, ICON_DIR, THUMBNAIL_DIR
+from minigalaxy.logger import logger
+
+
+class InfoKey(str, Enum):
+    """An enum representing all valid game-specific info/property keys"""
+
+    CHECK_UPDATES = "check_for_updates"
+    COMMAND = "command"
+    CUSTOM_WINE = "custom_wine"
+    HIDE_GAME = "hide_game"
+    MANGOHUD = "use_mangohud"
+    SHOW_FPS = "show_fps"
+    GAMEMODE = "use_gamemode"
+    VARIABLES = "variable"
+    VERSION = "version"
 
 
 class Game:
@@ -73,6 +89,10 @@ class Game:
     def save_minigalaxy_info_json(self, json_dict):
         if not os.path.exists(CONFIG_GAMES_DIR):
             os.makedirs(CONFIG_GAMES_DIR, mode=0o755)
+        # delete the json file if it exists and its new value would be just an empty dictionary
+        if len(json_dict) == 0 and os.path.isfile(self.status_file_path):
+            os.remove(self.status_file_path)
+            return
         with open(self.status_file_path, 'w') as status_file:
             json.dump(json_dict, status_file)
 
@@ -96,10 +116,10 @@ class Game:
         if dlc_title:
             installed_version = self.get_dlc_info("version", dlc_title)
         else:
-            installed_version = self.get_info("version")
+            installed_version = self.get_info(InfoKey.VERSION)
             if not installed_version:
                 installed_version = self.fallback_read_installed_version()
-                self.set_info("version", installed_version)
+                self.set_info(InfoKey.VERSION, installed_version)
         if installed_version and version_from_api and version_from_api != installed_version:
             update_available = True
 
@@ -117,9 +137,14 @@ class Game:
             version = "0"
         return version
 
-    def set_info(self, key, value):
+    def set_info(self, key: InfoKey, value):
+        """Set given key-value-pair for the game. Deletes the entry when None is passed as value."""
+        key = self.__info_key_from_arg(key)
         json_dict = self.load_minigalaxy_info_json()
-        json_dict[key] = value
+        if value is None:
+            del json_dict[key]
+        else:
+            json_dict[key] = value
         self.save_minigalaxy_info_json(json_dict)
 
     def set_dlc_info(self, key, value, dlc_title):
@@ -131,7 +156,8 @@ class Game:
         json_dict["dlcs"][dlc_title][key] = value
         self.save_minigalaxy_info_json(json_dict)
 
-    def get_info(self, key, default_value=""):
+    def get_info(self, key: InfoKey, default_value=""):
+        key = self.__info_key_from_arg(key)
         value = ""
         json_dict = self.load_minigalaxy_info_json()
         if key in json_dict:
@@ -175,6 +201,16 @@ class Game:
         if not self.install_dir:
             self.install_dir = os.path.join(install_dir, self.get_install_directory_name())
 
+    def __info_key_from_arg(self, key):
+        """
+        For test compatibility. Regular MG production could should use InfoKey for protection against typos etc.
+        But this method takes either str or InfoKey and returns the str value to use as json key.
+        """
+        if isinstance(key, InfoKey):
+            return key.value
+        logger.warning("An instance of game.InfoKey is expected, but %s was given!", type(key))
+        return key
+
     def __str__(self):
         return self.name
 
@@ -186,7 +222,7 @@ class Game:
             game_id={self.id},
             install_dir="{self.install_dir}",
             image_url="{self.image_url}",
-            platform="linux",
+            platform="{self.platform}",
             dlcs={self.dlcs},
             category="{self.category}"
         )'''

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -7,6 +7,7 @@ import shlex
 import threading
 from typing import List
 
+from minigalaxy.game import InfoKey
 from minigalaxy.logger import logger
 from minigalaxy.translation import _
 from minigalaxy.constants import BINARY_NAMES_TO_IGNORE
@@ -14,7 +15,7 @@ from minigalaxy.constants import BINARY_NAMES_TO_IGNORE
 
 def get_wine_path(game):
     binary_name = "wine"
-    custom_wine_path = game.get_info("custom_wine")
+    custom_wine_path = game.get_info(InfoKey.CUSTOM_WINE)
     if custom_wine_path and custom_wine_path != shutil.which(binary_name):
         binary_name = custom_wine_path
     return binary_name
@@ -79,9 +80,9 @@ def get_execute_command(game) -> list:
     else:
         # If no executable was found at all, raise an error
         raise FileNotFoundError()
-    if game.get_info("use_gamemode") is True:
+    if game.get_info(InfoKey.GAMEMODE) is True:
         exe_cmd.insert(0, "gamemoderun")
-    if game.get_info("use_mangohud") is True:
+    if game.get_info(InfoKey.MANGOHUD) is True:
         exe_cmd.insert(0, "mangohud")
         exe_cmd.insert(1, "--dlsym")
     exe_cmd = get_exe_cmd_with_var_command(game, exe_cmd)
@@ -107,8 +108,8 @@ def determine_launcher_type(files):
 
 
 def get_exe_cmd_with_var_command(game, exe_cmd):
-    var_list = shlex.split(game.get_info("variable"))
-    command_list = shlex.split(game.get_info("command"))
+    var_list = shlex.split(game.get_info(InfoKey.VARIABLES))
+    command_list = shlex.split(game.get_info(InfoKey.COMMAND))
 
     if var_list:
         if var_list[0] not in ["env"]:
@@ -222,7 +223,7 @@ def get_final_resort_exe_cmd(game, files):
 def set_fps_display(game):
     error_message = ""
     # Enable FPS Counter for Nvidia or AMD (Mesa) users
-    if game.get_info("show_fps"):
+    if game.get_info(InfoKey.SHOW_FPS):
         os.environ["__GL_SHOW_GRAPHICS_OSD"] = "1"  # For Nvidia users + OpenGL/Vulkan games
         os.environ["GALLIUM_HUD"] = "simple,fps"  # For AMDGPU users + OpenGL games
         os.environ["VK_INSTANCE_LAYERS"] = "VK_LAYER_MESA_overlay"  # For AMDGPU users + Vulkan games

--- a/minigalaxy/ui/information.py
+++ b/minigalaxy/ui/information.py
@@ -6,6 +6,7 @@ from minigalaxy.api import Api
 from minigalaxy.config import Config
 from minigalaxy.download import Download
 from minigalaxy.download_manager import DownloadManager
+from minigalaxy.game import InfoKey
 from minigalaxy.paths import THUMBNAIL_DIR, COVER_DIR
 from minigalaxy.translation import _
 from minigalaxy.ui.gtk import Gtk, GLib, Gio, GdkPixbuf, load_ui
@@ -140,5 +141,5 @@ class Information(Gtk.Dialog):
                     genre = genre_value
             description = "{}: {}\n{}".format(_("Genre"), genre, description)
         if self.game.is_installed():
-            description = "{}: {}\n{}".format(_("Version"), self.game.get_info("version"), description)
+            description = "{}: {}\n{}".format(_("Version"), self.game.get_info(InfoKey.VERSION), description)
         GLib.idle_add(self.label_game_description.set_text, description)

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -8,7 +8,7 @@ from minigalaxy.api import Api
 from minigalaxy.config import Config
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.entity.state import State
-from minigalaxy.game import Game
+from minigalaxy.game import Game, InfoKey
 from minigalaxy.logger import logger
 from minigalaxy.paths import CATEGORIES_FILE_PATH
 from minigalaxy.translation import _
@@ -111,7 +111,7 @@ class Library(Gtk.Viewport):
             if tile.current_state in [State.DOWNLOADABLE, State.INSTALLABLE]:
                 return False
 
-        if not self.config.show_hidden_games and tile.game.get_info("hide_game"):
+        if not self.config.show_hidden_games and tile.game.get_info(InfoKey.HIDE_GAME):
             return False
 
         if len(self.category_filters) > 0:

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -8,7 +8,7 @@ from minigalaxy.api import NoDownloadLinkFound
 from minigalaxy.download import CombinedProgressWatcher, Download, DownloadType
 from minigalaxy.download_manager import DownloadState
 from minigalaxy.entity.state import State
-from minigalaxy.game import Game
+from minigalaxy.game import Game, InfoKey
 from minigalaxy.installer import uninstall_game, enqueue_game_install, check_diskspace, \
     InstallerInventory, InstallResult, InstallResultType
 from minigalaxy.launcher import start_game
@@ -395,7 +395,7 @@ class LibraryEntry:
             if dlc_title:
                 self.game.set_dlc_info("version", self.api.get_version(self.game, dlc_name=dlc_title), dlc_title)
             else:
-                self.game.set_info("version", self.api.get_version(self.game))
+                self.game.set_info(InfoKey.VERSION, self.api.get_version(self.game))
             if on_success:
                 on_success()
             return
@@ -485,7 +485,7 @@ class LibraryEntry:
         if self.game.is_installed() and self.game.id and not self.offline:
             game_info = self.api.get_info(self.game)
             self.__download_icon(game_info=game_info)
-            if self.game.get_info("check_for_updates", True):
+            if self.game.get_info(InfoKey.CHECK_UPDATES, True):
                 game_version = self.api.get_version(self.game, gameinfo=game_info)
                 update_available = self.game.is_update_available(game_version)
                 if update_available:

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -2,6 +2,7 @@ import shutil
 import subprocess
 
 from minigalaxy.config import Config
+from minigalaxy.game import InfoKey
 from minigalaxy.installer import create_applications_file
 from minigalaxy.translation import _
 from minigalaxy.launcher import config_game, regedit_game, winetricks_game
@@ -44,29 +45,29 @@ class Properties(Gtk.Dialog):
         self.button_sensitive(game)
 
         # Keep switch check for updates disabled/enabled
-        self.switch_properties_check_for_updates.set_active(self.game.get_info("check_for_updates"))
+        self.switch_properties_check_for_updates.set_active(self.game.get_info(InfoKey.CHECK_UPDATES))
 
         # Retrieve custom wine path each time Properties is open
-        if self.game.get_info("custom_wine"):
-            self.button_properties_wine.set_filename(self.game.get_info("custom_wine"))
+        if self.game.get_info(InfoKey.CUSTOM_WINE):
+            self.button_properties_wine.set_filename(self.game.get_info(InfoKey.CUSTOM_WINE))
         elif shutil.which("wine"):
             self.button_properties_wine.set_filename(shutil.which("wine"))
 
         # Keep switch FPS disabled/enabled
-        self.switch_properties_show_fps.set_active(self.game.get_info("show_fps"))
+        self.switch_properties_show_fps.set_active(self.game.get_info(InfoKey.SHOW_FPS))
 
         # Keep switch game shown/hidden
-        self.switch_properties_hide_game.set_active(self.game.get_info("hide_game"))
+        self.switch_properties_hide_game.set_active(self.game.get_info(InfoKey.HIDE_GAME))
 
         # Keep switch use GameMode disabled/enabled
-        self.switch_properties_use_gamemode.set_active(self.game.get_info("use_gamemode"))
+        self.switch_properties_use_gamemode.set_active(self.game.get_info(InfoKey.GAMEMODE))
 
         # Keep switch use MangoHud disabled/enabled
-        self.switch_properties_use_mangohud.set_active(self.game.get_info("use_mangohud"))
+        self.switch_properties_use_mangohud.set_active(self.game.get_info(InfoKey.MANGOHUD))
 
         # Retrieve variable & command each time properties is open
-        self.entry_properties_variable.set_text(self.game.get_info("variable"))
-        self.entry_properties_command.set_text(self.game.get_info("command"))
+        self.entry_properties_variable.set_text(self.game.get_info(InfoKey.VARIABLES))
+        self.entry_properties_command.set_text(self.game.get_info(InfoKey.COMMAND))
 
         # Center properties window
         self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
@@ -79,22 +80,22 @@ class Properties(Gtk.Dialog):
     def ok_pressed(self, button):
         game_installed = self.game.is_installed()
         if game_installed:
-            self.game.set_info("check_for_updates", self.switch_properties_check_for_updates.get_active())
-            self.game.set_info("show_fps", self.switch_properties_show_fps.get_active())
+            self.game.set_info(InfoKey.CHECK_UPDATES, self.switch_properties_check_for_updates.get_active())
+            self.game.set_info(InfoKey.SHOW_FPS, self.switch_properties_show_fps.get_active())
             if self.switch_properties_use_gamemode.get_active() and not shutil.which("gamemoderun"):
                 self.parent_window.show_error(_("GameMode wasn't found. Using GameMode cannot be enabled."))
-                self.game.set_info("use_gamemode", False)
+                self.game.set_info(InfoKey.GAMEMODE, False)
             else:
-                self.game.set_info("use_gamemode", self.switch_properties_use_gamemode.get_active())
+                self.game.set_info(InfoKey.GAMEMODE, self.switch_properties_use_gamemode.get_active())
             if self.switch_properties_use_mangohud.get_active() and not shutil.which("mangohud"):
                 self.parent_window.show_error(_("MangoHud wasn't found. Using MangoHud cannot be enabled."))
-                self.game.set_info("use_mangohud", False)
+                self.game.set_info(InfoKey.MANGOHUD, False)
             else:
-                self.game.set_info("use_mangohud", self.switch_properties_use_mangohud.get_active())
-            self.game.set_info("variable", str(self.entry_properties_variable.get_text()))
-            self.game.set_info("command", str(self.entry_properties_command.get_text()))
-        self.game.set_info("hide_game", self.switch_properties_hide_game.get_active())
-        self.game.set_info("custom_wine", str(self.button_properties_wine.get_filename()))
+                self.game.set_info(InfoKey.MANGOHUD, self.switch_properties_use_mangohud.get_active())
+            self.game.set_info(InfoKey.VARIABLES, str(self.entry_properties_variable.get_text()))
+            self.game.set_info(InfoKey.COMMAND, str(self.entry_properties_command.get_text()))
+        self.game.set_info(InfoKey.HIDE_GAME, self.switch_properties_hide_game.get_active())
+        self.game.set_info(InfoKey.CUSTOM_WINE, str(self.button_properties_wine.get_filename()))
         self.parent_library.filter_library()
 
         if game_installed and self.config.create_applications_file:

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 from unittest.mock import MagicMock, mock_open, patch
-from minigalaxy.game import Game
+from minigalaxy.game import Game, InfoKey
 
 
 class TestGame(unittest.TestCase):
@@ -132,7 +132,7 @@ en-US
         json_content = '{"version": "gog-2"}'
         with patch("builtins.open", mock_open(read_data=json_content)) as m:
             game = Game("Game Name test2")
-            game.set_info("version", "gog-3")
+            game.set_info(InfoKey.VERSION, "gog-3")
         mock_c = m.mock_calls
         write_string = ""
         for kall in mock_c:


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This is a very small PR which only adds a couple of new preferences in `Config` which i'll be needing later.
There is no UI for them yet, it will follow after the implementation of the free platform selection feature.

### Look-ahead about preferences and how i plan to use them:

I plan to replace the current `show_windows_games` with a more dynamic variant consisting of 2 other properties:
  1. Users can specify one `preferred_platform` (which effectively is what we have hard-coded as 'linux' everywhere)
  2. The combination of `preferred_platform` and `game_listing_mode` will control which games are shown and which are hidden. The `preferred_platform` generally is the one that is always shown. `game_listing_mode` defines if and how other platforms are shown.
- The combination of `preferred_platform=linux` and `game_listing_mode=all` would correspond to the current behavior when `show_windows_games=True`
- `preferred_platform=linux` + `game_listing_mode=preferred` => The current default where only linux games are visible
- `game_list_mode=mixed` would be new and correspond to a somewhat older suggestion from https://github.com/sharkwouter/minigalaxy/issues/404#issuecomment-2498998199 but in a more generalised way

`preferred_platform` has 2 more purposes, it's not just used as a library filter:
1. Games that support multiple platforms generally allow a per-game selection, but this can quickly become tedious to click and change if a user generally prefers another platform as what we would deem 'the standard'. `preferred_platform` is used as a default fallback instead of forcing the user to pick every time. What platform is preferred will be placed very prominently in the UI later, so that it's always visible.
2. To declutter icons, but still behave in a way that's similar to how the wine icon is shown currently. Installed games will not show the platform icon, if the installed variant corresponds to the current `preferred_platform`. E.g. one might set `preferred_platform=windows`, then installed windows games will appear without the wine icon and native linux games instead will get a little penguin. A user that decides to primarily install windows games should have the wine icon obstruct almost every game.  
Evaluation of this setting will be dynamic, changing the preferred platfrom and restarting will impact the icons shown on installed games.  
Not installed games supporting several platforms will always show one icon per platform. They will be clickable to allow quick platform selection.

Changelog wasn't touched in this PR and will be updated with the UI changes to prevent unnecessary merge conflicts with the other open PR.

@sharkwouter I'm open to any feedback or ideas you might have about my plans. I can also post a few screenshots

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
