### PR TITLE
Feature: Prepare new preferences for platform choice (reopened)

### DIFF
--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,4 +1,4 @@
-## Logo image (data/minigalaxy.png)
+## Logo image (minigalaxy/ui/data/io.github.sharkwouter.Minigalaxy.png)
 
 **[Copyright 2014 Epic Runes](https://opengameart.org/users/epic-runes)**
 

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -142,6 +142,14 @@ class Config:
         self.__set_and_write("keep_installers", new_value)
 
     @property
+    def keep_installers_per_platform(self) -> bool:
+        return self.__config.get("keep_installers_per_platform", True)
+
+    @keep_installers_per_platform.setter
+    def keep_installers_per_platform(self, new_value: bool) -> None:
+        self.__set_and_write("keep_installers_per_platform", new_value)
+
+    @property
     def stay_logged_in(self) -> bool:
         return self.__config.get("stay_logged_in", True)
 
@@ -172,6 +180,22 @@ class Config:
     @show_windows_games.setter
     def show_windows_games(self, new_value: bool) -> None:
         self.__set_and_write("show_windows_games", new_value)
+
+    @property
+    def preferred_platform(self) -> str:
+        return self.__config.get("preferred_platform", "linux")
+
+    @preferred_platform.setter
+    def preferred_platform(self, new_value: str) -> None:
+        self.__set_and_write("preferred_platform", new_value)
+
+    @property
+    def game_listing_mode(self) -> str:
+        return self.__config.get("game_listing_mode", "linux")
+
+    @game_listing_mode.setter
+    def game_listing_mode(self, new_value: str) -> None:
+        self.__set_and_write("game_listing_mode", new_value)
 
     @property
     def keep_window_maximized(self) -> bool:

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -20,16 +20,22 @@ class Config:
         self.__is_batch_edit = False
         self.__config_file = config_file
         self.__config = {}
+        # this property is cached, because its config value representation differs from the structure in code
+        self.__platform_mode = None
         self.__load()
 
     def __load(self) -> None:
-        if os.path.isfile(self.__config_file):
-            with open(self.__config_file, "r", encoding="utf-8") as file:
-                try:
-                    self.__config = json.loads(file.read())
-                except (json.decoder.JSONDecodeError, UnicodeDecodeError):
-                    logger.warning("Reading config.json failed, creating new config file.")
-                    os.remove(self.__config_file)
+        if not os.path.isfile(self.__config_file):
+            return
+
+        with open(self.__config_file, "r", encoding="utf-8") as file:
+            try:
+                self.__config = json.loads(file.read())
+            except (json.decoder.JSONDecodeError, UnicodeDecodeError):
+                logger.warning("Reading config.json failed, creating new config file.")
+                os.remove(self.__config_file)
+        # reset cached transformed properties
+        self.__platform_mode = None
 
     def __write(self) -> None:
         if not os.path.isfile(self.__config_file):
@@ -39,6 +45,13 @@ class Config:
         with open(temp_file, "w", encoding="utf-8") as file:
             file.write(json.dumps(self.__config, ensure_ascii=False))
         os.rename(temp_file, self.__config_file)
+
+    def __as_list(self, value: str):
+        return value.split(",") if str else []
+
+    def __as_csv(self, value):
+        """When value is a list, join it with comma and return, else expect it to be string and just return as is"""
+        return ",".join(value) if isinstance(value, list) else value
 
     def start_batch_edit(self):
         """
@@ -142,14 +155,6 @@ class Config:
         self.__set_and_write("keep_installers", new_value)
 
     @property
-    def keep_installers_per_platform(self) -> bool:
-        return self.__config.get("keep_installers_per_platform", True)
-
-    @keep_installers_per_platform.setter
-    def keep_installers_per_platform(self, new_value: bool) -> None:
-        self.__set_and_write("keep_installers_per_platform", new_value)
-
-    @property
     def stay_logged_in(self) -> bool:
         return self.__config.get("stay_logged_in", True)
 
@@ -182,20 +187,22 @@ class Config:
         self.__set_and_write("show_windows_games", new_value)
 
     @property
-    def preferred_platform(self) -> str:
-        return self.__config.get("preferred_platform", "linux")
+    def platform_mode(self) -> str:
+        """NOTE: This property is stored as string, but represented internally as list"""
+        if not self.__platform_mode:
+            # cache the splitted value for performance reasons
+            self.__platform_mode = self.__as_list(self.__config.get("platform_mode", "linux"))
+        return self.__platform_mode
 
-    @preferred_platform.setter
-    def preferred_platform(self, new_value: str) -> None:
-        self.__set_and_write("preferred_platform", new_value)
-
-    @property
-    def game_listing_mode(self) -> str:
-        return self.__config.get("game_listing_mode", "linux")
-
-    @game_listing_mode.setter
-    def game_listing_mode(self, new_value: str) -> None:
-        self.__set_and_write("game_listing_mode", new_value)
+    @platform_mode.setter
+    def platform_mode(self, new_value) -> None:
+        """
+        Accepts str or list[str] as value, should consist of values found in 'constants.py:PLATFORM_MODE[n][0]'.
+        'platform_mode' is stored as string because it is easier to use in a ComboBox and select in preferences dialog.
+        """
+        new_value = self.__as_csv(new_value)
+        self.__set_and_write("platform_mode", new_value)
+        self.__platform_mode = None
 
     @property
     def keep_window_maximized(self) -> bool:

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -79,6 +79,17 @@ VIEWS = [
     ["list", _("List")],
 ]
 
+PLATFORMS = [
+    ["linux", _("Linux")],
+    ["windows", _("Windows")]
+]
+
+GAME_LISTING_MODE = [
+    ["preferred", _("Preferred platform only")],
+    ["mixed", _("Highlight preferred")],
+    ["all", _("Show all")]
+]
+
 # Game IDs to ignore when received by the API
 IGNORE_GAME_IDS = [
     1424856371,  # Hotline Miami 2: Wrong Number - Digital Comics

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -79,15 +79,13 @@ VIEWS = [
     ["list", _("List")],
 ]
 
-PLATFORMS = [
-    ["linux", _("Linux")],
-    ["windows", _("Windows")]
-]
-
-GAME_LISTING_MODE = [
-    ["preferred", _("Preferred platform only")],
-    ["mixed", _("Highlight preferred")],
-    ["all", _("Show all")]
+# PLATFORM_MODE controls which platforms/icons are visible
+# the order of values defines priority: the first value is used as default for install (when not overridden per game)
+PLATFORM_MODE = [
+    ["linux", _("Linux only")],
+    ["linux,windows", _("Prefer Linux")],
+    ["windows,linux", _("Prefer Windows")],
+    ["windows", _("Windows only")]
 ]
 
 # Game IDs to ignore when received by the API

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,14 @@ from minigalaxy.paths import DEFAULT_INSTALL_DIR
 
 class TestConfig(TestCase):
 
+    def setUp(self):
+        """
+        Simple tests of methods contained in config don't have to care about the file.
+        They can just use a prepared real instance of Config in "batch_mode" to prevent writes.
+        """
+        self.config = Config("/no/writes/because/batch/mode")
+        self.config.start_batch_edit()
+
     @patch('os.path.isfile')
     def test_read_config_file(self, mock_isfile: MagicMock):
         mock_isfile.return_value = True
@@ -103,76 +111,42 @@ class TestConfig(TestCase):
         self.assertEqual(False, config.create_applications_file)
         self.assertEqual([], config.current_downloads)
 
-    @patch("os.path.isfile")
-    def test_config_property_setters(self, mock_isfile: MagicMock):
-        mock_isfile.return_value = True
-        filename = "/this/is/a/test"
-        config_data = "{}"
-        with patch("builtins.open", mock_open(read_data=config_data)):
-            config = Config(filename)
-            config._Config__write = MagicMock()
+    def test_config_property_setters(self):
+        config = self.config
+        config._Config__set_and_write = MagicMock(wraps=config._Config__set_and_write)
 
-        self.assertEqual("", config.locale)
-        config.locale = "en_US.UTF-8"
-        self.assertEqual("en_US.UTF-8", config.locale)
+        test_properties = [
+            ["locale", "", "en_US.UTF-8"],
+            ["lang", "en", "pl"],
+            ["view", "grid", "list"],
+            ["username", "", "username"],
+            ["install_dir", DEFAULT_INSTALL_DIR, "/install/dir"],
+            ["refresh_token", "", "refresh_token"],
+            ["keep_installers", False, True],
+            ["stay_logged_in", True, False],
+            ["use_dark_theme", False, True],
+            ["show_hidden_games", False, True],
+            ["show_windows_games", False, True],
+            # NOTE: platform_mode getter/setter work on incompatible types
+            # can not be tested here with the regular simple test loop
+            # ["platform_mode", ["linux"], "windows,linux"]
+            ["keep_window_maximized", False, True],
+            ["installed_filter", False, True],
+            ["create_applications_file", False, True],
+            ["current_downloads", [], [1, 2, 3]],
+            ["paused_downloads", {}, {"/some/file": 55}]
+        ]
 
-        config._Config__write.assert_called_once()
+        for prop in test_properties:
+            key = prop[0]
+            current_value = prop[1]
+            new_value = prop[2]
+            self.assertEqual(current_value, getattr(config, key), f"Property '{key}' default not as expected")
+            setattr(config, key, new_value)
+            self.assertEqual(new_value, getattr(config, key, f"Property '{key}' setter or getter not not working"))
 
-        self.assertEqual("en", config.lang)
-        config.lang = "pl"
-        self.assertEqual("pl", config.lang)
-
-        self.assertEqual("grid", config.view)
-        config.view = "list"
-        self.assertEqual("list", config.view)
-
-        self.assertEqual("", config.username)
-        config.username = "username"
-        self.assertEqual("username", config.username)
-
-        self.assertEqual(DEFAULT_INSTALL_DIR, config.install_dir)
-        config.install_dir = "/install/dir"
-        self.assertEqual("/install/dir", config.install_dir)
-
-        self.assertEqual("", config.refresh_token)
-        config.refresh_token = "refresh_token"
-        self.assertEqual("refresh_token", config.refresh_token)
-
-        self.assertEqual(False, config.keep_installers)
-        config.keep_installers = True
-        self.assertEqual(True, config.keep_installers)
-
-        self.assertEqual(True, config.stay_logged_in)
-        config.stay_logged_in = False
-        self.assertEqual(False, config.stay_logged_in)
-
-        self.assertEqual(False, config.use_dark_theme)
-        config.use_dark_theme = True
-        self.assertEqual(True, config.use_dark_theme)
-
-        self.assertEqual(False, config.show_hidden_games)
-        config.show_hidden_games = True
-        self.assertEqual(True, config.show_hidden_games)
-
-        self.assertEqual(False, config.show_windows_games)
-        config.show_windows_games = True
-        self.assertEqual(True, config.show_windows_games)
-
-        self.assertEqual(False, config.keep_window_maximized)
-        config.keep_window_maximized = True
-        self.assertEqual(True, config.keep_window_maximized)
-
-        self.assertEqual(False, config.installed_filter)
-        config.installed_filter = True
-        self.assertEqual(True, config.installed_filter)
-
-        self.assertEqual(False, config.create_applications_file)
-        config.create_applications_file = True
-        self.assertEqual(True, config.create_applications_file)
-
-        self.assertEqual([], config.current_downloads)
-        config.current_downloads = [1, 2, 3]
-        self.assertEqual([1, 2, 3], config.current_downloads)
+        err_msg = f"Expected {len(test_properties)} calls of Config.__set_and_write"
+        self.assertEqual(len(test_properties), config._Config__set_and_write.call_count, err_msg)
 
     @patch("os.rename")
     @patch('os.path.isfile')
@@ -186,36 +160,51 @@ class TestConfig(TestCase):
         mock_makedirs.assert_called_once_with("/path", mode=0o700, exist_ok=True)
         mock_rename.assert_called_once_with("/path/config.json.tmp", "/path/config.json")
 
-    @patch('os.path.isfile')
-    def test_add_ongoing_download(self, mock_isfile: MagicMock):
-        mock_isfile.return_value = True
-        config_data = "{}"
-        with patch("builtins.open", mock_open(read_data=config_data)):
-            config = Config("/pseudo/test/name")
-            config._Config__write = MagicMock()
+    def test_add_ongoing_download(self):
+        self.assertEqual([], self.config.current_downloads)
 
-        self.assertEqual(0, len(config.current_downloads))
-
-        config.add_ongoing_download("TESTID")
-        self.assertEqual(["TESTID"], config.current_downloads)
+        self.config.add_ongoing_download("TESTID")
+        self.assertEqual(["TESTID"], self.config.current_downloads)
 
         # not added a second time
-        config.add_ongoing_download("TESTID")
-        self.assertEqual(1, len(config.current_downloads))
+        self.config.add_ongoing_download("TESTID")
+        self.assertEqual(1, len(self.config.current_downloads))
 
-    @patch('os.path.isfile')
-    def test_remove_ongoing_download(self, mock_isfile: MagicMock):
-        mock_isfile.return_value = True
-        config_data = "{}"
-        with patch("builtins.open", mock_open(read_data=config_data)):
-            config = Config("/pseudo/test/name")
-            config._Config__write = MagicMock()
-
-        self.assertEqual(0, len(config.current_downloads))
+    def test_remove_ongoing_download(self):
+        self.assertEqual([], self.config.current_downloads)
 
         # removing something that is not contained should just be silently ignored
-        config.remove_ongoing_download("UNKNOWN-ID")
+        self.config.remove_ongoing_download("UNKNOWN-ID")
 
-        config.add_ongoing_download("TESTID")
-        config.remove_ongoing_download("TESTID")
-        self.assertEqual(0, len(config.current_downloads))
+        self.config.add_ongoing_download("TESTID")
+        self.config.remove_ongoing_download("TESTID")
+        self.assertEqual([], self.config.current_downloads)
+
+    def test_add_paused_download(self):
+        self.assertEqual({}, self.config.paused_downloads)
+
+        self.config.add_paused_download("/test/file", 12)
+        self.assertEqual({"/test/file": 12}, self.config.paused_downloads)
+
+    def test_remove_paused_download(self):
+        self.assertEqual({}, self.config.paused_downloads)
+
+        # removing something that is not contained should just be silently ignored
+        self.config.remove_paused_download("/unknown/file")
+
+        self.config.add_paused_download("/known/file", 42)
+        self.config.remove_paused_download("/known/file")
+        self.assertEqual({}, self.config.paused_downloads)
+
+    def test_platform_mode(self):
+        # default value
+        self.assertEqual(["linux"], self.config.platform_mode)
+
+        # set new value as string
+        self.config.platform_mode = "windows,linux"
+        self.assertEqual(["windows", "linux"], self.config.platform_mode)
+
+        # platform mode also (optionally) takes a list of strings for convenience in code
+        # this test can't use the getter, because that automatically wraps back to list
+        self.config.platform_mode = ["linux", "windows"]
+        self.assertEqual("linux,windows", self.config._Config__config["platform_mode"])


### PR DESCRIPTION
(I had to recreate the PR because github didn't let my reopen the first PR (#736 ) after my rebase)
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This is a very small PR which only adds a couple of new preferences in `Config` which i'll be needing later.
There is no UI for them yet, it will follow after the implementation of the free platform selection feature.

### Look-ahead about preferences and how i plan to use them:

I plan to replace the current `show_windows_games` with a more dynamic variant consisting of 2 other properties:
  1. Users can specify one `preferred_platform` (which effectively is what we have hard-coded as 'linux' everywhere)
  2. The combination of `preferred_platform` and `game_listing_mode` will control which games are shown and which are hidden. The `preferred_platform` generally is the one that is always shown. `game_listing_mode` defines if and how other platforms are shown.
- The combination of `preferred_platform=linux` and `game_listing_mode=all` would correspond to the current behavior when `show_windows_games=True`
- `preferred_platform=linux` + `game_listing_mode=preferred` => The current default where only linux games are visible
- `game_list_mode=mixed` would be new and correspond to a somewhat older suggestion from https://github.com/sharkwouter/minigalaxy/issues/404#issuecomment-2498998199 but in a more generalised way

`preferred_platform` has 2 more purposes, it's not just used as a library filter:
1. Games that support multiple platforms generally allow a per-game selection, but this can quickly become tedious to click and change if a user generally prefers another platform as what we would deem 'the standard'. `preferred_platform` is used as a default fallback instead of forcing the user to pick every time. What platform is preferred will be placed very prominently in the UI later, so that it's always visible.
2. To declutter icons, but still behave in a way that's similar to how the wine icon is shown currently. Installed games will not show the platform icon, if the installed variant corresponds to the current `preferred_platform`. E.g. one might set `preferred_platform=windows`, then installed windows games will appear without the wine icon and native linux games instead will get a little penguin. A user that decides to primarily install windows games shouldn't have the wine icon obstruct almost every game's thumbnail.  
Evaluation of this setting will be dynamic, changing the preferred platfrom and restarting will impact the icons shown on installed games.  
Not installed games supporting several platforms will always show one icon per platform. They will be clickable to allow quick platform selection.

`keep_installers_per_platform` is for folks that like to switch and try both variants. Initially i ran into problems with `keep_installers` alone when i switched platforms after downloading the other one. E.g. I had windows downloaded and switched to linux. The install failed miserably because it took the windows files. I've got some download manangement in place now so that this won't happen again - and ``keep_installers_per_platform` controls part of it.

When `True`, the downloads of the previous platform are kept by renaming the game installer directory (which is restored when switching back). When `False`, switching platforms deletes all previously downloaded files to make sure the correct ones for the new current are downloaded.
That means to keep all installers for ALL platforms, both `keep_installers` and `keep_installers_per_platform` need to be `True`. `keep_installers=True` alone will only persist installers until the next effective platform switch for a game. `keep_installers_per_platform` will effectively be ignore when `keep_installers=False`

Changelog wasn't touched in this PR and will be updated with the UI changes.

@sharkwouter I'm open to any feedback or ideas you might have about my plans. I can also post a few screenshots

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
