### PR TITLE
Feature: Introduce `platform_mode` in Preferences and use it to select installers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **1.4.3**
+- Introduce a global preference to pick if linux or windows game installers are preferred. (thanks to GB609)
 - Reduce unnecessary writes to the config file. (thanks to GB609)
 
 **1.4.2**

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -78,46 +78,55 @@ class Api:
             refresh_token = ""
         return refresh_token
 
-    # Get all Linux games in the library of the user. Ignore other platforms and movies
     def get_library(self):
+        """Get all Linux games in the library of the user. Ignore movies."""
         err_msg = ""
-        games = []
-        if self.active_token:
-            current_page = 1
-            all_pages_processed = False
-            url = "https://embed.gog.com/account/getFilteredProducts"
-
-            while not all_pages_processed:
-                params = {
-                    'mediaType': 1,  # 1 means game
-                    'page': current_page,
-                }
-                response = self.__request(url, params=params)
-                if "totalPages" not in response:
-                    err_msg = "Couldn't load game library"
-                    return games, err_msg
-                total_pages = response["totalPages"]
-
-                for product in response["products"]:
-                    if product["id"] not in IGNORE_GAME_IDS:
-                        # Only support Linux unless the show_windows_games setting is enabled
-                        if product["worksOn"]["Linux"]:
-                            platform = "linux"
-                        elif self.config.show_windows_games:
-                            platform = "windows"
-                        else:
-                            continue
-                        if not product["url"]:
-                            logger.warning("{} ({}) has no store page url".format(product["title"], product['id']))
-                        game = Game(name=product["title"], url=product["url"], game_id=product["id"],
-                                    image_url=product["image"], platform=platform, category=product["category"])
-                        games.append(game)
-                if current_page == total_pages:
-                    all_pages_processed = True
-                current_page += 1
-        else:
+        if not self.active_token:
             err_msg = "Couldn't connect to GOG servers"
-        return games, err_msg
+            return [], err_msg
+
+        current_page = 0
+        total_pages = 1
+        url = "https://embed.gog.com/account/getFilteredProducts"
+
+        gamesById = {}
+
+        while current_page < total_pages:
+            current_page += 1
+            params = {
+                'mediaType': 1,  # 1 means game
+                'page': current_page,
+            }
+            response = self.__request(url, params=params)
+            if "totalPages" not in response:
+                err_msg = "Couldn't load game library"
+                return [*gamesById.values()], err_msg
+            total_pages = response["totalPages"]
+            self.__parse_product_json(response["products"], gamesById)
+
+        return [*gamesById.values()], err_msg
+
+    def __parse_product_json(self, product_list, games_by_id):
+        for product in product_list:
+            if product["id"] in IGNORE_GAME_IDS:
+                continue
+
+            worksOn = product.get("worksOn", {})
+            platforms = []
+            if worksOn["Linux"]:
+                platforms.append("linux")
+            if worksOn["Windows"]:
+                platforms.append("windows")
+
+            if not platforms:
+                logger.warn("%s has no platform information - skip", product["title"])
+                continue
+
+            if not product["url"]:
+                logger.warning("%s (%s) has no store page url", product["title"], product['id'])
+            game = Game(name=product["title"], url=product["url"], game_id=product["id"],
+                        image_url=product["image"], platform=platforms, category=product["category"])
+            games_by_id[game.id] = game
 
     def get_owned_products_ids(self):
         if not self.active_token:

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -37,6 +37,14 @@ class Config:
         # reset cached transformed properties
         self.__platform_mode = None
 
+        # property migration
+        if "show_windows_games" in self.__config and "platform_mode" not in self.__config:
+            value = self.__config["show_windows_games"]
+            del self.__config["show_windows_games"]
+            new_mode = "linux,windows" if value else "linux"
+            logger.info("Migrating 'show_windows_games=%s' to 'platform_mode=%s", value, new_mode)
+            self.platform_mode = new_mode
+
     def __write(self) -> None:
         if not os.path.isfile(self.__config_file):
             config_dir = os.path.dirname(self.__config_file)
@@ -179,19 +187,11 @@ class Config:
         self.__set_and_write("show_hidden_games", new_value)
 
     @property
-    def show_windows_games(self) -> bool:
-        return self.__config.get("show_windows_games", False)
-
-    @show_windows_games.setter
-    def show_windows_games(self, new_value: bool) -> None:
-        self.__set_and_write("show_windows_games", new_value)
-
-    @property
     def platform_mode(self) -> str:
         """NOTE: This property is stored as string, but represented internally as list"""
         if not self.__platform_mode:
             # cache the splitted value for performance reasons
-            self.__platform_mode = self.__as_list(self.__config.get("platform_mode", "linux"))
+            self.__platform_mode = self.__as_list(self._raw_platform_mode())
         return self.__platform_mode
 
     @platform_mode.setter
@@ -203,6 +203,15 @@ class Config:
         new_value = self.__as_csv(new_value)
         self.__set_and_write("platform_mode", new_value)
         self.__platform_mode = None
+
+    def _raw_platform_mode(self):
+        """To be used by preferences dialog only. Returns plain config string. Used to check for changes."""
+        return self.__config.get("platform_mode", "linux")
+
+    @property
+    def preferred_platform(self):
+        """Not a full settings - it only exists as a convenient shortcut for 'Config.platform_mode[0]'"""
+        return self.platform_mode[0]
 
     @property
     def keep_window_maximized(self) -> bool:
@@ -249,14 +258,14 @@ class Config:
         self.__set_and_write("current_downloads", new_value)
 
     def add_ongoing_download(self, download_id):
-        '''Adds the given id to the list of active downloads if not contained already. Does nothing otherwise.'''
+        """Adds the given id to the list of active downloads if not contained already. Does nothing otherwise."""
         current = self.current_downloads
         if download_id not in current:
             current.append(download_id)
             self.current_downloads = current
 
     def remove_ongoing_download(self, download_id):
-        '''Removes the given id from the list of active downloads, if contained. Does nothing otherwise.'''
+        """Removes the given id from the list of active downloads, if contained. Does nothing otherwise."""
         current = self.current_downloads
         if download_id in current:
             current.remove(download_id)

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -39,6 +39,11 @@ class Game:
     def get_stripped_name(self, to_path=False):
         return Game.strip_string(self.name, to_path=to_path)
 
+    def supported_platforms(self):
+        if isinstance(self.platform, str):
+            return [self.platform]
+        return [*self.platform]
+
     def get_install_directory_name(self):
         return Game.strip_string(self.name, to_path=True)
 

--- a/minigalaxy/platforms.py
+++ b/minigalaxy/platforms.py
@@ -1,0 +1,23 @@
+from minigalaxy.config import Config
+from minigalaxy.game import Game
+
+
+def update_supported_platforms(game: Game, config: Config):
+    """Update 'Game.platform' of the given game depending on 'Config.platform_mode' and the install state"""
+    if game.is_installed():
+        # do nothing, installed games get their platform tag when loading from the install dir
+        return
+
+    active_platforms = set(config.platform_mode)
+    supported_platforms = list(set(game.supported_platforms()) & active_platforms)
+
+    # temporary: until full platform selection support is merged in the UI, do a forced pre-selection here
+    # this block will be removed later and the (reduced) supported_platforms set will be used directly
+    if len(supported_platforms) > 1 and config.preferred_platform in supported_platforms:
+        supported_platforms = config.preferred_platform
+    elif len(supported_platforms) == 1:
+        supported_platforms = supported_platforms[0]
+    else:
+        supported_platforms = []
+
+    game.platform = supported_platforms

--- a/minigalaxy/ui/data/preferences.ui
+++ b/minigalaxy/ui/data/preferences.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface domain="minigalaxy">
   <requires lib="gtk+" version="3.20"/>
   <template class="Preferences" parent="GtkDialog">
@@ -51,27 +51,12 @@
           </packing>
         </child>
         <child>
-          <!-- n-columns=3 n-rows=9 -->
+          <!-- n-columns=2 n-rows=10 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="row-spacing">2</property>
             <property name="row-homogeneous">True</property>
-            <property name="column-homogeneous">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="language_tooltip">The preferred language on Minigalaxy start</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="language" comments="The preferred language on Minigalaxy start. Has to end with &quot;: &quot;">Language: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">0</property>
-              </packing>
-            </child>
             <child>
               <object class="GtkComboBox" id="combobox_program_language">
                 <property name="visible">True</property>
@@ -81,20 +66,6 @@
               <packing>
                 <property name="left-attach">1</property>
                 <property name="top-attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="preferred_game_language_tooltip">The preferred language for downloading games in</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="preferred_game_language" comments="Preferred language for downloading games in. Has to end with &quot;: &quot;">Preferred game language: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">1</property>
               </packing>
             </child>
             <child>
@@ -109,20 +80,6 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="view_tooltip">The preferred view of game library</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="view" comments="The preferred view of game library. Has to end with &quot;: &quot;">View: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">2</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkComboBox" id="combobox_view">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -130,20 +87,6 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="install_path_tooltip">This is where games will be installed</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="install_path" comments="The place directory in which games are installed. Has to end with &quot;: &quot;">Installation path: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
                 <property name="top-attach">3</property>
               </packing>
             </child>
@@ -158,19 +101,6 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label_keep_installers">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="keep_installer" comments="Whether installer files are kept after download. Has to end with &quot;: &quot;">Keep installers: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
                 <property name="top-attach">4</property>
               </packing>
             </child>
@@ -183,20 +113,6 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="stay_logged_in_tooltip">When disabled you'll be asked to log in each time Minigalaxy is started</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="stay_logged_in" comments="Whether the user will stay logged in after closing Minigalaxy. Has to end with &quot;: &quot;">Stay logged in:</property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
                 <property name="top-attach">5</property>
               </packing>
             </child>
@@ -210,20 +126,6 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="use_dark_theme_tooltip">Whether Minigalaxy should use dark theme or not</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="use_dark_theme" comments="Has to end with &quot;: &quot;">Use dark theme: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
                 <property name="top-attach">6</property>
               </packing>
             </child>
@@ -236,51 +138,11 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="show_hidden_games_tooltip">Whether hidden games are shown in the library or not</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="show_hidden_games" comments="Has to end with &quot;: &quot;">Show hidden games: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
                 <property name="top-attach">7</property>
               </packing>
             </child>
             <child>
               <object class="GtkSwitch" id="switch_show_hidden_games">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="show_windows_games_tooltip">Whether Windows games are shown in the library or not</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="show_windows_games" comments="Has to end with &quot;: &quot;">Show Windows games: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">8</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="switch_show_windows_games">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="halign">start</property>
@@ -304,6 +166,128 @@
               </packing>
             </child>
             <child>
+              <object class="GtkComboBox" id="combobox_platform_mode">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="valign">center</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="language_tooltip">The preferred language on Minigalaxy start</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="language" comments="The preferred language on Minigalaxy start. Has to end with &quot;: &quot;">Language: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="preferred_game_language_tooltip">The preferred language for downloading games in</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="preferred_game_language" comments="Preferred language for downloading games in. Has to end with &quot;: &quot;">Preferred game language: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="view_tooltip">The preferred view of game library</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="view" comments="The preferred view of game library. Has to end with &quot;: &quot;">View: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="install_path_tooltip">This is where games will be installed</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="install_path" comments="The place directory in which games are installed. Has to end with &quot;: &quot;">Installation path: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label_keep_installers">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="keep_installer" comments="Whether installer files are kept after download. Has to end with &quot;: &quot;">Keep installers: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="stay_logged_in_tooltip">When disabled you'll be asked to log in each time Minigalaxy is started</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="stay_logged_in" comments="Whether the user will stay logged in after closing Minigalaxy. Has to end with &quot;: &quot;">Stay logged in:</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="use_dark_theme_tooltip">Whether Minigalaxy should use dark theme or not</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="use_dark_theme" comments="Has to end with &quot;: &quot;">Use dark theme: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="show_hidden_games_tooltip">Whether hidden games are shown in the library or not</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="show_hidden_games" comments="Has to end with &quot;: &quot;">Show hidden games: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">8</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -318,28 +302,18 @@
               </packing>
             </child>
             <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Which platforms to show and favor when installing games</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Platform support:</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">2</property>
+              </packing>
             </child>
           </object>
           <packing>

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -18,6 +18,7 @@ from minigalaxy.ui.gametilelist import GameTileList
 from minigalaxy.ui.gtk import Gtk, GLib, load_ui
 
 from typing import List
+from minigalaxy.platforms import update_supported_platforms
 
 
 @Gtk.Template(string=load_ui("library.ui"))
@@ -130,11 +131,11 @@ class Library(Gtk.Viewport):
 
     def __create_gametiles(self) -> None:
         """Gets called twice: Once for installed, once for not installed games."""
-        games_with_tiles = []
+        games_with_tiles = {}
         for child in self.flowbox.get_children():
             tile = child.get_children()[0]
             if tile.game in self.games:
-                games_with_tiles.append(tile.game)
+                games_with_tiles[tile.game.id] = tile.game
                 """Games which already have a tile during the second invocation are installed games.
                 These did NOT have api information about the thumbnail url in their Game instance in the first pass.
                 Thus, they weren't able to load the thumbnail if it wasn't cached before. Try again now.
@@ -144,7 +145,10 @@ class Library(Gtk.Viewport):
                 tile.load_thumbnail()
 
         for game in self.games:
-            if game not in games_with_tiles:
+            if game.id in games_with_tiles:
+                continue
+            update_supported_platforms(game, self.config)
+            if game.supported_platforms():
                 self.__add_gametile(game)
 
     def __add_gametile(self, game):
@@ -216,17 +220,29 @@ class Library(Gtk.Viewport):
             if game not in self.games:
                 self.games.append(game)
 
+            # this updates the local instance of Game with data retrieved from remote
             local_game = self.games[self.games.index(game)]
-            if local_game.id == 0 or local_game.name != game.name:
-                local_game.id = game.id
-                local_game.name = game.name
+            _update_gameinfo(local_game, game, game_category_dict)
 
-            local_game.image_url = game.image_url
-            local_game.url = game.url
-            local_game.category = game.category
-            if len(game.category) > 0:  # exclude games without set category
-                game_category_dict[game.name] = game.category
         update_game_categories_file(game_category_dict, CATEGORIES_FILE_PATH)
+
+
+def _update_gameinfo(local_game, api_game, game_category_dict={}):
+    """
+    Installed games are detected first, and they will be missing some information provided by GOG.
+    This function takes a local Game and a freshly oobtained Game from API and updates the local instance with
+    a select list of properties from API.
+    'game_category_dict' is used for library filters and should be passed in from the called.
+    """
+    if local_game.id == 0 or local_game.name != api_game.name:
+        local_game.id = api_game.id
+        local_game.name = api_game.name
+
+    local_game.image_url = api_game.image_url
+    local_game.url = api_game.url
+    local_game.category = api_game.category
+    if len(api_game.category) > 0:  # exclude games without set category
+        game_category_dict[api_game.name] = api_game.category
 
 
 def get_installed_windows_games(full_path, game_categories_dict=None):

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -3,12 +3,12 @@ import locale
 import shutil
 
 from minigalaxy.config import Config
-from minigalaxy.constants import SUPPORTED_DOWNLOAD_LANGUAGES, SUPPORTED_LOCALES, VIEWS
+from minigalaxy.constants import PLATFORM_MODE, SUPPORTED_DOWNLOAD_LANGUAGES, SUPPORTED_LOCALES, VIEWS
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.logger import logger
 from minigalaxy.translation import _
 from minigalaxy.ui.gtk import Gtk, load_ui
-from minigalaxy.ui.widget_utils import populate_combobox
+from minigalaxy.ui.widget_utils import get_combo_value, populate_combobox
 
 
 @Gtk.Template(string=load_ui("preferences.ui"))
@@ -18,12 +18,12 @@ class Preferences(Gtk.Dialog):
     combobox_program_language = Gtk.Template.Child()
     combobox_language = Gtk.Template.Child()
     combobox_view = Gtk.Template.Child()
+    combobox_platform_mode = Gtk.Template.Child()
     button_file_chooser = Gtk.Template.Child()
     label_keep_installers = Gtk.Template.Child()
     switch_keep_installers = Gtk.Template.Child()
     switch_stay_logged_in = Gtk.Template.Child()
     switch_show_hidden_games = Gtk.Template.Child()
-    switch_show_windows_games = Gtk.Template.Child()
     switch_create_applications_file = Gtk.Template.Child()
     switch_use_dark_theme = Gtk.Template.Child()
     button_cancel = Gtk.Template.Child()
@@ -38,12 +38,12 @@ class Preferences(Gtk.Dialog):
         self.__set_locale_list()
         self.__set_language_list()
         self.__set_view_list()
+        populate_combobox(self.combobox_platform_mode, PLATFORM_MODE, self.config._raw_platform_mode())
         self.button_file_chooser.set_filename(self.config.install_dir)
         self.switch_keep_installers.set_active(self.config.keep_installers)
         self.switch_stay_logged_in.set_active(self.config.stay_logged_in)
         self.switch_use_dark_theme.set_active(self.config.use_dark_theme)
         self.switch_show_hidden_games.set_active(self.config.show_hidden_games)
-        self.switch_show_windows_games.set_active(self.config.show_windows_games)
         self.switch_create_applications_file.set_active(self.config.create_applications_file)
 
         # Set tooltip for keep installers label
@@ -51,6 +51,9 @@ class Preferences(Gtk.Dialog):
         self.label_keep_installers.set_tooltip_text(
             _("Keep installers after downloading a game.\nInstallers are stored in: {}").format(installer_dir)
         )
+
+        # used to make sure `window.reset_library` is only called once per `save`, as it is an expensive operation
+        self.requires_reset_library = False
 
     def __set_locale_list(self) -> None:
         # Set the active option
@@ -68,45 +71,35 @@ class Preferences(Gtk.Dialog):
         populate_combobox(self.combobox_view, VIEWS, self.config.view)
 
     def __apply_locale_choice(self) -> None:
-        new_locale = self.combobox_program_language.get_active_iter()
-        if new_locale is not None:
-            model = self.combobox_program_language.get_model()
-            locale_choice = model[new_locale][-2]
-            if locale_choice == '':
-                default_locale = locale.getdefaultlocale()[0]
-                locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
-                self.config.locale = locale_choice
-            else:
-                try:
-                    locale.setlocale(locale.LC_ALL, (locale_choice, 'UTF-8'))
-                    self.config.locale = locale_choice
-                except locale.Error:
-                    self.parent.show_error(_("Failed to change program language. Make sure locale is generated on "
-                                             "your system."))
+        locale_choice = get_combo_value(self.combobox_program_language)
+        if locale_choice == '' or not locale_choice:
+            locale_choice = locale.getdefaultlocale()[0]
 
-    def __apply_language_choice(self) -> None:
-        lang_choice = self.combobox_language.get_active_iter()
-        if lang_choice is not None:
-            model = self.combobox_language.get_model()
-            lang, _ = model[lang_choice][:2]
-            self.config.lang = lang
+        try:
+            locale.setlocale(locale.LC_ALL, (locale_choice, 'UTF-8'))
+            self.config.locale = locale_choice
+        except locale.Error:
+            self.parent.show_error(_("Failed to change program language. Make sure locale is generated on "
+                                     "your system."))
 
     def __apply_view_choice(self) -> None:
-        view_choice = self.combobox_view.get_active_iter()
-        if view_choice is not None:
-            model = self.combobox_view.get_model()
-            view, _ = model[view_choice][:2]
-            if view != self.config.view:
-                self.parent.reset_library()
-            self.config.view = view
+        view = get_combo_value(self.combobox_view)
+        self.requires_reset_library = view != self.config.view
+        self.config.view = view
 
     def __apply_theme_choice(self) -> None:
         settings = Gtk.Settings.get_default()
         self.config.use_dark_theme = self.switch_use_dark_theme.get_active()
-        if self.config.use_dark_theme is True:
-            settings.set_property("gtk-application-prefer-dark-theme", True)
-        else:
-            settings.set_property("gtk-application-prefer-dark-theme", False)
+        settings.set_property("gtk-application-prefer-dark-theme", self.config.use_dark_theme)
+
+    def __apply_platform_mode(self):
+        new_mode = get_combo_value(self.combobox_platform_mode)
+        if new_mode == self.config._raw_platform_mode():
+            return
+        self.config.platform_mode = new_mode
+        self.requires_reset_library = True
+        if "windows" in new_mode and not shutil.which("wine"):
+            self.parent.show_error(_("Wine wasn't found. Windows games will be shown but not be installable."))
 
     def __save_install_dir_choice(self) -> bool:
         choice = self.button_file_chooser.get_filename()
@@ -141,42 +134,40 @@ class Preferences(Gtk.Dialog):
     def save_pressed(self, button):
         save_changes = True
         try:
-            self.config.start_batch_edit()
+            config = self.config
+            config.start_batch_edit()
 
             self.__apply_locale_choice()
-            self.__apply_language_choice()
+            config.lang = get_combo_value(self.combobox_language)
             self.__apply_view_choice()
             self.__apply_theme_choice()
-            self.config.keep_installers = self.switch_keep_installers.get_active()
-            self.config.stay_logged_in = self.switch_stay_logged_in.get_active()
-            self.config.show_hidden_games = self.switch_show_hidden_games.get_active()
-            self.config.create_applications_file = self.switch_create_applications_file.get_active()
+            config.keep_installers = self.switch_keep_installers.get_active()
+            config.stay_logged_in = self.switch_stay_logged_in.get_active()
+            config.show_hidden_games = self.switch_show_hidden_games.get_active()
+            config.create_applications_file = self.switch_create_applications_file.get_active()
             self.parent.library.filter_library()
 
-            if self.switch_show_windows_games.get_active() != self.config.show_windows_games:
-                if self.switch_show_windows_games.get_active() and not shutil.which("wine"):
-                    self.parent.show_error(_("Wine wasn't found. Showing Windows games cannot be enabled."))
-                    self.config.show_windows_games = False
-                else:
-                    self.config.show_windows_games = self.switch_show_windows_games.get_active()
-                    self.parent.reset_library()
+            self.__apply_platform_mode()
 
             # Only change the install_dir is it was actually changed
-            if self.button_file_chooser.get_filename() != self.config.install_dir:
+            if self.button_file_chooser.get_filename() != config.install_dir:
                 if self.__save_install_dir_choice():
                     self.download_manager.cancel_all_downloads()
-                    self.parent.reset_library()
+                    self.requires_reset_library = True
                 else:
                     self.parent.show_error(_("{} isn't a usable path").format(self.button_file_chooser.get_filename()))
 
         except Exception as e:
             logger.error("Could not save preferences", exc_info=1)
-            self.config.cancel_batch_edit()
+            config.cancel_batch_edit()
             save_changes = False
             self.parent.show_error(_("There was an error while saving preferences."), str(e))
 
         if save_changes:
-            self.config.save()
+            config.save()
+
+        if self.requires_reset_library:
+            self.parent.reset_library()
 
         self.destroy()
 

--- a/minigalaxy/ui/widget_utils.py
+++ b/minigalaxy/ui/widget_utils.py
@@ -27,3 +27,14 @@ def populate_combobox(combo: Gtk.ComboBox, str_tuple_list, active_value: str):
         if data_list[key][:1][0] == active_value:
             combo.set_active(key)
             break
+
+
+def get_combo_value(combo):
+    """Return key string of the currently selected entry in ComboBox. Expects same structure as 'populate_combobox'"""
+    selected_index = combo.get_active_iter()
+    if selected_index is None:
+        return None
+
+    model = combo.get_model()
+    result, _ = model[selected_index][:2]
+    return result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,6 @@ class TestConfig(TestCase):
                 "stay_logged_in": false,
                 "use_dark_theme": true,
                 "show_hidden_games": true,
-                "show_windows_games": true,
                 "keep_window_maximized": true,
                 "installed_filter": true,
                 "create_applications_file": true,
@@ -52,7 +51,6 @@ class TestConfig(TestCase):
         self.assertEqual(False, config.stay_logged_in)
         self.assertEqual(True, config.use_dark_theme)
         self.assertEqual(True, config.show_hidden_games)
-        self.assertEqual(True, config.show_windows_games)
         self.assertEqual(True, config.keep_window_maximized)
         self.assertEqual(True, config.installed_filter)
         self.assertEqual(True, config.create_applications_file)
@@ -74,7 +72,6 @@ class TestConfig(TestCase):
         self.assertEqual(True, config.stay_logged_in)
         self.assertEqual(False, config.use_dark_theme)
         self.assertEqual(False, config.show_hidden_games)
-        self.assertEqual(False, config.show_windows_games)
         self.assertEqual(False, config.keep_window_maximized)
         self.assertEqual(False, config.installed_filter)
         self.assertEqual(False, config.create_applications_file)
@@ -105,7 +102,6 @@ class TestConfig(TestCase):
         self.assertEqual(True, config.stay_logged_in)
         self.assertEqual(False, config.use_dark_theme)
         self.assertEqual(False, config.show_hidden_games)
-        self.assertEqual(False, config.show_windows_games)
         self.assertEqual(False, config.keep_window_maximized)
         self.assertEqual(False, config.installed_filter)
         self.assertEqual(False, config.create_applications_file)
@@ -126,7 +122,6 @@ class TestConfig(TestCase):
             ["stay_logged_in", True, False],
             ["use_dark_theme", False, True],
             ["show_hidden_games", False, True],
-            ["show_windows_games", False, True],
             # NOTE: platform_mode getter/setter work on incompatible types
             # can not be tested here with the regular simple test loop
             # ["platform_mode", ["linux"], "windows,linux"]


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This PR introduces a partial implementation of the final platform selection feature:
It is now possible to set up globally if linux or windows installers shall be used (applies for games supporting both).
Additionally, pure windows games will be shown or hidden depending on the value of `platform_mode` that was picked.
The code in this PR is complete enough to have a working state in master - the new preference is used. So a basic way to chose exists now. Users going from git directly could use/test the current state without having to wait for a release.

This new setting replaces the previous option `show_windows_games`. Code to migrate the property value was added and will apply when Minigalaxy loads its config.json:
1. when `show_windows_games` exists as a key, take the value and then remove the key
2. if it was `True` before, apply `platform_mode=linux,windows`
3. If it was `False`, apply `platform_mode=linux`

NEW modes:
- "Linux only":`platform_mode=linux`: Show all games supporting a native linux version. Any additional support for windows is ignored and won't even be given as a choice to pick from. This is the _current_ behaviour when `show_windows_games=False`
- "Prefer Linux":`platform_mode=linux,windows`: Show all games supporting at least one of the given platforms.  
   Use/prefer the linux installers where available.
- "Prefer Windows":`platform_mode=windows,linux`: Show all games supporting at least one of the given platforms.  
   Use/prefer the windows installers where available.
- "Windows only":`platform_mode=windows`: The inverse of `platform_mode=linux`. In theory, **pure** linux games would be hidden (if such games exist, although rare). Aside from that, for games that support both, it will later have the effect that the linux version won't be offered for download at all (icon to change is hidden).

The difference between the two "Prefer" variants gets more pronounced and important when selection per game is added as well since it will then impact the default and the icon visibility. For now (without the per-game icons), "Prefer Windows" is effectively the same as "Windows only" because there are literally close to zero **pure** linux games on GOG (if at all).

This PR also includes a few code refactorings to reduce nesting levels and complexity.

**Open bugs**:
1. State
Downloading a game and then changing the preferred platform BEFORE it has finished downloading or before it is installed, will likely utterly confuse MG and have it try to e.g. resume windows-started downloads with linux files (effectively a restart), or try to use wine for shell scripts.
I haven't added extra code to accomodate this situation, as the current state is intermediate.
It works as in the master branch starts ups and is capable of downloading and installing according to the selected preferences. But changing the pref should best be done only when MG is idle. The rest will be dealt with in the next 1-2 PRs.

2. Wine
I have temporarily removed part of the `shutil.which("wine")` check in preferences which could result in an error dialog and the reverting of `show_windows_games`. I plan to instead just make the game's main button disabled when there's no wine (plus add a suitable tooltip)

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
