### PR TITLE
Feature: Migrate preferences to `platform_mode` (reworked)

### DIFF
--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -114,19 +114,19 @@ class Api:
 
             worksOn = product.get("worksOn", {})
             platform = None
-            if worksOn["Linux"]:
+            if worksOn.get("Linux", False):
                 platform = "linux"
-            elif worksOn["Windows"]:
+            elif worksOn.get("Windows", False):
                 platform = "windows"
 
             if not platform:
                 logger.warn("%s has no platform information - skip", product["title"])
                 continue
 
-            if not product["url"]:
+            if not product.get("url", None):
                 logger.warning("%s (%s) has no store page url", product["title"], product['id'])
 
-            game = Game(name=product["title"], url=product["url"], game_id=product["id"],
+            game = Game(name=product["title"], url=product.get("url", None), game_id=product["id"],
                         image_url=product["image"], platform=platform, category=product["category"])
             game_list.append(game)
 

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -98,26 +98,37 @@ class Api:
                     return games, err_msg
                 total_pages = response["totalPages"]
 
-                for product in response["products"]:
-                    if product["id"] not in IGNORE_GAME_IDS:
-                        # Only support Linux unless the show_windows_games setting is enabled
-                        if product["worksOn"]["Linux"]:
-                            platform = "linux"
-                        elif self.config.show_windows_games:
-                            platform = "windows"
-                        else:
-                            continue
-                        if not product["url"]:
-                            logger.warning("{} ({}) has no store page url".format(product["title"], product['id']))
-                        game = Game(name=product["title"], url=product["url"], game_id=product["id"],
-                                    image_url=product["image"], platform=platform, category=product["category"])
-                        games.append(game)
+                self.__parse_productlist_json(response["products"], games)
+
                 if current_page == total_pages:
                     all_pages_processed = True
                 current_page += 1
         else:
             err_msg = "Couldn't connect to GOG servers"
         return games, err_msg
+
+    def __parse_productlist_json(self, product_list, game_list):
+        for product in product_list:
+            if product["id"] in IGNORE_GAME_IDS:
+                continue
+
+            worksOn = product.get("worksOn", {})
+            platform = None
+            if worksOn["Linux"]:
+                platform = "linux"
+            elif worksOn["Windows"]:
+                platform = "windows"
+
+            if not platform:
+                logger.warn("%s has no platform information - skip", product["title"])
+                continue
+
+            if not product["url"]:
+                logger.warning("%s (%s) has no store page url", product["title"], product['id'])
+
+            game = Game(name=product["title"], url=product["url"], game_id=product["id"],
+                        image_url=product["image"], platform=platform, category=product["category"])
+            game_list.append(game)
 
     def get_owned_products_ids(self):
         if not self.active_token:

--- a/minigalaxy/config.py
+++ b/minigalaxy/config.py
@@ -37,6 +37,14 @@ class Config:
         # reset cached transformed properties
         self.__platform_mode = None
 
+        # property migration
+        if "show_windows_games" in self.__config and "platform_mode" not in self.__config:
+            value = self.__config["show_windows_games"]
+            del self.__config["show_windows_games"]
+            new_mode = "linux,windows" if value else "linux"
+            logger.info("Migrating 'show_windows_games=%s' to 'platform_mode=%s", value, new_mode)
+            self.platform_mode = new_mode
+
     def __write(self) -> None:
         if not os.path.isfile(self.__config_file):
             config_dir = os.path.dirname(self.__config_file)
@@ -179,19 +187,11 @@ class Config:
         self.__set_and_write("show_hidden_games", new_value)
 
     @property
-    def show_windows_games(self) -> bool:
-        return self.__config.get("show_windows_games", False)
-
-    @show_windows_games.setter
-    def show_windows_games(self, new_value: bool) -> None:
-        self.__set_and_write("show_windows_games", new_value)
-
-    @property
     def platform_mode(self) -> str:
         """NOTE: This property is stored as string, but represented internally as list"""
         if not self.__platform_mode:
             # cache the splitted value for performance reasons
-            self.__platform_mode = self.__as_list(self.__config.get("platform_mode", "linux"))
+            self.__platform_mode = self.__as_list(self._raw_platform_mode())
         return self.__platform_mode
 
     @platform_mode.setter
@@ -203,6 +203,10 @@ class Config:
         new_value = self.__as_csv(new_value)
         self.__set_and_write("platform_mode", new_value)
         self.__platform_mode = None
+
+    def _raw_platform_mode(self):
+        """To be used by preferences dialog only. Returns plain config string. Used to check for changes."""
+        return self.__config.get("platform_mode", "linux")
 
     @property
     def keep_window_maximized(self) -> bool:
@@ -249,14 +253,14 @@ class Config:
         self.__set_and_write("current_downloads", new_value)
 
     def add_ongoing_download(self, download_id):
-        '''Adds the given id to the list of active downloads if not contained already. Does nothing otherwise.'''
+        """Adds the given id to the list of active downloads if not contained already. Does nothing otherwise."""
         current = self.current_downloads
         if download_id not in current:
             current.append(download_id)
             self.current_downloads = current
 
     def remove_ongoing_download(self, download_id):
-        '''Removes the given id from the list of active downloads, if contained. Does nothing otherwise.'''
+        """Removes the given id from the list of active downloads, if contained. Does nothing otherwise."""
         current = self.current_downloads
         if download_id in current:
             current.remove(download_id)

--- a/minigalaxy/constants.py
+++ b/minigalaxy/constants.py
@@ -83,9 +83,9 @@ VIEWS = [
 # the order of values defines priority: the first value is used as default for install (when not overridden per game)
 PLATFORM_MODE = [
     ["linux", _("Linux only")],
-    ["linux,windows", _("Prefer Linux")],
-    ["windows,linux", _("Prefer Windows")],
-    ["windows", _("Windows only")]
+    ["linux,windows", _("Prefer Linux")]
+    # ["windows,linux", _("Prefer Windows")],
+    # ["windows", _("Windows only")]
 ]
 
 # Game IDs to ignore when received by the API

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -201,6 +201,24 @@ class Game:
         if not self.install_dir:
             self.install_dir = os.path.join(install_dir, self.get_install_directory_name())
 
+    def update_from_other(self, other_game):
+        """
+        Take a certain set of property values from the given other Game instance.
+        Useful to refresh Games created from local data with additional data from the GOG Api.
+        """
+
+        # this update is only necessary if self and other_game are 2 different object instances
+        if self is other_game:
+            return
+
+        if self.id == 0 or self.name != other_game.name:
+            self.id = other_game.id
+            self.name = other_game.name
+
+        self.image_url = other_game.image_url
+        self.url = other_game.url
+        self.category = other_game.category
+
     def __info_key_from_arg(self, key):
         """
         For test compatibility. Regular MG production could should use InfoKey for protection against typos etc.

--- a/minigalaxy/ui/data/preferences.ui
+++ b/minigalaxy/ui/data/preferences.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface domain="minigalaxy">
   <requires lib="gtk+" version="3.20"/>
   <template class="Preferences" parent="GtkDialog">
@@ -51,27 +51,12 @@
           </packing>
         </child>
         <child>
-          <!-- n-columns=3 n-rows=9 -->
+          <!-- n-columns=2 n-rows=10 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="row-spacing">2</property>
             <property name="row-homogeneous">True</property>
-            <property name="column-homogeneous">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="language_tooltip">The preferred language on Minigalaxy start</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="language" comments="The preferred language on Minigalaxy start. Has to end with &quot;: &quot;">Language: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">0</property>
-              </packing>
-            </child>
             <child>
               <object class="GtkComboBox" id="combobox_program_language">
                 <property name="visible">True</property>
@@ -81,20 +66,6 @@
               <packing>
                 <property name="left-attach">1</property>
                 <property name="top-attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="preferred_game_language_tooltip">The preferred language for downloading games in</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="preferred_game_language" comments="Preferred language for downloading games in. Has to end with &quot;: &quot;">Preferred game language: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">1</property>
               </packing>
             </child>
             <child>
@@ -109,20 +80,6 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="view_tooltip">The preferred view of game library</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="view" comments="The preferred view of game library. Has to end with &quot;: &quot;">View: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">2</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkComboBox" id="combobox_view">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -130,20 +87,6 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="install_path_tooltip">This is where games will be installed</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="install_path" comments="The place directory in which games are installed. Has to end with &quot;: &quot;">Installation path: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
                 <property name="top-attach">3</property>
               </packing>
             </child>
@@ -158,19 +101,6 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label_keep_installers">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="keep_installer" comments="Whether installer files are kept after download. Has to end with &quot;: &quot;">Keep installers: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
                 <property name="top-attach">4</property>
               </packing>
             </child>
@@ -183,20 +113,6 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="stay_logged_in_tooltip">When disabled you'll be asked to log in each time Minigalaxy is started</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="stay_logged_in" comments="Whether the user will stay logged in after closing Minigalaxy. Has to end with &quot;: &quot;">Stay logged in:</property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
                 <property name="top-attach">5</property>
               </packing>
             </child>
@@ -210,20 +126,6 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="use_dark_theme_tooltip">Whether Minigalaxy should use dark theme or not</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="use_dark_theme" comments="Has to end with &quot;: &quot;">Use dark theme: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
                 <property name="top-attach">6</property>
               </packing>
             </child>
@@ -236,51 +138,11 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="show_hidden_games_tooltip">Whether hidden games are shown in the library or not</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="show_hidden_games" comments="Has to end with &quot;: &quot;">Show hidden games: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
                 <property name="top-attach">7</property>
               </packing>
             </child>
             <child>
               <object class="GtkSwitch" id="switch_show_hidden_games">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes" context="show_windows_games_tooltip">Whether Windows games are shown in the library or not</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes" context="show_windows_games" comments="Has to end with &quot;: &quot;">Show Windows games: </property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">8</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="switch_show_windows_games">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="halign">start</property>
@@ -304,6 +166,128 @@
               </packing>
             </child>
             <child>
+              <object class="GtkComboBox" id="combobox_platform_mode">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="valign">center</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="language_tooltip">The preferred language on Minigalaxy start</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="language" comments="The preferred language on Minigalaxy start. Has to end with &quot;: &quot;">Language: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="preferred_game_language_tooltip">The preferred language for downloading games in</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="preferred_game_language" comments="Preferred language for downloading games in. Has to end with &quot;: &quot;">Preferred game language: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="view_tooltip">The preferred view of game library</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="view" comments="The preferred view of game library. Has to end with &quot;: &quot;">View: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="install_path_tooltip">This is where games will be installed</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="install_path" comments="The place directory in which games are installed. Has to end with &quot;: &quot;">Installation path: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label_keep_installers">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="keep_installer" comments="Whether installer files are kept after download. Has to end with &quot;: &quot;">Keep installers: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="stay_logged_in_tooltip">When disabled you'll be asked to log in each time Minigalaxy is started</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="stay_logged_in" comments="Whether the user will stay logged in after closing Minigalaxy. Has to end with &quot;: &quot;">Stay logged in:</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="use_dark_theme_tooltip">Whether Minigalaxy should use dark theme or not</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="use_dark_theme" comments="Has to end with &quot;: &quot;">Use dark theme: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes" context="show_hidden_games_tooltip">Whether hidden games are shown in the library or not</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes" context="show_hidden_games" comments="Has to end with &quot;: &quot;">Show hidden games: </property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">8</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -318,28 +302,18 @@
               </packing>
             </child>
             <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Which platforms to show and favor when installing games</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Platform support:</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">2</property>
+              </packing>
             </child>
           </object>
           <packing>

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -144,8 +144,19 @@ class Library(Gtk.Viewport):
                 tile.load_thumbnail()
 
         for game in self.games:
-            if game not in games_with_tiles:
+            if game in games_with_tiles:
+                continue
+            if game.is_installed():
                 self.__add_gametile(game)
+            elif game.id in self.config.current_downloads:
+                self.__add_gametile(game)
+            elif game.platform in self.config.platform_mode:
+                self.__add_gametile(game)
+            else:
+                # housekeeping: API.get_library returns all owned games
+                # (useful when api-caching is introduced as the same request can be used independent of platform_mode)
+                # removing not shown games is only a small memory optimization
+                self.games.remove(game)
 
     def __add_gametile(self, game):
         view = self.config.view

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -250,17 +250,7 @@ def _update_gameinfo(local_game, api_game, game_category_dict={}):
     if len(api_game.category) > 0:  # exclude games without set category
         game_category_dict[api_game.name] = api_game.category
 
-    # this update is only necessary if local_game and api_game are 2 different object instances
-    if local_game is api_game:
-        return
-
-    if local_game.id == 0 or local_game.name != api_game.name:
-        local_game.id = api_game.id
-        local_game.name = api_game.name
-
-    local_game.image_url = api_game.image_url
-    local_game.url = api_game.url
-    local_game.category = api_game.category
+    local_game.update_from_other(api_game)
 
 
 def get_installed_windows_games(full_path, game_categories_dict=None):

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -224,20 +224,43 @@ class Library(Gtk.Viewport):
             GLib.idle_add(self.parent_window.show_error, _("Failed to retrieve library"), _(err_msg))
         game_category_dict = {}
         for game in retrieved_games:
+            # NOTE: the 'in' check and 'list.index' function depend on the '__eq__' method of Game.
+            # 'Game.__eq__(self, other)' is a bit lenient, it ignores the property 'id' if it is zero for 'self' or 'other'.
+            # This leniency is vital in correctly detecting installed games with missing metadata.
+
+            # add game to list which is not installed
             if game not in self.games:
                 self.games.append(game)
 
             local_game = self.games[self.games.index(game)]
-            if local_game.id == 0 or local_game.name != game.name:
-                local_game.id = game.id
-                local_game.name = game.name
+            # update the local Game instance with data retrieved from remote, but only when both are not the same instance
+            _update_gameinfo(local_game, game, game_category_dict)
 
-            local_game.image_url = game.image_url
-            local_game.url = game.url
-            local_game.category = game.category
-            if len(game.category) > 0:  # exclude games without set category
-                game_category_dict[game.name] = game.category
         update_game_categories_file(game_category_dict, CATEGORIES_FILE_PATH)
+
+
+def _update_gameinfo(local_game, api_game, game_category_dict={}):
+    """
+    Installed games are detected first, and they will be missing some information provided by GOG.
+    This function takes a local Game and a freshly obtained Game from API and updates the local instance with
+    a select list of properties from API.
+    'game_category_dict' is used for library filters and should be passed in from the caller.
+    """
+
+    if len(api_game.category) > 0:  # exclude games without set category
+        game_category_dict[api_game.name] = api_game.category
+
+    # this update is only necessary if local_game and api_game are 2 different object instances
+    if local_game is api_game:
+        return
+
+    if local_game.id == 0 or local_game.name != api_game.name:
+        local_game.id = api_game.id
+        local_game.name = api_game.name
+
+    local_game.image_url = api_game.image_url
+    local_game.url = api_game.url
+    local_game.category = api_game.category
 
 
 def get_installed_windows_games(full_path, game_categories_dict=None):

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -218,7 +218,7 @@ class LibraryEntry:
 
     def __download_game(self) -> None:
         finish_func = self.__install_game
-        result, download_info = self.get_download_info()
+        result, download_info = self.get_download_info(self.game.platform)
         if result:
             self._download(InstallableItem(self.game.id, self.game.name), download_info, DownloadType.GAME, finish_func)
 

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -3,12 +3,12 @@ import locale
 import shutil
 
 from minigalaxy.config import Config
-from minigalaxy.constants import SUPPORTED_DOWNLOAD_LANGUAGES, SUPPORTED_LOCALES, VIEWS
+from minigalaxy.constants import PLATFORM_MODE, SUPPORTED_DOWNLOAD_LANGUAGES, SUPPORTED_LOCALES, VIEWS
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.logger import logger
 from minigalaxy.translation import _
 from minigalaxy.ui.gtk import Gtk, load_ui
-from minigalaxy.ui.widget_utils import populate_combobox
+from minigalaxy.ui.widget_utils import get_combo_value, populate_combobox
 
 
 @Gtk.Template(string=load_ui("preferences.ui"))
@@ -18,12 +18,12 @@ class Preferences(Gtk.Dialog):
     combobox_program_language = Gtk.Template.Child()
     combobox_language = Gtk.Template.Child()
     combobox_view = Gtk.Template.Child()
+    combobox_platform_mode = Gtk.Template.Child()
     button_file_chooser = Gtk.Template.Child()
     label_keep_installers = Gtk.Template.Child()
     switch_keep_installers = Gtk.Template.Child()
     switch_stay_logged_in = Gtk.Template.Child()
     switch_show_hidden_games = Gtk.Template.Child()
-    switch_show_windows_games = Gtk.Template.Child()
     switch_create_applications_file = Gtk.Template.Child()
     switch_use_dark_theme = Gtk.Template.Child()
     button_cancel = Gtk.Template.Child()
@@ -38,12 +38,12 @@ class Preferences(Gtk.Dialog):
         self.__set_locale_list()
         self.__set_language_list()
         self.__set_view_list()
+        populate_combobox(self.combobox_platform_mode, PLATFORM_MODE, self.config._raw_platform_mode())
         self.button_file_chooser.set_filename(self.config.install_dir)
         self.switch_keep_installers.set_active(self.config.keep_installers)
         self.switch_stay_logged_in.set_active(self.config.stay_logged_in)
         self.switch_use_dark_theme.set_active(self.config.use_dark_theme)
         self.switch_show_hidden_games.set_active(self.config.show_hidden_games)
-        self.switch_show_windows_games.set_active(self.config.show_windows_games)
         self.switch_create_applications_file.set_active(self.config.create_applications_file)
 
         # Set tooltip for keep installers label
@@ -108,6 +108,15 @@ class Preferences(Gtk.Dialog):
         else:
             settings.set_property("gtk-application-prefer-dark-theme", False)
 
+    def __apply_platform_mode(self):
+        new_mode = get_combo_value(self.combobox_platform_mode)
+        if new_mode == self.config._raw_platform_mode():
+            return
+        self.config.platform_mode = new_mode
+        self.parent.reset_library()
+        if "windows" in new_mode and not shutil.which("wine"):
+            self.parent.show_error(_("Wine wasn't found. Windows games will be shown but not be installable."))
+
     def __save_install_dir_choice(self) -> bool:
         choice = self.button_file_chooser.get_filename()
         old_dir = self.config.install_dir
@@ -153,13 +162,7 @@ class Preferences(Gtk.Dialog):
             self.config.create_applications_file = self.switch_create_applications_file.get_active()
             self.parent.library.filter_library()
 
-            if self.switch_show_windows_games.get_active() != self.config.show_windows_games:
-                if self.switch_show_windows_games.get_active() and not shutil.which("wine"):
-                    self.parent.show_error(_("Wine wasn't found. Showing Windows games cannot be enabled."))
-                    self.config.show_windows_games = False
-                else:
-                    self.config.show_windows_games = self.switch_show_windows_games.get_active()
-                    self.parent.reset_library()
+            self.__apply_platform_mode()
 
             # Only change the install_dir is it was actually changed
             if self.button_file_chooser.get_filename() != self.config.install_dir:

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -68,45 +68,27 @@ class Preferences(Gtk.Dialog):
         populate_combobox(self.combobox_view, VIEWS, self.config.view)
 
     def __apply_locale_choice(self) -> None:
-        new_locale = self.combobox_program_language.get_active_iter()
-        if new_locale is not None:
-            model = self.combobox_program_language.get_model()
-            locale_choice = model[new_locale][-2]
-            if locale_choice == '':
-                default_locale = locale.getdefaultlocale()[0]
-                locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
-                self.config.locale = locale_choice
-            else:
-                try:
-                    locale.setlocale(locale.LC_ALL, (locale_choice, 'UTF-8'))
-                    self.config.locale = locale_choice
-                except locale.Error:
-                    self.parent.show_error(_("Failed to change program language. Make sure locale is generated on "
-                                             "your system."))
+        locale_choice = get_combo_value(self.combobox_program_language)
+        if locale_choice == '' or not locale_choice:
+            locale_choice = locale.getdefaultlocale()[0]
 
-    def __apply_language_choice(self) -> None:
-        lang_choice = self.combobox_language.get_active_iter()
-        if lang_choice is not None:
-            model = self.combobox_language.get_model()
-            lang, _ = model[lang_choice][:2]
-            self.config.lang = lang
+        try:
+            locale.setlocale(locale.LC_ALL, (locale_choice, 'UTF-8'))
+            self.config.locale = locale_choice
+        except locale.Error:
+            self.parent.show_error(_("Failed to change program language. Make sure locale is generated on your system."))
 
     def __apply_view_choice(self) -> None:
-        view_choice = self.combobox_view.get_active_iter()
-        if view_choice is not None:
-            model = self.combobox_view.get_model()
-            view, _ = model[view_choice][:2]
-            if view != self.config.view:
-                self.parent.reset_library()
-            self.config.view = view
+        view = get_combo_value(self.combobox_view)
+        if view != self.config.view:
+            self.parent.reset_library()
+        self.config.view = view
 
     def __apply_theme_choice(self) -> None:
         settings = Gtk.Settings.get_default()
         self.config.use_dark_theme = self.switch_use_dark_theme.get_active()
-        if self.config.use_dark_theme is True:
-            settings.set_property("gtk-application-prefer-dark-theme", True)
-        else:
-            settings.set_property("gtk-application-prefer-dark-theme", False)
+        if self.config.use_dark_theme != settings.get_property("gtk-application-prefer-dark-theme"):
+            settings.set_property("gtk-application-prefer-dark-theme", self.config.use_dark_theme)
 
     def __apply_platform_mode(self):
         new_mode = get_combo_value(self.combobox_platform_mode)
@@ -153,7 +135,7 @@ class Preferences(Gtk.Dialog):
             self.config.start_batch_edit()
 
             self.__apply_locale_choice()
-            self.__apply_language_choice()
+            self.config.lang = get_combo_value(self.combobox_language)
             self.__apply_view_choice()
             self.__apply_theme_choice()
             self.config.keep_installers = self.switch_keep_installers.get_active()

--- a/minigalaxy/ui/widget_utils.py
+++ b/minigalaxy/ui/widget_utils.py
@@ -27,3 +27,14 @@ def populate_combobox(combo: Gtk.ComboBox, str_tuple_list, active_value: str):
         if data_list[key][:1][0] == active_value:
             combo.set_active(key)
             break
+
+
+def get_combo_value(combo):
+    """Return key string of the currently selected entry in ComboBox. Expects same structure as 'populate_combobox'"""
+    selected_index = combo.get_active_iter()
+    if selected_index is None:
+        return None
+
+    model = combo.get_model()
+    result, _ = model[selected_index][:2]
+    return result

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -111,6 +111,23 @@ class TestApiGog(TestCase):
         _, obs = self.api.get_library()
         self.assertEqual(exp, obs)
 
+    def test_parse_productlist_json(self):
+        products = [
+            {"id": 2, "title": "Should not be included", "image": ""},
+            {"id": 12, "worksOn": {}, "title": "Should not be included", "image": "", "category": ""},
+            {"id": 22, "worksOn": {"Linux": True, "Windows": False}, "title": "Pure Linux Game", "image": "", "category": ""},
+            {"id": 32, "worksOn": {"Linux": False, "Windows": True}, "title": "Pure Windows Game", "image": "", "category": ""},
+            {"id": 42, "worksOn": {"Linux": True, "Windows": True}, "title": "Mixed Game", "image": "", "category": ""}
+        ]
+        expected = [
+            Game(name="Pure Linux Game", game_id=22, platform="linux"),
+            Game(name="Pure Windows Game", game_id=32, platform="window"),
+            Game(name="Mixed Game", game_id=42, platform="linux")
+        ]
+        game_list = []
+        self.api._Api__parse_productlist_json(products, game_list)
+        self.assertEqual(expected, game_list)
+
     def test_get_version(self):
         test_game = Game("Test Game", platform="linux")
         exp = "gog-2"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,148 +22,114 @@ API_GET_INFO_BLACKWELL = [{'id': '51437500425760439', 'game_id': '51295394952128
 GAMESDB_INFO_BLACKWELL = {'background': 'https://images.gog.com/e6e6d9001ec0c990327bd8f20630b5e39d0b5d33f69778163025d9d7b04f3c44.png?namespace=gamesdb', 'cover': 'https://images.gog.com/87f87afa3a55ca5eb59df9a66c5063c202281432262b3f0fe8ef8e324270df61.png?namespace=gamesdb', 'genre': {'*': 'Adventure, Indie, Puzzle, Point-and-click', 'en-US': 'Adventure, Indie, Puzzle, Point-and-click'}, 'summary': {'*': 'omitted for test', 'en-US': 'omitted for test'}, 'vertical_cover': 'https://images.gog.com/87f87afa3a55ca5eb59df9a66c5063c202281432262b3f0fe8ef8e324270df61.png?namespace=gamesdb'}
 
 
-class TestApi(TestCase):
+class TestApiGog(TestCase):
+
+    def setUp(self):
+        self.session = MagicMock()
+        self.config = MagicMock()
+        self.api = Api(self.config, self.session)
+
     def test_get_login_url(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
         exp = "https://auth.gog.com/auth?client_id=46899977096215655&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient&response_type=code&layout=client2"
-        obs = api.get_login_url()
+        obs = self.api.get_login_url()
         self.assertEqual(exp, obs)
 
     def test_get_redirect_url(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
         exp = "https://embed.gog.com/on_login_success?origin=client"
-        obs = api.get_redirect_url()
+        obs = self.api.get_redirect_url()
         self.assertEqual(exp, obs)
 
-    def test1_can_connect(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
+    def test_can_connect_success(self):
         exp = True
-        obs = api.can_connect()
+        obs = self.api.can_connect()
         self.assertEqual(exp, obs)
 
-    def test2_can_connect(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        session.get.side_effect = requests.exceptions.ConnectionError(Mock(status="Connection Error"))
+    def test_can_connect_exception(self):
+        self.session.get.side_effect = requests.exceptions.ConnectionError(Mock(status="Connection Error"))
         exp = False
-        obs = api.can_connect()
+        obs = self.api.can_connect()
         self.assertEqual(exp, obs)
 
-    def test1_get_download_info(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api.get_info = MagicMock()
-        api.get_info.return_value = API_GET_INFO_TOONSTRUCK
-        config.lang = "pl"
+    def test_get_download_info(self):
+        self.api.get_info = MagicMock()
+        self.api.get_info.return_value = API_GET_INFO_TOONSTRUCK
+        lang_variants = {
+            "pl": {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]},
+            "fr": {'id': 'installer_linux_fr', 'name': 'Toonstruck', 'os': 'linux', 'language': 'fr', 'language_full': 'français', 'version': 'gog-2', 'total_size': 1011875840, 'files': [{'id': 'fr3installer0', 'size': 1011875840, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr3installer0'}]},
+            "en": {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]}
+        }
         test_game = Game("Test Game")
-        exp = {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]}
-        obs = api.get_download_info(test_game)
-        self.assertEqual(exp, obs)
+        for lang in lang_variants:
+            with self.subTest(msg=lang):
+                self.config.lang = lang
+                exp = lang_variants[lang]
+                actual = self.api.get_download_info(test_game)
+                self.assertEqual(exp, actual)
 
-    def test2_get_download_info(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api.get_info = MagicMock()
-        api.get_info.return_value = API_GET_INFO_TOONSTRUCK
-        config.lang = "fr"
-        test_game = Game("Test Game")
-        exp = {'id': 'installer_linux_fr', 'name': 'Toonstruck', 'os': 'linux', 'language': 'fr', 'language_full': 'français', 'version': 'gog-2', 'total_size': 1011875840, 'files': [{'id': 'fr3installer0', 'size': 1011875840, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr3installer0'}]}
-        obs = api.get_download_info(test_game)
-        self.assertEqual(exp, obs)
-
-    def test3_get_download_info(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api.get_info = MagicMock()
-        api.get_info.return_value = {'downloads': {'installers': [
+    def test_get_download_info_no_linux(self):
+        self.api.get_info = MagicMock()
+        self.api.get_info.return_value = {'downloads': {'installers': [
             {'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]},
             {'id': 'installer_mac_en', 'name': 'Toonstruck', 'os': 'mac', 'language': 'en', 'language_full': 'English', 'version': 'gog-3', 'total_size': 975175680, 'files': [{'id': 'en2installer0', 'size': 975175680, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en2installer0'}]},
             {'id': 'installer_windows_fr', 'name': 'Toonstruck', 'os': 'windows', 'language': 'fr', 'language_full': 'français', 'version': '1.0', 'total_size': 985661440, 'files': [{'id': 'fr1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer0'}, {'id': 'fr1installer1', 'size': 984612864, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr1installer1'}]},
             {'id': 'installer_mac_fr', 'name': 'Toonstruck', 'os': 'mac', 'language': 'fr', 'language_full': 'français', 'version': 'gog-3', 'total_size': 1023410176, 'files': [{'id': 'fr2installer0', 'size': 1023410176, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/fr2installer0'}]}
         ]}}
-        config.lang = "en"
+        self.config.lang = "en"
         test_game = Game("Test Game")
         exp = {'id': 'installer_windows_en', 'name': 'Toonstruck', 'os': 'windows', 'language': 'en', 'language_full': 'English', 'version': '1.0', 'total_size': 939524096, 'files': [{'id': 'en1installer0', 'size': 1048576, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer0'}, {'id': 'en1installer1', 'size': 938475520, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en1installer1'}]}
-        obs = api.get_download_info(test_game)
+        obs = self.api.get_download_info(test_game)
         self.assertEqual(exp, obs)
 
-    def test4_get_download_info(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
+    def test_get_download_info_dlc(self):
         dlc_test_installer = API_GET_INFO_TOONSTRUCK["downloads"]["installers"]
-        config.lang = "en"
+        self.config.lang = "en"
         test_game = Game("Test Game")
         exp = {'id': 'installer_linux_en', 'name': 'Toonstruck', 'os': 'linux', 'language': 'en', 'language_full': 'English', 'version': 'gog-2', 'total_size': 963641344, 'files': [{'id': 'en3installer0', 'size': 963641344, 'downlink': 'https://api.gog.com/products/1207666633/downlink/installer/en3installer0'}]}
-        obs = api.get_download_info(test_game, dlc_installers=dlc_test_installer)
+        obs = self.api.get_download_info(test_game, dlc_installers=dlc_test_installer)
         self.assertEqual(exp, obs)
 
-    def test1_get_library(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api.active_token = True
+    def test_get_library_ok(self):
+        self.api.active_token = True
         response_dict = {'totalPages': 1, 'products': [{'id': 1097893768, 'title': 'Neverwinter Nights: Enhanced Edition', 'image': '//images-2.gog-statics.com/8706f7fb87a4a41bc34254f3b49f59f96cf13d067b2c8bbfd8d41c327392052a', 'url': '/game/neverwinter_nights_enhanced_edition_pack', 'worksOn': {'Windows': True, 'Mac': True, 'Linux': True}, "category": "Role-playing"}]}
-        api.active_token_expiration_time = time.time() + 10.0
+        self.api.active_token_expiration_time = time.time() + 10.0
         response_mock = MagicMock()
         response_mock.json.return_value = response_dict
-        session.get.return_value = response_mock
-        session.get().status_code = http.HTTPStatus.OK
+        self.session.get.return_value = response_mock
+        self.session.get().status_code = http.HTTPStatus.OK
         exp = "Neverwinter Nights: Enhanced Edition"
-        retrieved_games, err_msg = api.get_library()
+        retrieved_games, _ = self.api.get_library()
         obs = retrieved_games[0].name
         self.assertEqual(exp, obs)
 
-    def test2_get_library(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api.active_token = False
-        api.active_token_expiration_time = time.time() + 10.0
+    def test_get_library_invalid_httpstatus(self):
+        self.api.active_token = False
+        self.api.active_token_expiration_time = time.time() + 10.0
         response_mock = MagicMock()
         response_mock.json.return_value = {}
-        session.get.return_value = response_mock
+        self.session.get.return_value = response_mock
         exp = "Couldn't connect to GOG servers"
-        retrieved_games, obs = api.get_library()
+        _, obs = self.api.get_library()
         self.assertEqual(exp, obs)
 
-    def test1_get_version(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
+    def test_get_version(self):
         test_game = Game("Test Game", platform="linux")
         exp = "gog-2"
-        obs = api.get_version(test_game, gameinfo=API_GET_INFO_TOONSTRUCK)
+        obs = self.api.get_version(test_game, gameinfo=API_GET_INFO_TOONSTRUCK)
         self.assertEqual(exp, obs)
 
-    def test2_get_version(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
+    def test_get_version_dlc(self):
         test_game = Game("Test Game", platform="linux")
         dlc_name = "Test DLC"
         game_info = API_GET_INFO_TOONSTRUCK
         game_info["expanded_dlcs"] = [{"title": dlc_name, "downloads": {"installers": [{"os": "linux", "version": "1.2.3.4"}]}}]
         exp = "1.2.3.4"
-        obs = api.get_version(test_game, gameinfo=API_GET_INFO_TOONSTRUCK, dlc_name=dlc_name)
+        obs = self.api.get_version(test_game, gameinfo=API_GET_INFO_TOONSTRUCK, dlc_name=dlc_name)
         self.assertEqual(exp, obs)
 
     def test_get_download_file__info_md5(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
+        session = self.session
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"checksum": "url"}
         session.get.side_effect = MagicMock()
         session.get().status_code = http.HTTPStatus.OK
         session.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="8acedf66c0d2986e7dee9af912b7df4f" chunks="4" timestamp="2015-07-30 17:11:12" total_size="36717998">
@@ -173,42 +139,35 @@ class TestApi(TestCase):
     <chunk id="3" from="31457280" to="36717997" method="md5">0261b9225fc10c407df083f6d254c47b</chunk>
 </file>'''
         exp = "8acedf66c0d2986e7dee9af912b7df4f"
-        obs = api.get_download_file_info("url").md5
+        obs = self.api.get_download_file_info("url").md5
         self.assertEqual(exp, obs)
 
     def test_get_download_file_info_md5_returns_empty_string_on_empty_response(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
+        session = self.session
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"checksum": "url"}
         session.get.side_effect = MagicMock()
         session.get().status_code = http.HTTPStatus.OK
         session.get().text = ""
 
         exp = ""
-        obs = api.get_download_file_info("url").md5
+        obs = self.api.get_download_file_info("url").md5
         self.assertEqual(exp, obs)
 
     def test_get_download_file_info_md5_returns_empty_string_on_response_error(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
-        session.get.side_effect = MagicMock()
-        session.get().status_code = http.HTTPStatus.NOT_FOUND
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"checksum": "url"}
+        self.session.get.side_effect = MagicMock()
+        self.session.get().status_code = http.HTTPStatus.NOT_FOUND
 
         exp = ""
-        obs = api.get_download_file_info("url").md5
+        obs = self.api.get_download_file_info("url").md5
         self.assertEqual(exp, obs)
 
     def test_get_download_file_info_md5_returns_empty_string_on_missing_md5(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
+        session = self.session
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"checksum": "url"}
         session.get.side_effect = MagicMock()
         session.get().status_code = http.HTTPStatus.OK
         session.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="" chunks="4" timestamp="2015-07-30 17:11:12" total_size="36717998">
@@ -219,15 +178,13 @@ class TestApi(TestCase):
 </file>'''
 
         exp = ""
-        obs = api.get_download_file_info("url").md5
+        obs = self.api.get_download_file_info("url").md5
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
+        session = self.session
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"checksum": "url"}
         session.get.side_effect = MagicMock()
         session.get().status_code = http.HTTPStatus.OK
         session.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="8acedf66c0d2986e7dee9af912b7df4f" chunks="4" timestamp="2015-07-30 17:11:12" total_size="36717998">
@@ -237,66 +194,54 @@ class TestApi(TestCase):
     <chunk id="3" from="31457280" to="36717997" method="md5">0261b9225fc10c407df083f6d254c47b</chunk>
 </file>'''
         exp = 36717998
-        obs = api.get_download_file_info("url").size
+        obs = self.api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size_returns_zero_on_empty_response(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
+        session = self.session
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"checksum": "url"}
         session.get.side_effect = MagicMock()
         session.get().status_code = http.HTTPStatus.OK
         session.get().text = ""
 
         exp = 0
-        obs = api.get_download_file_info("url").size
+        obs = self.api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size_returns_zero_on_response_error(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
+        session = self.session
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"checksum": "url"}
         session.get.side_effect = MagicMock()
         session.get().status_code = http.HTTPStatus.NOT_FOUND
 
         exp = 0
-        obs = api.get_download_file_info("url").size
+        obs = self.api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size_returns_zero_on_request_exception(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
-        session.get.side_effect = requests.exceptions.RequestException("test")
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"checksum": "url"}
+        self.session.get.side_effect = requests.exceptions.RequestException("test")
 
         exp = 0
-        obs = api.get_download_file_info("url").size
+        obs = self.api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size_returns_zero_on_request_timeout_exception(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
-        session.get.side_effect = requests.exceptions.ReadTimeout("test")
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"checksum": "url"}
+        self.session.get.side_effect = requests.exceptions.ReadTimeout("test")
 
         exp = 0
-        obs = api.get_download_file_info("url").size
+        obs = self.api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
     def test_get_file_info_size_returns_zero_on_missing_total_size(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"checksum": "url"}
+        session = self.session
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"checksum": "url"}
         session.get.side_effect = MagicMock()
         session.get().status_code = http.HTTPStatus.OK
         session.get().text = '''<file name="gog_tis_100_2.0.0.3.sh" available="1" notavailablemsg="" md5="8acedf66c0d2986e7dee9af912b7df4f" chunks="4" timestamp="2015-07-30 17:11:12">
@@ -307,92 +252,79 @@ class TestApi(TestCase):
 </file>'''
 
         exp = 0
-        obs = api.get_download_file_info("url").size
+        obs = self.api.get_download_file_info("url").size
         self.assertEqual(exp, obs)
 
+    def test_get_user_info_from_api(self):
+        username = "test"
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"username": username}
+        self.config.username = ""
+        self.session.get.side_effect = MagicMock()
+        self.session.get().status_code = http.HTTPStatus.OK
+
+        obs = self.api.get_user_info()
+        self.assertEqual(username, obs)
+
+    def test_get_user_info_from_config(self):
+        username = "test"
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {"username": "wrong"}
+        self.config.username = username
+
+        obs = self.api.get_user_info()
+        self.assertEqual(username, obs)
+
+    def test_get_user_info_return_empty_string_when_nothing_is_returned(self):
+        self.api._Api__request = MagicMock()
+        self.api._Api__request.return_value = {}
+        self.config.username = ""
+
+        exp = ""
+        obs = self.api.get_user_info()
+        self.assertEqual(exp, obs)
+
+
+class TestApiGamesDb(TestCase):
+
+    def setUp(self):
+        self.session = MagicMock()
+        self.config = MagicMock()
+        self.api = Api(self.config, self.session)
+
     def test1_get_gamesdb_info(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request_gamesdb = MagicMock()
-        api._Api__request_gamesdb.side_effect = [{}]
+        self.api._Api__request_gamesdb = MagicMock()
+        self.api._Api__request_gamesdb.side_effect = [{}]
         test_game = Game("Test Game")
         exp = {"cover": "", "vertical_cover": "", "background": "", "genre": {}, "summary": {}}
-        obs = api.get_gamesdb_info(test_game)
+        obs = self.api.get_gamesdb_info(test_game)
         self.assertEqual(exp, obs)
 
     def test2_get_gamesdb_info(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request_gamesdb = MagicMock()
-        api._Api__request_gamesdb.side_effect = API_GET_INFO_STELLARIS
+        self.api._Api__request_gamesdb = MagicMock()
+        self.api._Api__request_gamesdb.side_effect = API_GET_INFO_STELLARIS
         test_game = Game("Stellaris")
         exp = GAMESDB_INFO_STELLARIS
-        obs = api.get_gamesdb_info(test_game)
+        obs = self.api.get_gamesdb_info(test_game)
         self.assertEqual(exp, obs)
 
     def test3_get_gamesdb_info_no_genre(self):
         api_info = copy.deepcopy(API_GET_INFO_STELLARIS)
         api_info[0]["game"]["genres"] = []
         api_info[0]["game"]["genres_ids"] = []
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request_gamesdb = MagicMock()
-        api._Api__request_gamesdb.side_effect = api_info
+        self.api._Api__request_gamesdb = MagicMock()
+        self.api._Api__request_gamesdb.side_effect = api_info
 
         test_game = Game("Stellaris")
         exp = copy.deepcopy(GAMESDB_INFO_STELLARIS)
         exp['genre'] = {}
-        obs = api.get_gamesdb_info(test_game)
+        obs = self.api.get_gamesdb_info(test_game)
         self.assertEqual(exp, obs)
 
     def test_get_gamesdb_info_with_multiple_genres(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request_gamesdb = MagicMock()
-        api._Api__request_gamesdb.side_effect = API_GET_INFO_BLACKWELL
+        self.api._Api__request_gamesdb = MagicMock()
+        self.api._Api__request_gamesdb.side_effect = API_GET_INFO_BLACKWELL
         test_game = Game("Blackwell Legacy")
         exp = GAMESDB_INFO_BLACKWELL
-        obs = api.get_gamesdb_info(test_game)
-        self.assertEqual(exp, obs)
-
-    def test_get_user_info_from_api(self):
-        username = "test"
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"username": username}
-        config.username = ""
-        session.get.side_effect = MagicMock()
-        session.get().status_code = http.HTTPStatus.OK
-
-        obs = api.get_user_info()
-        self.assertEqual(username, obs)
-
-    def test_get_user_info_from_config(self):
-        username = "test"
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {"username": "wrong"}
-        config.username = username
-
-        obs = api.get_user_info()
-        self.assertEqual(username, obs)
-
-    def test_get_user_info_return_empty_string_when_nothing_is_returned(self):
-        session = MagicMock()
-        config = MagicMock()
-        api = Api(config, session)
-        api._Api__request = MagicMock()
-        api._Api__request.return_value = {}
-        config.username = ""
-
-        exp = ""
-        obs = api.get_user_info()
+        obs = self.api.get_gamesdb_info(test_game)
         self.assertEqual(exp, obs)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,6 @@ class TestConfig(TestCase):
                 "stay_logged_in": false,
                 "use_dark_theme": true,
                 "show_hidden_games": true,
-                "show_windows_games": true,
                 "keep_window_maximized": true,
                 "installed_filter": true,
                 "create_applications_file": true,
@@ -52,7 +51,6 @@ class TestConfig(TestCase):
         self.assertEqual(False, config.stay_logged_in)
         self.assertEqual(True, config.use_dark_theme)
         self.assertEqual(True, config.show_hidden_games)
-        self.assertEqual(True, config.show_windows_games)
         self.assertEqual(True, config.keep_window_maximized)
         self.assertEqual(True, config.installed_filter)
         self.assertEqual(True, config.create_applications_file)
@@ -74,7 +72,6 @@ class TestConfig(TestCase):
         self.assertEqual(True, config.stay_logged_in)
         self.assertEqual(False, config.use_dark_theme)
         self.assertEqual(False, config.show_hidden_games)
-        self.assertEqual(False, config.show_windows_games)
         self.assertEqual(False, config.keep_window_maximized)
         self.assertEqual(False, config.installed_filter)
         self.assertEqual(False, config.create_applications_file)
@@ -105,7 +102,6 @@ class TestConfig(TestCase):
         self.assertEqual(True, config.stay_logged_in)
         self.assertEqual(False, config.use_dark_theme)
         self.assertEqual(False, config.show_hidden_games)
-        self.assertEqual(False, config.show_windows_games)
         self.assertEqual(False, config.keep_window_maximized)
         self.assertEqual(False, config.installed_filter)
         self.assertEqual(False, config.create_applications_file)
@@ -126,7 +122,6 @@ class TestConfig(TestCase):
             ["stay_logged_in", True, False],
             ["use_dark_theme", False, True],
             ["show_hidden_games", False, True],
-            ["show_windows_games", False, True],
             # NOTE: platform_mode getter/setter work on incompatible types
             # can not be tested here with the regular simple test loop
             # ["platform_mode", ["linux"], "windows,linux"]

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -347,14 +347,38 @@ en-US
         observed = game_get_status
         self.assertEqual(expected, observed)
 
-    def test1_get_status_file_path(self):
+    def test_get_status_file_path_default(self):
         game = Game(name="Europa Universalis 2")
         expected = os.path.expanduser("~/.config/minigalaxy/games/Europa Universalis 2.json")
         observed = game.get_status_file_path()
         self.assertEqual(expected, observed)
 
-    def test2_get_status_file_path(self):
+    def test_get_status_file_path_override_install_dir(self):
         game = Game(name="Europa Universalis 2", install_dir="/home/user/GoG Games//Europa Universalis II")
         expected = os.path.expanduser("~/.config/minigalaxy/games/Europa Universalis II.json")
         observed = game.get_status_file_path()
         self.assertEqual(expected, observed)
+
+    def test_update_from_other_different_id(self):
+        game = Game("Empty")
+        update = Game("Empty", game_id=42, image_url="file:/dev/null", url="https://www.google.com")
+
+        game.update_from_other(update)
+        # make sure 'game' has taken the values from 'update'
+        # assert doesn't use properties from update directly because these would also be
+        # fulfilled if update took the values from game instead (coding error)
+        self.assertEqual(42, game.id)
+        self.assertEqual("file:/dev/null", game.image_url)
+        self.assertEqual("https://www.google.com", game.url)
+
+    def test_update_from_other_different_name(self):
+        game = Game("Empty", game_id=42)
+        update = Game("Other Name", game_id=42, image_url="file:/dev/null", url="https://www.google.com")
+
+        game.update_from_other(update)
+        # make sure 'game' has taken the values from 'update'
+        # assert doesn't use properties from update directly because these would also be
+        # fulfilled if update took the values from game instead (coding error)
+        self.assertEqual("Other Name", game.name)
+        self.assertEqual("file:/dev/null", game.image_url)
+        self.assertEqual("https://www.google.com", game.url)


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

After the issues we found yesterday with the other PR (#739), i decided to take a little step back and don't immediately implement a 'global' way to change the default platform.

Functionally, this PR now ONLY contains the move from `show_windows_games` to using `platform_mode` for game visibility instead. NO other selection capabilities _yet_. And a game's platform is set up as it has been before - if linux is supported, use linux. Try windows otherwise. Resuming downloads and installing is no problem, because any game can only either be linux or windows, no selection. If a Game has platform "windows" it will also be resumed as such, regardless of whether "Linux only" or "Prefer Linux" is picked.
So it's not **more** to fix the selection, it's **less** first. Just enough to make the new combo work instead of the `show_windows_games` switch. The rest WILL still come. Just takes a bit more time.

I added 2 other refactorings in `api.py` and `library.py` where i split up complicated methods into smaller ones for which i also added tests.

Before any more work on platform selection can be done, i might need to take another little detour and work on how downloads are resumed, or at least think some more about how to best integrate platform selection into that.
The way it is done now makes switching (default) platforms very hard because the entire download list for a game is refetched and rebuild from API after every restart (this might also cause download failures when GOG has published a new version before a download is resumed at a later date).

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
