### PR TITLE
Fix unsetting missing value in game config

### DIFF
--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -142,7 +142,8 @@ class Game:
         key = self.__info_key_from_arg(key)
         json_dict = self.load_minigalaxy_info_json()
         if value is None:
-            del json_dict[key]
+            if key in json_dict:
+                del json_dict[key]
         else:
             json_dict[key] = value
         self.save_minigalaxy_info_json(json_dict)

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -126,9 +126,11 @@ en-US
             observed = game.fallback_read_installed_version()
         self.assertEqual(expected, observed)
 
+    @unittest.mock.patch('os.path.isfile')
     @unittest.mock.patch('os.path.exists')
-    def test1_set_info(self, mock_exists):
+    def test1_set_info(self, mock_exists, mock_isfile):
         mock_exists.return_value = True
+        mock_isfile.return_value = True
         json_content = '{"version": "gog-2"}'
         with patch("builtins.open", mock_open(read_data=json_content)) as m:
             game = Game("Game Name test2")
@@ -142,6 +144,57 @@ en-US
         expected = '{"version": "gog-3"}'
         observed = write_string
         self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.path.isfile')
+    @unittest.mock.patch('os.path.exists')
+    def test2_set_info(self, mock_exists, mock_isfile):
+        mock_exists.return_value = True
+        mock_isfile.return_value = True
+        json_content = '{"version": "gog-2", "show_fps": true}'
+        with patch("builtins.open", mock_open(read_data=json_content)) as m:
+            game = Game("Game Name test2")
+            game.set_info(InfoKey.VERSION, None)
+        mock_c = m.mock_calls
+        write_string = ""
+        for kall in mock_c:
+            name, args, kwargs = kall
+            if name == "().write":
+                write_string = "{}{}".format(write_string, args[0])
+        expected = '{"show_fps": true}'
+        observed = write_string
+        self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.path.isfile')
+    @unittest.mock.patch('os.path.exists')
+    def test3_set_info(self, mock_exists, mock_isfile):
+        mock_exists.return_value = True
+        mock_isfile.return_value = True
+        json_content = '{"show_fps": true}'
+        with patch("builtins.open", mock_open(read_data=json_content)) as m:
+            game = Game("Game Name test2")
+            game.set_info(InfoKey.VERSION, None)
+        mock_c = m.mock_calls
+        write_string = ""
+        for kall in mock_c:
+            name, args, kwargs = kall
+            if name == "().write":
+                write_string = "{}{}".format(write_string, args[0])
+        expected = '{"show_fps": true}'
+        observed = write_string
+        self.assertEqual(expected, observed)
+
+    @unittest.mock.patch('os.remove')
+    @unittest.mock.patch('os.path.isfile')
+    @unittest.mock.patch('os.path.exists')
+    def test4_set_info(self, mock_exists, mock_isfile, mock_remove: MagicMock):
+        mock_exists.return_value = True
+        mock_isfile.return_value = True
+        json_content = '{"version": "gog-2"}'
+        with patch("builtins.open", mock_open(read_data=json_content)) as m:
+            game = Game("Game Name test2")
+            game.set_info(InfoKey.VERSION, None)
+        self.assertEqual(1, m.call_count)
+        self.assertEqual(1, mock_remove.call_count)
 
     @unittest.mock.patch('os.path.exists')
     @unittest.mock.patch('os.makedirs')


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

<!-- Describe what was changed -->
I was seeing this error somewhat regularly during installs:
```
2026-05-25 13:29:48,610 - root - ERROR - Installation callback handler threw an error:
Traceback (most recent call last):
  File "/home/wouter/Sources/minigalaxy/minigalaxy/installer.py", line 816, in notifyStep
    self.callback(InstallResult(self.installer_id, result_type, reason, details))
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wouter/Sources/minigalaxy/minigalaxy/ui/library_entry.py", line 447, in install_finished
    self.__install_step_callback(result, on_success, on_failure, dlc_title)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wouter/Sources/minigalaxy/minigalaxy/ui/library_entry.py", line 398, in __install_step_callback
    self.game.set_info(InfoKey.VERSION, self.api.get_version(self.game))
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wouter/Sources/minigalaxy/minigalaxy/game.py", line 145, in set_info
    del json_dict[key]
        ~~~~~~~~~^^^^^
KeyError: 'version'
```

This fixes that and adds unit tests for it.

## Checklist
 
 - [x _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))

No changelog change is needed, since it is a fix for code that is not in any releases yet.