### PR TITLE
Windows games: Allow to change the wine executable **before** installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Reduce unnecessary writes to the config file. (thanks to GB609)
 - Fix a possible exception during game installation not being handled correctly.
 - Logs are now also written to `~/.cache/minigalaxy/minigalaxy.log`.
+- The `wine` executable can now also be changed before a game is installed (thanks to GB609).
 
 **1.4.2**
 - Switch to using PEP 302 compliant resources, excluding translations. (thanks to EmperorArthur)

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -94,6 +94,7 @@ class Properties(Gtk.Dialog):
                 self.game.set_info(InfoKey.MANGOHUD, self.switch_properties_use_mangohud.get_active())
             self.game.set_info(InfoKey.VARIABLES, str(self.entry_properties_variable.get_text()))
             self.game.set_info(InfoKey.COMMAND, str(self.entry_properties_command.get_text()))
+
         self.game.set_info(InfoKey.HIDE_GAME, self.switch_properties_hide_game.get_active())
         self.game.set_info(InfoKey.CUSTOM_WINE, str(self.button_properties_wine.get_filename()))
         self.parent_library.filter_library()
@@ -129,8 +130,6 @@ class Properties(Gtk.Dialog):
     def button_sensitive(self, game):
         if not game.is_installed():
             self.button_properties_open_files.set_sensitive(False)
-            self.button_properties_wine.set_sensitive(False)
-            self.button_properties_reset.set_sensitive(False)
             self.button_properties_regedit.set_sensitive(False)
             self.button_properties_winecfg.set_sensitive(False)
             self.button_properties_winetricks.set_sensitive(False)
@@ -149,3 +148,6 @@ class Properties(Gtk.Dialog):
             self.button_properties_wine.hide()
             self.button_properties_reset.hide()
             self.label_wine_custom.hide()
+        elif game.platform == 'windows':
+            self.button_properties_wine.set_sensitive(True)
+            self.button_properties_reset.set_sensitive(True)


### PR DESCRIPTION
## Description

This is a quick and tiny little change i've mentioned on Discord. All it does is enable the file selection for wine executables in the windows games properties dialog, even when the game is not yet installed.
All the code to support custom wine executables set like this already exists. The only thing that was missing was to actually enable the UI.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
