### PR TITLE
chore: resolve warnings and test output noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Logs are now also written to `~/.cache/minigalaxy/minigalaxy.log`.
 - Ask the user which binary to launch if Minigalaxy is unsure.
 - The `wine` executable can now also be changed before a game is installed (thanks to GB609).
+- Resolve deprecation/syntax warnings and quiet test output noise. (thanks to slowsage)
 
 **1.4.2**
 - Switch to using PEP 302 compliant resources, excluding translations. (thanks to EmperorArthur)

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -118,7 +118,7 @@ class Api:
                 platform = "windows"
 
             if not platform:
-                logging.warn("%s has no platform information - skip", product["title"])
+                logging.warning("%s has no platform information - skip", product["title"])
                 continue
 
             if not product.get("url", None):
@@ -233,15 +233,14 @@ class Api:
             response = self.session.get(url)
             if response.status_code == http.HTTPStatus.OK and len(response.text) > 0:
                 response_object = ET.fromstring(response.text)
-                if response_object and response_object.attrib:
+                if response_object is not None and response_object.attrib:
                     result = response_object.attrib
             else:
                 logging.error("Couldn't read xml data. Response with code %s received with the following content: %s",
                               response.status_code, response.text, exc_info=1)
-        except requests.exceptions.RequestException:
-            logging.error("Couldn't read xml data. Received RequestException", exc_info=1)
-        finally:
-            return result
+        except (requests.exceptions.RequestException, ET.ParseError):
+            logging.error("Couldn't read xml data", exc_info=1)
+        return result
 
     def get_user_info(self) -> str:
         username = self.config.username

--- a/minigalaxy/translation.py
+++ b/minigalaxy/translation.py
@@ -29,7 +29,9 @@ os.unsetenv("LANGUAGE")
 os.unsetenv("LANG")
 
 current_locale = Config().locale
-default_locale = locale.getdefaultlocale()[0]
+# getlocale() returns the locale set by setlocale(LC_ALL, '') earlier in this
+# module, which read the environment before LANG/LANGUAGE were unset above.
+default_locale = locale.getlocale()[0]
 if current_locale == '':
     if default_locale is None:
         lang = gettext.translation(TRANSLATION_DOMAIN, LOCALE_DIR, languages=['en'], fallback=True)

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -33,7 +33,7 @@ class Library(Gtk.Viewport):
         self.config = config
 
         current_locale = self.config.locale
-        default_locale = locale.getdefaultlocale()[0]
+        default_locale = locale.getlocale()[0]
         if current_locale == '':
             locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
         else:

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -55,7 +55,7 @@ class Preferences(Gtk.Dialog):
     def __set_locale_list(self) -> None:
         # Set the active option
         current_locale = self.config.locale
-        default_locale = locale.getdefaultlocale()
+        default_locale = locale.getlocale()
         if current_locale is None:
             locale.setlocale(locale.LC_ALL, default_locale)
 
@@ -70,7 +70,7 @@ class Preferences(Gtk.Dialog):
     def __apply_locale_choice(self) -> None:
         locale_choice = get_combo_value(self.combobox_program_language)
         if locale_choice == '' or not locale_choice:
-            locale_choice = locale.getdefaultlocale()[0]
+            locale_choice = locale.getlocale()[0]
 
         try:
             locale.setlocale(locale.LC_ALL, (locale_choice, 'UTF-8'))

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -33,7 +33,7 @@ class Window(Gtk.ApplicationWindow):
 
     def __init__(self, config: Config, api: 'Api', download_manager: DownloadManager, name="Minigalaxy"):
         current_locale = config.locale
-        default_locale = locale.getdefaultlocale()[0]
+        default_locale = locale.getlocale()[0]
         if current_locale == '':
             locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
         else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -176,6 +176,7 @@ class TestApiGog(TestCase):
         self.api._Api__request.return_value = {"checksum": "url"}
         self.session.get.side_effect = MagicMock()
         self.session.get().status_code = http.HTTPStatus.NOT_FOUND
+        self.session.get().text = ""
 
         exp = ""
         obs = self.api.get_download_file_info("url").md5
@@ -232,6 +233,7 @@ class TestApiGog(TestCase):
         self.api._Api__request.return_value = {"checksum": "url"}
         session.get.side_effect = MagicMock()
         session.get().status_code = http.HTTPStatus.NOT_FOUND
+        session.get().text = ""
 
         exp = 0
         obs = self.api.get_download_file_info("url").size

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -199,7 +199,8 @@ class Test(TestCase):
         """[scenario: linux installer, unpack success]"""
         mock_is_file.return_value = True
         mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readlines.return_value = ["\n"]
+        mock_subprocess().stdout.readline.return_value = ""
+        mock_subprocess().stderr.readline.return_value = ""
         mock_listdir.return_value = ["object1", "object2"]
         game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
@@ -215,7 +216,8 @@ class Test(TestCase):
         """[scenario: linux installer, unpack failed]"""
         mock_is_file.return_value = True
         mock_subprocess().poll.return_value = 2
-        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
+        mock_subprocess().stdout.readline.return_value = ""
+        mock_subprocess().stderr.readline.return_value = ""
         mock_listdir.return_value = ["object1", "object2"]
         game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
@@ -230,7 +232,8 @@ class Test(TestCase):
     def test_extract_linux(self, mock_subprocess, mock_listdir, mock_is_file):
         mock_is_file.return_value = True
         mock_subprocess().poll.return_value = 1
-        mock_subprocess().stdout.readlines.return_value = ["stdout", "(attempting to process anyway)"]
+        mock_subprocess().stdout.readline.return_value = ""
+        mock_subprocess().stderr.readline.return_value = ""
         mock_listdir.return_value = ["object1", "object2"]
         installer_path = "/home/makson/.cache/minigalaxy/download/Beneath a Steel Sky/beneath_a_steel_sky_en_gog_2_20150.sh"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1207658695"
@@ -294,7 +297,8 @@ class Test(TestCase):
         """[scenario: success]"""
         mock_path_exists.return_value = True
         mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
+        mock_subprocess().stdout.readline.return_value = ""
+        mock_subprocess().stderr.readline.return_value = ""
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
@@ -310,7 +314,8 @@ class Test(TestCase):
         """[scenario: install failed]"""
         mock_path_exists.return_value = True
         mock_subprocess().poll.return_value = 1
-        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
+        mock_subprocess().stdout.readline.return_value = ""
+        mock_subprocess().stderr.readline.return_value = ""
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform="windows")
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
@@ -323,7 +328,8 @@ class Test(TestCase):
     def test1_postinstaller(self, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = False
         mock_subprocess().poll.return_value = 1
-        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
+        mock_subprocess().stdout.readline.return_value = ""
+        mock_subprocess().stderr.readline.return_value = ""
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = ""
         obs = installer.postinstaller(game)
@@ -335,7 +341,8 @@ class Test(TestCase):
     def test2_postinstaller(self, mock_chmod, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = True
         mock_subprocess().poll.return_value = 0
-        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
+        mock_subprocess().stdout.readline.return_value = ""
+        mock_subprocess().stderr.readline.return_value = ""
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = ""
         obs = installer.postinstaller(game)
@@ -347,7 +354,8 @@ class Test(TestCase):
     def test3_postinstaller(self, mock_chmod, mock_path_isfile, mock_subprocess):
         mock_path_isfile.return_value = True
         mock_subprocess().poll.return_value = 1
-        mock_subprocess().stdout.readlines.return_value = ["stdout", "stderr"]
+        mock_subprocess().stdout.readline.return_value = ""
+        mock_subprocess().stderr.readline.return_value = ""
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift")
         exp = "Postinstallation script failed: /home/makson/GOG Games/Absolute Drift/support/postinst.sh"
         obs = installer.postinstaller(game)


### PR DESCRIPTION
## Description

Resolves deprecation/syntax warnings and quiets test output noise - easier to track if anything is actually wrong. No behavioral change; 177 tests pass.
Follow up to #731.
Arch PKGBUILD issue tracked [here](https://github.com/FabioLolix/PKGBUILD-AUR_fix/pull/91).

Warnings:
- `api.py`: use `logging.warning` instead of deprecated `logging.warn`.
- `api.py`: compare XML Element with `is not None` rather than its deprecated boolean truth-value.
- `api.py`: move `return result` out of the `finally` block (SyntaxWarning) and catch `ET.ParseError` alongside `RequestException`, so malformed XML yields an empty result instead of propagating.
- `library`/`window`/`preferences`/`translation`: replace deprecated `locale.getdefaultlocale()` with `locale.getlocale()`; the process locale is already initialized by `translation.py` at import time.

Test output noise:
- `test_installer` mocked Popen `stdout.readlines` (plural), but `_exe_cmd` reads `readline` (singular), so `readline` returned a live MagicMock that was truthy yet had `__len__ == 0` — the read loop only terminated by accident, and `extract_by_wine` (`print_output=True`) printed the mock to stdout. Stub `readline` on both streams to return `""` for deterministic termination and clean output.
- `test_api` 404 paths set `status_code` but not `text`, so `__get_xml_checksum` logged `response.text` as a MagicMock repr. Stub `text` to `""`.

## Checklist

- [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
