### PR TITLE
Critical bugfix: Repair API requests broken by changes from GOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
-**1.4.3**
+**1.4.2**
+- Critical bugfix: Use another API to determine game platform support (thanks to GB609)
+- UI improvement: Show games in the library incrementally when starting (thanks to GB609)
 - Reduce unnecessary writes to the config file. (thanks to GB609)
 - Fix a possible exception during game installation not being handled correctly.
 - Logs are now also written to `~/.cache/minigalaxy/minigalaxy.log`.
 - Ask the user which binary to launch if Minigalaxy is unsure.
 - The `wine` executable can now also be changed before a game is installed (thanks to GB609).
 - Resolve deprecation/syntax warnings and quiet test output noise. (thanks to slowsage)
-
-**1.4.2**
 - Switch to using PEP 302 compliant resources, excluding translations. (thanks to EmperorArthur)
 - Allow installing Minigalaxy via pipx. (thanks to EmperorArthur)
 - Switch debian builds to using pybuild-plugin-pyproject. (thanks to EmperorArthur)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ In addition to that, Minigalaxy also allows you to:
 - Use the system's ScummVM or DOSBox installation
 - Install Windows games using Wine
 
+### **Important:** GOG compatibility
+GOG has changed some of their API responses around May-July 2026 (exact point in time not known).
+
+This required to change how Minigalaxy retrieves some pieces of data.
+
+Any version of Minigalaxy from before the date mentioned above will NOT be able to show and install all 
+linux and windows games correctly.
+
+The first release working with the new APIs will be **1.4.2**.
+
 ### Backwards compatibility
 Minigalaxy version 1.3.2 and higher change some aspects of windows game installations through wine.
 It will try to adapt already installed games to the new concept when launched through Minigalaxy.

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -168,6 +168,18 @@ class Api:
         if compat.get("windows", False):
             return "windows"
 
+        # content_system_compatibility is not correct sometimes,
+        # see Goodbye Eternity for example: https://api.gog.com/products/1424453125?expand=downloads,expanded_dlcs
+        # as a fallback, iterate over the installers and pull the OS info from there
+        os_support = {}
+        for installer in product["downloads"]["installer"]:
+            if 'os' in installer:
+                os_support[installer['os']] = True
+        if os_support.get("linux", False):
+            return "linux"
+        if os_support.get("windows", False):
+            return "windows"
+
         logging.warning("%s has no platform information - skip", product["title"])
         return None
 

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -157,9 +157,13 @@ class Api:
 
     # Get Extrainfo about a game
     def get_info(self, game: Game) -> dict:
-        request_url = "{}/{}?locale=en-US&expand=downloads,expanded_dlcs,description,screenshots," \
-                      "videos".format(self.PRODUCTS_API, str(game.id))
+        if game.product_info and game.product_info_age < 60:
+            logging.debug("Reusing cached result for api.get_info(%s)", game.name)
+            return game.product_info
+
+        request_url = "{}/{}?locale=en-US&expand=downloads,expanded_dlcs".format(self.PRODUCTS_API, str(game.id))
         response = self.__request(request_url)
+        game.product_info = response
         return response
 
     def get_dlc_info(self, game: Game, dlc_id):

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -80,29 +80,30 @@ class Api:
     def get_library(self):
         err_msg = ""
         games = []
-        if self.active_token:
-            current_page = 1
-            all_pages_processed = False
-            url = "https://embed.gog.com/account/getFilteredProducts"
+        if not self.active_token:
+            return [], "Couldn't connect to GOG servers"
 
-            while not all_pages_processed:
-                params = {
-                    'mediaType': 1,  # 1 means game
-                    'page': current_page,
-                }
-                response = self.__request(url, params=params)
-                if "totalPages" not in response:
-                    err_msg = "Couldn't load game library"
-                    return games, err_msg
-                total_pages = response["totalPages"]
+        current_page = 1
+        all_pages_processed = False
+        url = "https://embed.gog.com/account/getFilteredProducts"
 
-                self.__parse_productlist_json(response["products"], games)
+        while not all_pages_processed:
+            params = {
+                'mediaType': 1,  # 1 means game
+                'page': current_page,
+            }
+            response = self.__request(url, params=params)
+            if "totalPages" not in response:
+                err_msg = "Couldn't load game library"
+                return games, err_msg
+            total_pages = response["totalPages"]
 
-                if current_page == total_pages:
-                    all_pages_processed = True
-                current_page += 1
-        else:
-            err_msg = "Couldn't connect to GOG servers"
+            self.__parse_productlist_json(response["products"], games)
+
+            if current_page == total_pages:
+                all_pages_processed = True
+            current_page += 1
+
         return games, err_msg
 
     def __parse_productlist_json(self, product_list, game_list):

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -119,7 +119,7 @@ class Api:
                 logging.warning("%s (%s) has no store page url", product["title"], product['id'])
 
             game = Game(name=product["title"], url=product.get("url", None), game_id=product["id"],
-                        image_url=product["image"], platform="windows", category=product["category"])
+                        image_url=product["image"], platform="windows", category=product.get("category", None))
             game_list.append(game)
 
     def __filter_games_with_valid_platforms(self, games):

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -106,6 +106,8 @@ class Api:
                 all_pages_processed = True
             current_page += 1
 
+        games = self.__filter_games_with_valid_platforms(games)
+
         return games, err_msg
 
     def __parse_productlist_json(self, product_list, game_list):
@@ -113,23 +115,61 @@ class Api:
             if product["id"] in IGNORE_GAME_IDS:
                 continue
 
-            worksOn = product.get("worksOn", {})
-            platform = None
-            if worksOn.get("Linux", False):
-                platform = "linux"
-            elif worksOn.get("Windows", False):
-                platform = "windows"
-
-            if not platform:
-                logging.warning("%s has no platform information - skip", product["title"])
-                continue
-
             if not product.get("url", None):
                 logging.warning("%s (%s) has no store page url", product["title"], product['id'])
 
             game = Game(name=product["title"], url=product.get("url", None), game_id=product["id"],
-                        image_url=product["image"], platform=platform, category=product["category"])
+                        image_url=product["image"], platform="windows", category=product["category"])
             game_list.append(game)
+
+    def __filter_games_with_valid_platforms(self, games):
+        """
+        Query the products api in batches of 50 and pull the supported platforms info out of there.
+        This will also assign the resulting product info to the game to cache it for further use by LibraryEntry.
+        """
+        # the additional platform check is only needed for games which are not installed
+        games_with_platform = []
+        for game in games:
+            if not game.is_installed():
+                games_with_platform.append(game)
+        games = games_with_platform
+        games_with_platform = []
+
+        while len(games) > 0:
+            chunk = {}
+            for game in games[:50]:
+                chunk[game.id] = game
+            games = games[50:]
+
+            id_query = ','.join(str(gameid) for gameid in chunk)
+            request_url = "{}?expand=downloads,expanded_dlcs&ids={}".format(self.PRODUCTS_API, id_query)
+            # returns a list at the top level
+            product_infos = self.__request(request_url)
+            if not product_infos or len(product_infos) < len(chunk):
+                logging.warning("The current batch of product infos does not contain all requested games.")
+
+            self.__upate_games_with_platform(games_with_platform, product_infos, chunk)
+        return games_with_platform
+
+    def __upate_games_with_platform(self, games_with_platform: list, product_infos: list, game_dict: dict):
+        for product in product_infos:
+            platform = self.__platform_from_product(product)
+            game = game_dict[product.get('id')]
+            if platform:
+                games_with_platform.append(game)
+                game.platform = platform
+                game.product_info = product
+
+    def __platform_from_product(self, product: dict):
+        """Expects a dictionary in the format provided by 'api.gog.com/products' """
+        compat = product.get("content_system_compatibility", {})
+        if compat.get("linux", False):
+            return "linux"
+        if compat.get("windows", False):
+            return "windows"
+
+        logging.warning("%s has no platform information - skip", product["title"])
+        return None
 
     def get_owned_products_ids(self):
         if not self.active_token:

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -162,22 +162,18 @@ class Api:
 
     def __platform_from_product(self, product: dict):
         """Expects a dictionary in the format provided by 'api.gog.com/products' """
+
         compat = product.get("content_system_compatibility", {})
-        if compat.get("linux", False):
-            return "linux"
-        if compat.get("windows", False):
-            return "windows"
 
         # content_system_compatibility is not correct sometimes,
         # see Goodbye Eternity for example: https://api.gog.com/products/1424453125?expand=downloads,expanded_dlcs
         # as a fallback, iterate over the installers and pull the OS info from there
-        os_support = {}
         for installer in product["downloads"]["installer"]:
             if 'os' in installer:
-                os_support[installer['os']] = True
-        if os_support.get("linux", False):
+                compat[installer['os']] = True
+        if compat.get("linux", False):
             return "linux"
-        if os_support.get("windows", False):
+        if compat.get("windows", False):
             return "windows"
 
         logging.warning("%s has no platform information - skip", product["title"])

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -19,6 +19,8 @@ class NoDownloadLinkFound(BaseException):
 
 
 class Api:
+    PRODUCTS_API = "https://api.gog.com/products"
+
     def __init__(self, config: Config, session: Session):
         self.config = config
         self.session = session
@@ -155,8 +157,8 @@ class Api:
 
     # Get Extrainfo about a game
     def get_info(self, game: Game) -> dict:
-        request_url = "https://api.gog.com/products/{}?locale=en-US&expand=downloads,expanded_dlcs,description,screenshots," \
-                      "videos,related_products,changelog".format(str(game.id))
+        request_url = "{}/{}?locale=en-US&expand=downloads,expanded_dlcs,description,screenshots," \
+                      "videos".format(self.PRODUCTS_API, str(game.id))
         response = self.__request(request_url)
         return response
 

--- a/minigalaxy/api.py
+++ b/minigalaxy/api.py
@@ -168,7 +168,7 @@ class Api:
         # content_system_compatibility is not correct sometimes,
         # see Goodbye Eternity for example: https://api.gog.com/products/1424453125?expand=downloads,expanded_dlcs
         # as a fallback, iterate over the installers and pull the OS info from there
-        for installer in product["downloads"]["installer"]:
+        for installer in product["downloads"]["installers"]:
             if 'os' in installer:
                 compat[installer['os']] = True
         if compat.get("linux", False):

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -1,10 +1,11 @@
+import json
 import logging
 import os
 import re
-import json
 
 from enum import Enum
 from minigalaxy.paths import CONFIG_GAMES_DIR, ICON_DIR, THUMBNAIL_DIR
+from time import monotonic
 
 
 class InfoKey(str, Enum):
@@ -36,6 +37,7 @@ class Game:
         self.dlcs = [] if dlcs is None else dlcs
         self.category = category
         self.status_file_path = self.get_status_file_path()
+        self.product_info = None
 
     def get_stripped_name(self, to_path=False):
         return Game.strip_string(self.name, to_path=to_path)
@@ -220,6 +222,21 @@ class Game:
         self.image_url = other_game.image_url
         self.url = other_game.url
         self.category = other_game.category
+
+    @property
+    def product_info(self) -> dict:
+        return self.__product_info
+
+    @product_info.setter
+    def product_info(self, product_info: dict) -> None:
+        self.__product_info = product_info
+        self.__product_info_settime = monotonic()
+
+    @property
+    def product_info_age(self):
+        """Time in minutes since the last update of product_info"""
+        current_time = monotonic()
+        return (current_time - self.__product_info_settime) / 60
 
     def __info_key_from_arg(self, key):
         """

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -38,6 +38,7 @@ class Game:
         self.category = category
         self.status_file_path = self.get_status_file_path()
         self.product_info = None
+        self.library_tile = None
 
     def get_stripped_name(self, to_path=False):
         return Game.strip_string(self.name, to_path=to_path)

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -289,7 +289,7 @@ def extract_by_wine(game, installer, game_lang, config=Config()):
 
 
 def try_wine_command(command_arr):
-    logging.debug('trying to run wine command:', shlex.join(command_arr))
+    logging.debug('trying to run wine command:[%s]', shlex.join(command_arr))
     stdout, stderr, exitcode = _exe_cmd(command_arr, True)
     if exitcode not in [0]:
         logging.error(stderr)

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -215,6 +215,7 @@ class Library(Gtk.Viewport):
         return games
 
     def __add_games_from_api(self):
+        logging.info("Start retrieving owned games from the api...")
         retrieved_games, err_msg = self.api.get_library()
         if not err_msg:
             self.offline = False
@@ -223,6 +224,7 @@ class Library(Gtk.Viewport):
             logging.info("Client is offline, showing installed games only")
             GLib.idle_add(self.parent_window.show_error, _("Failed to retrieve library"), _(err_msg))
         game_category_dict = {}
+        logging.info("Create or update the game list with %s games", len(retrieved_games))
         for game in retrieved_games:
             # NOTE: the 'in' check and 'list.index' function depend on the '__eq__' method of Game.
             # 'Game.__eq__(self, other)' is a bit lenient, it ignores the property 'id' if it is zero for 'self' or 'other'.

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -134,7 +134,7 @@ class Library(Gtk.Viewport):
         tile2 = child2.get_children()[0].game
         return tile2 < tile1
 
-    def __create_gametiles(self, games_to_add=[]) -> None:
+    def __create_gametiles(self, games_to_add=None) -> None:
         """Gets called twice: Once for installed, once for not installed games."""
 
         if not games_to_add:

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -81,17 +81,24 @@ class Library(Gtk.Viewport):
         self.owned_products_ids = self.api.get_owned_products_ids()
         # Get already installed games first
         self.games = self.__get_installed_games()
-        GLib.idle_add(self.__create_gametiles)
+        self.__create_gametiles_iteratively(5)
 
         # Get games from the API
         self.__add_games_from_api()
+        self.__create_gametiles_iteratively(5)
+        GLib.idle_add(self.filter_library)
+
+    def __create_gametiles_iteratively(self, step_width=5):
+        if len(self.games) < step_width*2:
+            GLib.idle_add(self.__create_gametiles)
+            return
+
         index = 0
         while index < len(self.games):
-            games_chunk = self.games[index:index+10]
+            games_chunk = self.games[index:index+step_width]
             GLib.idle_add(self.__create_gametiles, games_chunk)
-            index += 5
+            index += step_width
             time.sleep(0.1)
-        GLib.idle_add(self.filter_library)
 
     def __load_tile_states(self):
         for child in self.flowbox.get_children():
@@ -139,6 +146,16 @@ class Library(Gtk.Viewport):
 
         if not games_to_add:
             games_to_add = self.games
+
+        logging.debug("Create gametiles for %s games", str(len(games_to_add)))
+
+        for child in self.flowbox.get_children():
+            tile = child.get_children()[0]
+            if tile.game in games_to_add:
+                logging.debug("Update existing tile for [%s] with new game instance", tile.game.name)
+                new_game = games_to_add[games_to_add.index(tile.game)]
+                new_game.library_tile = tile
+                tile.game = new_game
 
         for game in games_to_add:
             if game.library_tile:

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import threading
+import time
 
 from minigalaxy.api import Api
 from minigalaxy.config import Config
@@ -84,7 +85,12 @@ class Library(Gtk.Viewport):
 
         # Get games from the API
         self.__add_games_from_api()
-        GLib.idle_add(self.__create_gametiles)
+        index = 0
+        while index < len(self.games):
+            games_chunk = self.games[index:index+10]
+            GLib.idle_add(self.__create_gametiles, games_chunk)
+            index += 5
+            time.sleep(0.1)
         GLib.idle_add(self.filter_library)
 
     def __load_tile_states(self):
@@ -128,23 +134,17 @@ class Library(Gtk.Viewport):
         tile2 = child2.get_children()[0].game
         return tile2 < tile1
 
-    def __create_gametiles(self) -> None:
+    def __create_gametiles(self, games_to_add=[]) -> None:
         """Gets called twice: Once for installed, once for not installed games."""
-        games_with_tiles = []
-        for child in self.flowbox.get_children():
-            tile = child.get_children()[0]
-            if tile.game in self.games:
-                games_with_tiles.append(tile.game)
-                """Games which already have a tile during the second invocation are installed games.
-                These did NOT have api information about the thumbnail url in their Game instance in the first pass.
-                Thus, they weren't able to load the thumbnail if it wasn't cached before. Try again now.
-                This mostly applies when the user empties the cache. Otherwise THUMBNAIL dir should contain a file from
-                when the game still wasn't installed
-                """
-                tile.load_thumbnail()
 
-        for game in self.games:
-            if game in games_with_tiles:
+        if not games_to_add:
+            games_to_add = self.games
+
+        for game in games_to_add:
+            if game.library_tile:
+                # the game already has a visible entry in the library
+                # request to load the thumbnail, if there is a url for it and it hasnt been loaded before
+                game.library_tile.load_thumbnail()
                 continue
             if game.is_installed():
                 self.__add_gametile(game)
@@ -152,7 +152,7 @@ class Library(Gtk.Viewport):
                 self.__add_gametile(game)
             elif game.platform in self.config.platform_mode:
                 self.__add_gametile(game)
-            else:
+            elif game in self.games:
                 # housekeeping: API.get_library returns all owned games
                 # (useful when api-caching is introduced as the same request can be used independent of platform_mode)
                 # removing not shown games is only a small memory optimization
@@ -164,6 +164,7 @@ class Library(Gtk.Viewport):
             game_tile = GameTile(self, game)
         elif view == "list":
             game_tile = GameTileList(self, game)
+        game.library_tile = game_tile
 
         # Start download if Minigalaxy was closed while downloading this game
         game_tile.resume_download_if_expected()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -94,7 +94,7 @@ class TestApiGog(TestCase):
             # for getFilteredProducts
             {'totalPages': 1, 'products': [{'id': 1097893768, 'title': 'Neverwinter Nights: Enhanced Edition', 'image': '//images-2.gog-statics.com/8706f7fb87a4a41bc34254f3b49f59f96cf13d067b2c8bbfd8d41c327392052a', 'url': '/game/neverwinter_nights_enhanced_edition_pack', 'worksOn': {'Windows': True, 'Mac': True, 'Linux': True}, "category": "Role-playing"}]},
             # for api.gog.com/products
-            [{'id': 1097893768, 'content_system_compatibility': {'windows': True}}]
+            [{'id': 1097893768, 'content_system_compatibility': {'windows': True}, "downloads": {"installers": [{"os": "windows"}]}}]
         ]
         self.api.active_token_expiration_time = time.time() + 10.0
         response_mock = MagicMock()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,10 +90,15 @@ class TestApiGog(TestCase):
 
     def test_get_library_ok(self):
         self.api.active_token = True
-        response_dict = {'totalPages': 1, 'products': [{'id': 1097893768, 'title': 'Neverwinter Nights: Enhanced Edition', 'image': '//images-2.gog-statics.com/8706f7fb87a4a41bc34254f3b49f59f96cf13d067b2c8bbfd8d41c327392052a', 'url': '/game/neverwinter_nights_enhanced_edition_pack', 'worksOn': {'Windows': True, 'Mac': True, 'Linux': True}, "category": "Role-playing"}]}
+        api_responses = [
+            # for getFilteredProducts
+            {'totalPages': 1, 'products': [{'id': 1097893768, 'title': 'Neverwinter Nights: Enhanced Edition', 'image': '//images-2.gog-statics.com/8706f7fb87a4a41bc34254f3b49f59f96cf13d067b2c8bbfd8d41c327392052a', 'url': '/game/neverwinter_nights_enhanced_edition_pack', 'worksOn': {'Windows': True, 'Mac': True, 'Linux': True}, "category": "Role-playing"}]},
+            # for api.gog.com/products
+            [{'id': 1097893768, 'content_system_compatibility': {'windows': True}}]
+        ]
         self.api.active_token_expiration_time = time.time() + 10.0
         response_mock = MagicMock()
-        response_mock.json.return_value = response_dict
+        response_mock.json.side_effect = lambda: api_responses.pop(0)
         self.session.get.return_value = response_mock
         self.session.get().status_code = http.HTTPStatus.OK
         exp = "Neverwinter Nights: Enhanced Edition"
@@ -113,12 +118,13 @@ class TestApiGog(TestCase):
 
     def test_parse_productlist_json(self):
         products = [
-            {"id": 2, "title": "Should not be included", "image": ""},
-            {"id": 12, "worksOn": {}, "title": "Should not be included", "image": "", "category": ""},
-            {"id": 22, "worksOn": {"Linux": True, "Windows": False}, "title": "Pure Linux Game", "image": "", "category": ""},
-            {"id": 32, "worksOn": {"Linux": False, "Windows": True}, "title": "Pure Windows Game", "image": "", "category": ""},
-            {"id": 42, "worksOn": {"Linux": True, "Windows": True}, "title": "Mixed Game", "image": "", "category": ""}
+            {"id": 22, "title": "Pure Linux Game", "image": "", "category": ""},
+            {"id": 32, "title": "Pure Windows Game", "image": "", "category": ""},
+            {"id": 42, "title": "Mixed Game", "image": "", "category": ""}
         ]
+        # FIXME: platform is not part of the __eq__ check in game, so this test only made sense when
+        # __parse_productlist_json used the 'worksOn' subdict to filter out unsupported games
+        # (not the case anymore, this is done later)
         expected = [
             Game(name="Pure Linux Game", game_id=22, platform="linux"),
             Game(name="Pure Windows Game", game_id=32, platform="window"),


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

An analysis of the api responses from GOG triggered by the problems in #757 lead to the findings that Minigalaxy can't continue to depend on the api endpoint `/account/getFilteredProducts` for some of its core logic: Determining a game's platform support.

Up to now, the sub-dict `worksOn` of the data mentioned above was used. But that dict does not contain valid data anymore now, so Minigalaxy retrieves a full library of games which claim to not support any platform at all (according to that GOG endpoint).

This PR tackles this with a first fix. It could use a few optimizations, but it'll do for now.
The fix does: 
1. Additionally pull the API `api.gog.com/products` in 'batch mode' (for optimization)
2. Decide platform support based on the sub-dict `content_system_compatibility` of said api

Since this means that we do pull more apis and increase load times, i decided to also include a few small optimizations to improve startup time to counterbalance the longer api load:
- Caching of api responses where useful
- preventing as many redundant loops over the full game list as possible
- ease up the backpressure on the main thread when building the library by adding the games incrementally. The largest block still is the api retrieval which happens all at once (for now).

closes: #757 
closes: #756 
closes: #595 
closes: #717 

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
