### PR TITLE
Target Ubuntu 26.04

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**1.4.3**
+- Releases now target Ubuntu 26.04
+
 **1.4.2**
 - Critical bugfix: Use another API to determine game platform support (thanks to GB609)
 - UI improvement: Show games in the library incrementally when starting (thanks to GB609)


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

<!-- Describe what was changed -->
This seems necessary, since Ubuntu 24.04 requires changes which break the ability to build for any modern system at the moment. This is new and I don't know why, but it means we have to switch.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
