### PR TITLE
Feature: Provide AppImage with release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y debhelper dh-python python3-all help2man devscripts gettext lsb-release xmlstarlet git build-essential pybuild-plugin-pyproject
-        pip install setuptools
+        pip install setuptools python-appimage build
     - uses: actions/checkout@v6
       with:
         ref: master
@@ -26,6 +26,13 @@ jobs:
     - name: Build deb package
       run: |
         dpkg-buildpackage -us -uc
+    - name: Build AppImage
+      uses: kohlerdominik/docker-run-action@v2.1.0
+      with:
+        image: quay.io/pypa/manylinux_2_28_x86_64
+        volumes: ${{ github.workspace }}:/mnt/minigalaxy
+        run: |
+          /mnt/minigalaxy/scripts/make-appimage.sh
     - name: Commit changes
       run: |
         git config --global user.name 'Wouter Wijsman'
@@ -41,7 +48,9 @@ jobs:
         name: Minigalaxy version ${{ steps.tag.outputs.VERSION }}
         body_path: release.md
         prerelease: true
+        # the appimage script also builds the wheel, both are placed in the same directory
         files: |
           ../minigalaxy_*.deb
+          ./build-appimage/output/*
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ debian/minigalaxy.debhelper.log
 debian/minigalaxy.postinst.debhelper
 debian/minigalaxy.prerm.debhelper
 .vscode/settings.json
+tmp/
+/build-appimage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **1.4.3**
+- Releases will now include a basic AppImage (experimental) (thanks to GB609)
 - Releases now target Ubuntu 26.04
 - Mangohud dlsym enabled by default (thanks to RoGreat)
 

--- a/appimage-recipe/AppRun
+++ b/appimage-recipe/AppRun
@@ -1,0 +1,30 @@
+#! /bin/bash
+
+# This file is a slight modification of python.AppImage/usr/bin/python3.12
+# 1. Fixed an issue related to how 'self' is calculated (make it not care about whether its a link)
+# 2. Added LD_LIBRARY_PATH
+
+# If running from an extracted image, then export ARGV0 and APPDIR
+if [ -z "${APPIMAGE}" ]; then
+    export ARGV0="$0"
+
+    self=$(realpath -s "${BASH_SOURCE[0]}") # Protect spaces (issue 55)
+    export APPDIR=$(dirname "${self}")
+fi
+
+# Resolve the calling command (preserving symbolic links).
+export APPIMAGE_COMMAND=$(command -v -- "$ARGV0")
+
+# Export TCl/Tk
+export TCL_LIBRARY="${APPDIR}/usr/share/tcltk/tcl8.6"
+export TK_LIBRARY="${APPDIR}/usr/share/tcltk/tk8.6"
+export TKPATH="${TK_LIBRARY}"
+
+# Export SSL certificate
+export SSL_CERT_FILE="${APPDIR}/opt/_internal/certs.pem"
+
+# Call Python
+
+export LD_LIBRARY_PATH=${APPDIR}/usr/lib:${LD_LIBRARY_PATH}
+"$APPDIR/opt/python3.12/bin/python3.12" -I -m minigalaxy "$@"
+

--- a/appimage-recipe/requirements.txt
+++ b/appimage-recipe/requirements.txt
@@ -1,0 +1,2 @@
+requests
+PyGObject==3.44.2

--- a/minigalaxy/css.py
+++ b/minigalaxy/css.py
@@ -12,8 +12,11 @@ def load_css():
     Load CSS data.
     """
     try:
-        css_data = get_data_file("style.css").read_text(encoding='utf-8')
+        css_data_file = get_data_file("style.css")
+        # css_data = css_data_file.read_text(encoding='utf-8')
+        css_data = css_data_file.read_bytes()
         CSS_PROVIDER.load_from_data(css_data)
     except Exception:
         logging.error("The CSS could not be loaded", exc_info=1)
+#        logging.error("file:%s, data:%s", str(css_data_file), str(css_data))
     Gtk.StyleContext().add_provider_for_screen(Gdk.Screen.get_default(), CSS_PROVIDER, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)

--- a/minigalaxy/paths.py
+++ b/minigalaxy/paths.py
@@ -23,3 +23,6 @@ DEFAULT_INSTALL_DIR = os.path.expanduser("~/GOG Games")
 LOCALE_DIR = os.path.abspath(os.path.join(LAUNCH_DIR, "../data/mo"))
 if not os.path.exists(LOCALE_DIR):
     LOCALE_DIR = os.path.abspath(os.path.join(LAUNCH_DIR, "../share/minigalaxy/translations"))
+if not os.path.exists(LOCALE_DIR):
+    # for installation in non-standard python runtimes, like in AppImages
+    LOCALE_DIR = os.path.abspath(os.path.join(sys.base_prefix, "share/minigalaxy/translations"))

--- a/minigalaxy/translation.py
+++ b/minigalaxy/translation.py
@@ -32,6 +32,8 @@ current_locale = Config().locale
 # getlocale() returns the locale set by setlocale(LC_ALL, '') earlier in this
 # module, which read the environment before LANG/LANGUAGE were unset above.
 default_locale = locale.getlocale()[0]
+logging.debug("Init locales: default=%s, current=%s", default_locale, current_locale)
+logging.debug("Loading locale files from %s", LOCALE_DIR)
 if current_locale == '':
     if default_locale is None:
         lang = gettext.translation(TRANSLATION_DOMAIN, LOCALE_DIR, languages=['en'], fallback=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-PyGObject
+PyGObject==3.40.0

--- a/scripts/make-appimage.sh
+++ b/scripts/make-appimage.sh
@@ -1,0 +1,163 @@
+#!/bin/env bash
+
+# This script creates an appimage of minigalaxy by amending an already existing manylinux-python appimage as base.
+#
+# Basic steps:
+# 1. Download the image, utils and dependencies
+# 2. Unpack the base image
+# 3. Build a wheel for MG
+# 4. Install carefully picked, compatible versions of 'requests' and 'PyGObject' + minigalaxy
+# 5. add/patch/override appimage specific files
+# 6. Repack
+# 7. Enjoy
+#
+# This procedure is the result of weeks of trial and error with different ways to utilize 
+# 'python_appimage', 'auditwheel', the gtk-plugin for linuxdeploy and some others
+
+# vorgehensweise:
+# yum
+# basis-appimage extrahieren
+# runtime as extract als basis nutzen
+# deps installieren
+# MG bauen
+# mg installieren mit --force-install --no-deps
+# requirements installieren (mit festgenagelten versionen)
+# AppRun patchen: LD_LIBRARY_PATH+=APPDIR/usr/lib
+# verpacken mit linuxdeploy
+
+# when not in docker, check if docker command exists
+if ! [ -e /mnt/minigalaxy ]; then
+  if ! which docker; then
+    echo "'docker' is required" >&2
+    exit 1
+  fi
+fi
+
+set -e
+
+export SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+export REPO_ROOT=$(realpath "${SCRIPT_DIR}/..")
+
+WORK_DIR="${REPO_ROOT}/build-appimage"
+OUTPUT_DIR="${WORK_DIR}/output"
+APPIMAGE_SOURCES="${REPO_ROOT}/appimage-recipe"
+
+# This is a convenience helper for self-bootstrapping the build file in a local environment
+if ! [ -e /mnt/minigalaxy ]; then
+  sudo docker run \
+    --rm --name build-mg \
+    -v "${REPO_ROOT}:/mnt/minigalaxy" \
+    -it quay.io/pypa/manylinux_2_28_x86_64 \
+    "/mnt/minigalaxy/scripts/$(basename "${BASH_SOURCE[0]}")"
+  sudo docker container wait /build-mg
+  exit $?
+fi
+
+cd /mnt/minigalaxy
+mkdir -p "${WORK_DIR}" "${OUTPUT_DIR}"
+rm -rf "${WORK_DIR}"/*
+
+# pass a variable whose name matches '(.*)_URL', which points to a file to download
+# 1. Extract filename from URL
+# 2. Download the the file into $WORK_DIR, if it doesn't exist'
+# 3. The absolute path to the downloaded file is placed in another variable, named like the input,
+#    But without _URL.
+# Example: 
+#   PYTHON_URL=https://some.domain/sub/pythonabc-3.48.tgz
+#   download_if_required PYTHON_URL
+#   -> download: $WORK_DIR/pythonabc-3.48.tgz
+#   -> define: PYTHON=$WORK_DIR/pythonabc-3.48.tgz
+function download_if_required {
+  local -n url="$1"
+  local filename="${WORK_DIR}/$(basename "${url}")"
+  if ! [ -f "${filename}" ]; then
+    wget "${url}" -O "${filename}"
+  fi
+  declare -g "${1%_URL}=${filename}"
+}
+
+yum update -y
+yum -y install \
+  wget \
+  cairo-gobject-devel \
+  gobject-introspection-devel \
+  cairo-devel \
+  webkitgtk4 \
+  gtk3-devel \
+  python3-gobject
+
+LINUXDEPLOY_URL="https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage"
+download_if_required LINUXDEPLOY_URL
+
+# Define a batch of helper functions for easier python commands to manipulate the AppDir's instance.'
+PYEXE="${WORK_DIR}/AppDir/AppRun"
+function python { "${PYEXE}" "$@"; }
+function py-m { python -m "$@"; }
+function pip { py-m pip "$@"; }
+
+cd "${WORK_DIR}"
+chmod +x *.AppImage
+
+# build a python appimage
+# Reason: The prepackaged does not have a fixed version URL to wget 
+# It shifts all the time when the docker container is updated.
+# Since we're already running in a manylinux docker, we can as well just extract the runtime directly
+python3.12 -m pip install python_appimage
+python3.12 -m python_appimage build local
+mv python*AppImage python.AppImage
+BASEIMG="$(pwd)/python.AppImage"
+"${BASEIMG}" --appimage-extract
+mv squashfs-root AppDir
+
+### Build and install MG + deps
+
+# Install dependencies
+pip install -r "${APPIMAGE_SOURCES}/requirements.txt"
+# Build MG wheel against the dependencies.
+# Theoretically, we could just use 'pip install' directly.
+# But building the wheel first allows us to publish this independently as well
+py-m build --no-isolation --wheel --outdir "${OUTPUT_DIR}" ..
+
+# Now install the wheel of MG
+pip install --no-build-isolation --no-deps "${OUTPUT_DIR}/"minigalaxy*.whl
+
+### Patch/adjust the AppImage
+
+# The 'AppRun'' in the image should be a link to AppDir/usr/bin/python... which is a wrapper script.
+# we will copy and patch this to add LD_LIBRARY_PATH and change the python command line to MG instead
+# Reason: This gives access to any variable and logic the script prepares for the AppImage already,
+# without having to maintain duplications of that for ourselves
+mv AppDir/AppRun AppDir/python.sh
+# keep the path to the previous, real python exe because it might be needed after tampering with AppRun
+PYEXE=$(realpath AppDir/python.sh)
+cp -f "${APPIMAGE_SOURCES}/AppRun" AppDir/
+
+# some logging for error debugging
+echo "Diff python/AppRun <> mg/AppRun"
+sdiff AppDir/python.sh AppDir/AppRun || true
+
+# Desktop files and icons for MG
+dfile="io.github.sharkwouter.Minigalaxy.desktop"
+cp \
+  "${REPO_ROOT}/data/${dfile}" \
+  "${REPO_ROOT}/data/icons/192x192/io.github.sharkwouter.Minigalaxy.png" \
+  AppDir/
+rm AppDir/.DirIcon || true
+
+echo \
+"X-AppImage-Version=$(pip list | grep minigalaxy | cut -d' ' -s --output-delimiter='' -f2-)
+X-AppImage-Arch=x86_64" \
+  >>"AppDir/${dfile}"
+
+# remove desktop, png and sh files for python itself
+rm AppDir/python* AppDir/Python* || true
+
+# Final step: Package it up again
+# need to extract the AppImage in docker - fuse doesnt work there for various reasons
+"${LINUXDEPLOY}" --appimage-extract-and-run \
+  --appdir AppDir \
+  --desktop-file "AppDir/${dfile}" \
+  --icon-file "${REPO_ROOT}/data/icons/128x128/io.github.sharkwouter.Minigalaxy.png" \
+  --output appimage
+
+mv Minigalaxy*AppImage "${OUTPUT_DIR}/"


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This PR integrates an experimental script to build an AppImage of Minigalaxy into the `release.yml` workflow.

This introduces a new script, `scripts/make-appimage.sh [version]`, which does:
1. Set up a temporary directory (`repo-root/tmp`) and switch into it
2. Build MG wheel
3. Download a pre-packaged python runtime AppImage (Manylinux variant to allow broad distribition support)
4. Generate a temporary recipe folder for the AppImage
5. Patch some files into the AppImage folder (`*.desktop` and `requirements.txt`) to include whats needed for the AppImage to build correctly
6. Run `python-appimage build app [...]`

The new script can basically be started from anywhere. It will save the current directory, then switch to its working dir and switch back at the end.

The script has a couple of requirements, however:
- wget
- python-appimage
- python build

The script is called from the release workflow after the debian package is built. And the AppImage is also added to the `Release` step to publish it.

**Note**: I'm not entirely sure about the path i've added in the `Release` step. Normally, actions run from the root of the repo, but the `../Minigalaxy*deb` line confuses me as that would mean that...
1. debian packages are build one folder level ABOVE the repository.
2. OR the release action performs some kind of folder change?

## Checklist
 
 - [X] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
