### PR TITLE
Mangohud dlsym enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 **1.4.3**
 - Releases now target Ubuntu 26.04
+- Mangohud dlsym enabled by default (thanks to RoGreat)
 
 **1.4.2**
 - Critical bugfix: Use another API to determine game platform support (thanks to GB609)

--- a/minigalaxy/launch_command.py
+++ b/minigalaxy/launch_command.py
@@ -15,7 +15,6 @@ class LaunchCommand:
             self.command.insert(0, "gamemoderun")
         if game.get_info(InfoKey.MANGOHUD) is True:
             self.command.insert(0, "mangohud")
-            self.command.insert(1, "--dlsym")
 
         var_list = shlex.split(game.get_info(InfoKey.VARIABLES))
         command_list = shlex.split(game.get_info(InfoKey.COMMAND))


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

<!-- Describe what was changed -->

Removes `--dlysm` since mangohud enables it by default since last year https://github.com/sharkwouter/minigalaxy/issues/767.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
