### PR TITLE
Add per-game Steam Proton support through UMU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **1.4.3**
+- Add per-game Steam Proton support through UMU, including Proton discovery, installation/launch support, and managed UMU provisioning (thanks to adamjvr)
 - Releases will now include a basic AppImage (experimental) (thanks to GB609)
 - Releases now target Ubuntu 26.04
 - Mangohud dlsym enabled by default (thanks to RoGreat)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In addition to that, Minigalaxy also allows you to:
 - View the error message if a game fails to launch
 - Enable displaying the FPS in games
 - Use the system's ScummVM or DOSBox installation
-- Install Windows games using Wine
+- Install Windows games using Wine or a per-game Steam Proton compatibility tool
 
 ### **Important:** GOG compatibility
 GOG has changed some of their API responses around May-July 2026 (exact point in time not known).
@@ -98,6 +98,7 @@ Other Linux distributions may work as well. Minigalaxy requires the following de
 - Webkit2gtk with API version 4.0 support
 - Python Requests
 - gettext
+- UMU Launcher 1.4.4+ when using Proton (MiniGalaxy can install a verified user-level copy automatically)
 
 ## Installation
 

--- a/minigalaxy/compatibility.py
+++ b/minigalaxy/compatibility.py
@@ -234,3 +234,148 @@ def find_steam_proton_tools(
             str(tool.path),
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# User-facing compatibility choices
+# ---------------------------------------------------------------------------
+
+SYSTEM_WINE_CHOICE_ID = "wine:system"
+CUSTOM_WINE_CHOICE_ID = "wine:custom"
+PROTON_CHOICE_PREFIX = "proton:"
+
+
+@dataclass(frozen=True)
+class CompatibilityChoice:
+    """
+    One compatibility option presented by the per-game Properties dialog.
+
+    ``kind`` is one of:
+        wine-system
+        wine-custom
+        proton
+
+    Proton choices preserve the full canonical compatibility-tool path so the
+    exact selected Steam/GE Proton installation can be persisted per game.
+    """
+
+    choice_id: str
+    kind: str
+    name: str
+    path: str = ""
+    source: str = ""
+    available: bool = True
+
+
+def _make_proton_choice(
+    path: Path,
+    name: str,
+    source: str,
+    available: bool = True,
+) -> CompatibilityChoice:
+    canonical_path = str(_canonical_path(Path(path)))
+
+    return CompatibilityChoice(
+        choice_id=f"{PROTON_CHOICE_PREFIX}{canonical_path}",
+        kind="proton",
+        name=name,
+        path=canonical_path,
+        source=source,
+        available=available,
+    )
+
+
+def build_compatibility_choices(
+    proton_tools: Iterable[ProtonTool] | None = None,
+    selected_runner: str = "",
+    selected_proton_path: str = "",
+) -> list[CompatibilityChoice]:
+    """
+    Build the choices displayed in the per-game compatibility selector.
+
+    System Wine and Custom Wine always remain available.
+
+    All discovered Proton compatibility tools follow those entries.
+
+    If a game already references a Proton installation which has since been
+    removed, retain a non-available entry. This prevents the GUI from silently
+    replacing the user's configured Proton version with Wine.
+    """
+    if proton_tools is None:
+        proton_tools = find_steam_proton_tools()
+
+    choices = [
+        CompatibilityChoice(
+            choice_id=SYSTEM_WINE_CHOICE_ID,
+            kind="wine-system",
+            name="System Wine",
+        ),
+        CompatibilityChoice(
+            choice_id=CUSTOM_WINE_CHOICE_ID,
+            kind="wine-custom",
+            name="Custom Wine",
+        ),
+    ]
+
+    seen_proton_paths = set()
+
+    for tool in proton_tools:
+        choice = _make_proton_choice(
+            path=tool.path,
+            name=tool.name,
+            source=tool.source,
+        )
+
+        if choice.path in seen_proton_paths:
+            continue
+
+        seen_proton_paths.add(choice.path)
+        choices.append(choice)
+
+    if selected_runner == "proton" and selected_proton_path:
+        selected_path = str(
+            _canonical_path(Path(selected_proton_path))
+        )
+
+        if selected_path not in seen_proton_paths:
+            selected_name = Path(selected_path).name or selected_path
+
+            choices.append(
+                _make_proton_choice(
+                    path=Path(selected_path),
+                    name=selected_name,
+                    source="missing",
+                    available=False,
+                )
+            )
+
+    return choices
+
+
+def selected_compatibility_choice_id(
+    selected_runner: str,
+    selected_proton_path: str,
+    custom_wine_path: str,
+    system_wine_path: str,
+) -> str:
+    """
+    Convert existing per-game metadata into a compatibility selector ID.
+
+    Legacy games which have no runner metadata continue to resolve to Wine.
+    An old custom Wine executable remains Custom Wine unless it is simply the
+    current system Wine executable.
+    """
+    if selected_runner == "proton" and selected_proton_path:
+        selected_path = str(
+            _canonical_path(Path(selected_proton_path))
+        )
+
+        return f"{PROTON_CHOICE_PREFIX}{selected_path}"
+
+    if (
+        custom_wine_path
+        and custom_wine_path != system_wine_path
+    ):
+        return CUSTOM_WINE_CHOICE_ID
+
+    return SYSTEM_WINE_CHOICE_ID

--- a/minigalaxy/compatibility.py
+++ b/minigalaxy/compatibility.py
@@ -1,0 +1,236 @@
+"""Discovery helpers for Windows compatibility tools installed by Steam."""
+
+from __future__ import annotations
+
+import re
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+_LIBRARY_PATH_RE = re.compile(r'^\s*"path"\s*"((?:\\.|[^"])*)"\s*$')
+
+
+@dataclass(frozen=True)
+class ProtonTool:
+    """A Proton compatibility tool discovered in a Steam installation."""
+
+    name: str
+    path: Path
+    source: str
+
+
+def _canonical_path(path: Path) -> Path:
+    """
+    Return a normalized absolute path.
+
+    Steam commonly exposes the same installation through several symlinks,
+    for example ~/.local/share/Steam, ~/.steam/root and ~/.steam/steam.
+    Resolving those aliases prevents duplicate compatibility-tool entries.
+    """
+    path = path.expanduser()
+
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return path.absolute()
+
+
+def _unique_existing_directories(paths: Iterable[Path]) -> list[Path]:
+    """Return existing directories with equivalent paths deduplicated."""
+    unique_paths = []
+    seen_paths = set()
+
+    for path in paths:
+        if not path.is_dir():
+            continue
+
+        canonical_path = _canonical_path(path)
+
+        if canonical_path in seen_paths:
+            continue
+
+        seen_paths.add(canonical_path)
+        unique_paths.append(canonical_path)
+
+    return unique_paths
+
+
+def find_steam_roots(home: Path | None = None) -> list[Path]:
+    """
+    Find supported Steam installation roots.
+
+    Native Steam normally uses ~/.local/share/Steam and exposes compatibility
+    symlinks at ~/.steam/root and ~/.steam/steam. The Flatpak Steam location is
+    also considered so discovery can be reused by environments where that path
+    is accessible.
+    """
+    home = Path.home() if home is None else Path(home)
+
+    candidates = [
+        home / ".local" / "share" / "Steam",
+        home / ".steam" / "root",
+        home / ".steam" / "steam",
+        home / ".var" / "app" / "com.valvesoftware.Steam" / "data" / "Steam",
+    ]
+
+    return _unique_existing_directories(candidates)
+
+
+def _unescape_vdf_string(value: str) -> str:
+    """
+    Decode the small subset of VDF escaping relevant to filesystem paths.
+
+    We intentionally avoid adding a VDF dependency just to obtain Steam library
+    paths. Valve strings may escape a backslash or a double quote.
+    """
+    result = []
+    index = 0
+
+    while index < len(value):
+        character = value[index]
+
+        if character == "\\" and index + 1 < len(value):
+            next_character = value[index + 1]
+
+            if next_character in ("\\", '"'):
+                result.append(next_character)
+                index += 2
+                continue
+
+        result.append(character)
+        index += 1
+
+    return "".join(result)
+
+
+def parse_libraryfolders(vdf_path: Path) -> list[Path]:
+    """
+    Parse Steam library paths from steamapps/libraryfolders.vdf.
+
+    Only the ``path`` fields are required for compatibility-tool discovery, so
+    a complete KeyValues/VDF parser is unnecessary here.
+    """
+    vdf_path = Path(vdf_path)
+
+    if not vdf_path.is_file():
+        return []
+
+    libraries = []
+
+    try:
+        contents = vdf_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    for line in contents.splitlines():
+        match = _LIBRARY_PATH_RE.match(line)
+
+        if not match:
+            continue
+
+        libraries.append(Path(_unescape_vdf_string(match.group(1))))
+
+    return libraries
+
+
+def find_steam_libraries(
+    steam_roots: Iterable[Path] | None = None,
+    home: Path | None = None,
+) -> list[Path]:
+    """
+    Return every accessible Steam library, including secondary libraries.
+
+    The Steam installation root itself is a library and additional locations
+    are obtained from steamapps/libraryfolders.vdf.
+    """
+    roots = list(find_steam_roots(home=home) if steam_roots is None else steam_roots)
+
+    candidates = []
+
+    for steam_root in roots:
+        steam_root = Path(steam_root)
+        candidates.append(steam_root)
+
+        library_file = steam_root / "steamapps" / "libraryfolders.vdf"
+        candidates.extend(parse_libraryfolders(library_file))
+
+    return _unique_existing_directories(candidates)
+
+
+def _directory_children(path: Path) -> list[Path]:
+    """Return directory children safely and in a deterministic order."""
+    if not path.is_dir():
+        return []
+
+    try:
+        return sorted(
+            (child for child in path.iterdir() if child.is_dir()),
+            key=lambda child: child.name.casefold(),
+        )
+    except OSError:
+        return []
+
+
+def find_steam_proton_tools(
+    steam_roots: Iterable[Path] | None = None,
+    home: Path | None = None,
+) -> list[ProtonTool]:
+    """
+    Discover Proton builds installed for Steam.
+
+    Valve Proton builds are normally installed below
+    ``steamapps/common/Proton*``. User-installed compatibility tools such as
+    GE-Proton are normally installed below ``compatibilitytools.d``.
+
+    A candidate must contain a ``proton`` launcher file. Canonical paths are
+    used to prevent Steam symlink aliases from producing duplicate entries.
+    """
+    roots = list(find_steam_roots(home=home) if steam_roots is None else steam_roots)
+    libraries = find_steam_libraries(steam_roots=roots)
+
+    tools = []
+    seen_paths = set()
+
+    def add_tool(path: Path, source: str) -> None:
+        proton_launcher = path / "proton"
+
+        if not proton_launcher.is_file():
+            return
+
+        canonical_path = _canonical_path(path)
+
+        if canonical_path in seen_paths:
+            return
+
+        seen_paths.add(canonical_path)
+        tools.append(
+            ProtonTool(
+                name=path.name,
+                path=canonical_path,
+                source=source,
+            )
+        )
+
+    for library in libraries:
+        common_directory = library / "steamapps" / "common"
+
+        for candidate in _directory_children(common_directory):
+            if candidate.name.casefold().startswith("proton"):
+                add_tool(candidate, "steam")
+
+    for library in libraries:
+        compatibility_directory = library / "compatibilitytools.d"
+
+        for candidate in _directory_children(compatibility_directory):
+            add_tool(candidate, "custom")
+
+    return sorted(
+        tools,
+        key=lambda tool: (
+            tool.source != "steam",
+            tool.name.casefold(),
+            str(tool.path),
+        ),
+    )

--- a/minigalaxy/game.py
+++ b/minigalaxy/game.py
@@ -14,6 +14,8 @@ class InfoKey(str, Enum):
     CHECK_UPDATES = "check_for_updates"
     COMMAND = "command"
     CUSTOM_WINE = "custom_wine"
+    PROTON_PATH = "proton_path"
+    WINDOWS_RUNNER = "windows_runner"
     HIDE_GAME = "hide_game"
     MANGOHUD = "use_mangohud"
     SHOW_FPS = "show_fps"

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -21,7 +21,13 @@ from minigalaxy.file_info import FileInfo
 from minigalaxy.game import Game
 from minigalaxy.resources import get_data_file
 from minigalaxy.translation import _
-from minigalaxy.launcher import get_execute_commands, get_wine_path, wine_restore_game_link
+from minigalaxy.launcher import (
+    get_execute_commands,
+    get_windows_environment,
+    get_windows_runner,
+    uses_proton,
+    wine_restore_game_link,
+)
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, APPLICATIONS_DIR, DOWNLOAD_DIR
 
 
@@ -231,13 +237,11 @@ def extract_windows(game: Game, installer: str, language: str):
 
 
 def extract_by_wine(game, installer, game_lang, config=Config()):
-    # Set the prefix for Windows games
+    # Set the prefix and compatibility environment for Windows games.
     prefix_dir = os.path.join(game.install_dir, "prefix")
-    wine_env = [
-        f"WINEPREFIX={prefix_dir}",
-        "WINEDLLOVERRIDES=winemenubuilder.exe=d"
-    ]
-    wine_bin = get_wine_path(game)
+    windows_env = get_windows_environment(game)
+    windows_env.append("WINEDLLOVERRIDES=winemenubuilder.exe=d")
+    windows_runner = get_windows_runner(game)
 
     if not os.path.exists(prefix_dir):
         os.makedirs(prefix_dir, mode=0o755)
@@ -247,9 +251,30 @@ def extract_by_wine(game, installer, game_lang, config=Config()):
         So that it will also be disabled when patches, updates or dependencies like directx are installed
         later on by the game itself from within the prefix. Happened with UE4.
         '''
+        if uses_proton(game):
+            prefix_environment = get_windows_environment(game)
+            prefix_command = [
+                "env",
+                *prefix_environment,
+                windows_runner,
+                "",
+            ]
+            if not try_wine_command(prefix_command):
+                return _("Wineprefix creation failed.")
+
+        reg_environment = list(windows_env)
+        if uses_proton(game):
+            reg_environment.append("PROTON_VERB=runinprefix")
+
         reg_file_resource = get_data_file("wine_disable_menubuilder.reg")
         with as_file(reg_file_resource) as reg_file:
-            command = ["env", *wine_env, wine_bin, "regedit", str(reg_file.resolve())]
+            command = [
+                "env",
+                *reg_environment,
+                windows_runner,
+                "regedit",
+                str(reg_file.resolve()),
+            ]
             if not try_wine_command(command):
                 return _("Wineprefix creation failed.")
 
@@ -258,7 +283,7 @@ def extract_by_wine(game, installer, game_lang, config=Config()):
     wine_restore_game_link(game)
     # It's possible to set install dir as argument before installation
     installer_cmd_basic = [
-        'env', *wine_env, wine_bin, installer,
+        'env', *windows_env, windows_runner, installer,
         # use hard-coded directory name within wine, its just a backlink to game.install_dir
         # this avoids issues with varying path and spaces
         "/DIR=c:\\game",

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -26,6 +26,7 @@ from minigalaxy.launcher import (
     get_windows_environment,
     get_windows_runner,
     uses_proton,
+    validate_windows_compatibility,
     wine_restore_game_link,
 )
 from minigalaxy.paths import CACHE_DIR, THUMBNAIL_DIR, APPLICATIONS_DIR, DOWNLOAD_DIR
@@ -236,32 +237,56 @@ def extract_windows(game: Game, installer: str, language: str):
     return extract_by_wine(game, installer, game_lang), False
 
 
-def extract_by_wine(game, installer, game_lang, config=Config()):
+def extract_by_wine(game, installer, game_lang, config=Config()):  # noqa: C901
+    # Validate the selected backend before touching the game or prefix.
+    compatibility_error = validate_windows_compatibility(game)
+    if compatibility_error:
+        return compatibility_error
+
     # Set the prefix and compatibility environment for Windows games.
     prefix_dir = os.path.join(game.install_dir, "prefix")
     windows_env = get_windows_environment(game)
     windows_env.append("WINEDLLOVERRIDES=winemenubuilder.exe=d")
     windows_runner = get_windows_runner(game)
 
-    if not os.path.exists(prefix_dir):
-        os.makedirs(prefix_dir, mode=0o755)
-        '''
-        Creating the prefix before modifying dosdevices
-        Use regedit import as first command and try to disable the menubuilder for good
-        So that it will also be disabled when patches, updates or dependencies like directx are installed
-        later on by the game itself from within the prefix. Happened with UE4.
-        '''
+    prefix_exists = os.path.exists(prefix_dir)
+    prefix_initialized = prefix_exists
+
+    if uses_proton(game):
+        # Both Wine and Proton prefixes contain user.reg after successful
+        # initialization. Merely having an empty prefix directory is not
+        # enough, and may be residue from an interrupted earlier attempt.
+        prefix_initialized = os.path.isfile(
+            os.path.join(prefix_dir, "user.reg")
+        )
+
+    if not prefix_initialized:
         if uses_proton(game):
+            # UMU/Proton owns Proton-prefix creation. Do not pre-create the
+            # prefix directory as if it were a normal Wine prefix.
+            if prefix_exists and os.path.isdir(prefix_dir):
+                try:
+                    if not os.listdir(prefix_dir):
+                        os.rmdir(prefix_dir)
+                except OSError:
+                    pass
+
             prefix_environment = get_windows_environment(game)
             prefix_command = [
                 "env",
                 *prefix_environment,
                 windows_runner,
-                "",
+                "createprefix",
             ]
             if not try_wine_command(prefix_command):
-                return _("Wineprefix creation failed.")
+                return _("Proton prefix creation failed.")
+        elif not prefix_exists:
+            # Preserve MiniGalaxy's existing system/custom Wine behavior.
+            os.makedirs(prefix_dir, mode=0o755)
 
+        # Use regedit import as the first prefix-maintenance command and disable
+        # the menubuilder so it stays disabled when patches or dependencies are
+        # installed later by the game itself.
         reg_environment = list(windows_env)
         if uses_proton(game):
             reg_environment.append("PROTON_VERB=runinprefix")
@@ -276,6 +301,8 @@ def extract_by_wine(game, installer, game_lang, config=Config()):
                 str(reg_file.resolve()),
             ]
             if not try_wine_command(command):
+                if uses_proton(game):
+                    return _("Proton prefix configuration failed.")
                 return _("Wineprefix creation failed.")
 
     # calculate relative link prefix/c/game to game.install_dir

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -12,6 +12,11 @@ from minigalaxy.game import InfoKey
 from minigalaxy.launch_command import LaunchCommand
 from minigalaxy.translation import _
 from minigalaxy.constants import BINARY_NAMES_TO_IGNORE
+from minigalaxy.umu import (
+    MINIMUM_UMU_VERSION_TEXT,
+    find_compatible_umu,
+    get_umu_status,
+)
 
 
 def get_wine_path(game):
@@ -28,23 +33,11 @@ def uses_proton(game):
 
 
 def find_umu_run():
-    """
-    Return the UMU launcher executable without relying only on desktop PATH.
+    """Return a compatible UMU launcher, including MiniGalaxy's managed copy."""
+    installation = find_compatible_umu()
 
-    User installations of umu-launcher are officially placed in
-    ~/.local/bin/umu-run, which is not guaranteed to be present in the PATH of
-    a desktop-launched MiniGalaxy process.
-    """
-    umu_path = shutil.which("umu-run")
-    if umu_path:
-        return umu_path
-
-    user_umu_path = os.path.expanduser("~/.local/bin/umu-run")
-    if (
-        os.path.isfile(user_umu_path)
-        and os.access(user_umu_path, os.X_OK)
-    ):
-        return user_umu_path
+    if installation:
+        return installation.path
 
     return ""
 
@@ -74,10 +67,22 @@ def validate_windows_compatibility(game):
         ).format(proton_path)
 
     if not find_umu_run():
+        umu_status = get_umu_status()
+
+        if umu_status:
+            return _(
+                "UMU Launcher {} is installed, but version {} or newer "
+                "is required for Proton support."
+            ).format(
+                umu_status.version_text,
+                MINIMUM_UMU_VERSION_TEXT,
+            )
+
         return _(
-            "UMU Launcher (umu-run) is required to install and run games "
-            "with Proton through the Steam Linux Runtime, but it was not found."
-        )
+            "UMU Launcher (umu-run) version {} or newer is required to "
+            "install and run games with Proton through the Steam Linux "
+            "Runtime, but it was not found."
+        ).format(MINIMUM_UMU_VERSION_TEXT)
 
     return ""
 

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -22,6 +22,47 @@ def get_wine_path(game):
     return binary_name
 
 
+def uses_proton(game):
+    """Return True when the game is configured to use a specific Proton build."""
+    return (
+        game.get_info(InfoKey.WINDOWS_RUNNER) == "proton"
+        and bool(game.get_info(InfoKey.PROTON_PATH))
+    )
+
+
+def get_windows_runner(game):
+    """
+    Return the executable used to launch Windows programs for the game.
+
+    Wine remains the default. When Proton is explicitly selected, UMU is used
+    as the launcher and PROTONPATH selects the desired Proton installation.
+    """
+    if uses_proton(game):
+        return shutil.which("umu-run") or "umu-run"
+
+    return get_wine_path(game)
+
+
+def get_windows_environment(game):
+    """
+    Return environment assignments required by the selected Windows runner.
+
+    Keeping WINEPREFIX first preserves MiniGalaxy's existing Wine command
+    layout exactly. Proton adds the variables required by UMU after it.
+    """
+    prefix = os.path.join(game.install_dir, "prefix")
+    environment = [f"WINEPREFIX={prefix}"]
+
+    if uses_proton(game):
+        environment.extend([
+            f"PROTONPATH={game.get_info(InfoKey.PROTON_PATH)}",
+            "STORE=gog",
+            "GAMEID=0",
+        ])
+
+    return environment
+
+
 # should go into a separate file or into installer, but not possible ATM because
 # it's a circular import otherwise
 def wine_restore_game_link(game):
@@ -34,13 +75,15 @@ def wine_restore_game_link(game):
 
 
 def config_game(game):
-    prefix = os.path.join(game.install_dir, "prefix")
-    subprocess.Popen(['env', f'WINEPREFIX={prefix}', get_wine_path(game), 'winecfg'])
+    subprocess.Popen(
+        ['env', *get_windows_environment(game), get_windows_runner(game), 'winecfg']
+    )
 
 
 def regedit_game(game):
-    prefix = os.path.join(game.install_dir, "prefix")
-    subprocess.Popen(['env', f'WINEPREFIX={prefix}', get_wine_path(game), 'regedit'])
+    subprocess.Popen(
+        ['env', *get_windows_environment(game), get_windows_runner(game), 'regedit']
+    )
 
 
 def winetricks_game(game):
@@ -126,7 +169,7 @@ def get_windows_exe_cmd_from_goggame_info(game, file: str) -> List[str]:
             if "path" in task:
                 working_dir = task.get("workingDir", ".")
                 path = task["path"]
-                exe_cmd = [get_wine_path(game), "start", "/b", "/wait",
+                exe_cmd = [get_windows_runner(game), "start", "/b", "/wait",
                            "/d", f'c:\\game\\{working_dir}',
                            f'c:\\game\\{path}']
                 if "arguments" in task:
@@ -141,7 +184,6 @@ def get_windows_launch_commands(game, files) -> list[LaunchCommand]:
     '''Find game executable file'''
 
     launch_commands = []
-    prefix = os.path.join(game.install_dir, "prefix")
 
     # Get the execute command from the goggame info file
     goggame_file = os.path.join(game.install_dir, f'goggame-{game.id}.info')
@@ -153,7 +195,7 @@ def get_windows_launch_commands(game, files) -> list[LaunchCommand]:
     if not launch_commands and (launch_file_list := [file for file in files if re.match(r"^Launch .*\.lnk$", file)]):
         # Set Launch Game.lnk as executable
         launch_commands.append(LaunchCommand(
-            command=[get_wine_path(game), os.path.join(game.install_dir, launch_file_list[0])],
+            command=[get_windows_runner(game), os.path.join(game.install_dir, launch_file_list[0])],
             name=launch_file_list[0]
         ))
         logging.debug("using link file [%s] as execute command", launch_file_list[0])
@@ -168,15 +210,16 @@ def get_windows_launch_commands(game, files) -> list[LaunchCommand]:
             launch_commands.append(
                 LaunchCommand(
                     command=[
-                        get_wine_path(game), os.path.join(game.install_dir, file)
+                        get_windows_runner(game), os.path.join(game.install_dir, file)
                     ],
                     name=file
                 )
             )
 
-    # Add the wine prefix to every found command
+    # Add the compatibility environment to every found command.
+    environment = get_windows_environment(game)
     for launch_command in launch_commands:
-        launch_command.command = ['env', f'WINEPREFIX={prefix}'] + launch_command.command
+        launch_command.command = ['env', *environment] + launch_command.command
 
     # Backwards compatibility with windows games installed before installer fixes.
     # Will not fix games requiring registry keys, since the paths will already

--- a/minigalaxy/launcher.py
+++ b/minigalaxy/launcher.py
@@ -23,22 +23,74 @@ def get_wine_path(game):
 
 
 def uses_proton(game):
-    """Return True when the game is configured to use a specific Proton build."""
-    return (
-        game.get_info(InfoKey.WINDOWS_RUNNER) == "proton"
-        and bool(game.get_info(InfoKey.PROTON_PATH))
-    )
+    """Return True whenever Proton is explicitly selected for the game."""
+    return game.get_info(InfoKey.WINDOWS_RUNNER) == "proton"
+
+
+def find_umu_run():
+    """
+    Return the UMU launcher executable without relying only on desktop PATH.
+
+    User installations of umu-launcher are officially placed in
+    ~/.local/bin/umu-run, which is not guaranteed to be present in the PATH of
+    a desktop-launched MiniGalaxy process.
+    """
+    umu_path = shutil.which("umu-run")
+    if umu_path:
+        return umu_path
+
+    user_umu_path = os.path.expanduser("~/.local/bin/umu-run")
+    if (
+        os.path.isfile(user_umu_path)
+        and os.access(user_umu_path, os.X_OK)
+    ):
+        return user_umu_path
+
+    return ""
+
+
+def validate_windows_compatibility(game):
+    """
+    Validate the requirements of an explicitly selected compatibility backend.
+
+    Existing Wine behavior is intentionally unchanged. Proton is different:
+    selecting it is an explicit request that must never silently become Wine.
+    """
+    if not uses_proton(game):
+        return ""
+
+    proton_path = game.get_info(InfoKey.PROTON_PATH)
+
+    if not proton_path:
+        return _(
+            "Proton is selected for this game, but no Proton "
+            "compatibility tool is configured."
+        )
+
+    proton_launcher = os.path.join(proton_path, "proton")
+    if not os.path.isfile(proton_launcher):
+        return _(
+            "The selected Proton compatibility tool is unavailable: {}"
+        ).format(proton_path)
+
+    if not find_umu_run():
+        return _(
+            "UMU Launcher (umu-run) is required to install and run games "
+            "with Proton through the Steam Linux Runtime, but it was not found."
+        )
+
+    return ""
 
 
 def get_windows_runner(game):
     """
     Return the executable used to launch Windows programs for the game.
 
-    Wine remains the default. When Proton is explicitly selected, UMU is used
-    as the launcher and PROTONPATH selects the desired Proton installation.
+    Wine remains the default backend. Proton is a peer backend: when Proton is
+    selected, MiniGalaxy uses UMU and never falls back to host Wine.
     """
     if uses_proton(game):
-        return shutil.which("umu-run") or "umu-run"
+        return find_umu_run() or "umu-run"
 
     return get_wine_path(game)
 
@@ -74,16 +126,48 @@ def wine_restore_game_link(game):
         os.symlink(relative, game_dir)
 
 
+def get_windows_helper_environment(game):
+    """Return the compatibility environment for prefix maintenance tools."""
+    environment = get_windows_environment(game)
+
+    if uses_proton(game):
+        environment.append("PROTON_VERB=runinprefix")
+
+    return environment
+
+
 def config_game(game):
+    error_message = validate_windows_compatibility(game)
+    if error_message:
+        return error_message
+
     subprocess.Popen(
-        ['env', *get_windows_environment(game), get_windows_runner(game), 'winecfg']
+        [
+            "env",
+            *get_windows_helper_environment(game),
+            get_windows_runner(game),
+            "winecfg",
+        ]
     )
+
+    return ""
 
 
 def regedit_game(game):
+    error_message = validate_windows_compatibility(game)
+    if error_message:
+        return error_message
+
     subprocess.Popen(
-        ['env', *get_windows_environment(game), get_windows_runner(game), 'regedit']
+        [
+            "env",
+            *get_windows_helper_environment(game),
+            get_windows_runner(game),
+            "regedit",
+        ]
     )
+
+    return ""
 
 
 def winetricks_game(game):
@@ -96,6 +180,8 @@ def start_game(game, execute_command: LaunchCommand) -> str:
     process = None
     if not execute_command:
         error_message = "Cannot launch game, because no command to execute was specified"
+    if not error_message and game.platform == "windows":
+        error_message = validate_windows_compatibility(game)
     if not error_message:
         error_message = set_fps_display(game)
     if not error_message:

--- a/minigalaxy/ui/data/properties.ui
+++ b/minigalaxy/ui/data/properties.ui
@@ -35,7 +35,7 @@
                 <property name="spacing">6</property>
                 <property name="homogeneous">True</property>
                 <child>
-                  <!-- n-columns=2 n-rows=14 -->
+                  <!-- n-columns=2 n-rows=16 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -343,6 +343,49 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkLabel" id="label_properties_umu_runtime_title">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Runtime:</property>
+                        <property name="tooltip-text" translatable="yes">UMU Launcher runtime used to run Proton outside Steam</property>
+                        <property name="justify">fill</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">11</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_properties_umu_runtime">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="selectable">True</property>
+                        <property name="max-width-chars">45</property>
+                        <property name="ellipsize">middle</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">11</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_properties_umu_install">
+                        <property name="label" translatable="yes">Install UMU</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Install or update MiniGalaxy's verified user-level UMU Launcher runtime</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">12</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkButton" id="button_properties_compatibility_refresh">
                         <property name="label" translatable="yes">Refresh compatibility tools</property>
                         <property name="visible">True</property>
@@ -352,7 +395,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">11</property>
+                        <property name="top-attach">13</property>
                       </packing>
                     </child>
                     <child>
@@ -366,7 +409,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">13</property>
+                        <property name="top-attach">15</property>
                       </packing>
                     </child>
                     <child>
@@ -380,7 +423,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">12</property>
+                        <property name="top-attach">14</property>
                       </packing>
                     </child>
                     <child>
@@ -392,7 +435,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">12</property>
+                        <property name="top-attach">14</property>
                       </packing>
                     </child>
                     <child>

--- a/minigalaxy/ui/data/properties.ui
+++ b/minigalaxy/ui/data/properties.ui
@@ -35,7 +35,7 @@
                 <property name="spacing">6</property>
                 <property name="homogeneous">True</property>
                 <child>
-                  <!-- n-columns=2 n-rows=11 -->
+                  <!-- n-columns=2 n-rows=14 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -287,6 +287,75 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkLabel" id="label_properties_compatibility_tool">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Compatibility tool:</property>
+                        <property name="tooltip-text" translatable="yes">Select the Wine or Proton compatibility tool used for this game</property>
+                        <property name="justify">fill</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">9</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="combo_properties_compatibility">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="tooltip-text" translatable="yes">Select the Wine or Proton compatibility tool used for this game</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">9</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_properties_compatibility_path_title">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Compatibility path:</property>
+                        <property name="tooltip-text" translatable="yes">Filesystem path of the selected compatibility tool</property>
+                        <property name="justify">fill</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">10</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_properties_compatibility_path">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="selectable">True</property>
+                        <property name="max-width-chars">45</property>
+                        <property name="ellipsize">middle</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">10</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_properties_compatibility_refresh">
+                        <property name="label" translatable="yes">Refresh compatibility tools</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Scan Steam libraries again for installed Proton compatibility tools</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">11</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkButton" id="button_properties_reset">
                         <property name="label" translatable="yes">Reset wine executable</property>
                         <property name="visible">True</property>
@@ -297,7 +366,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">10</property>
+                        <property name="top-attach">13</property>
                       </packing>
                     </child>
                     <child>
@@ -311,7 +380,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">9</property>
+                        <property name="top-attach">12</property>
                       </packing>
                     </child>
                     <child>
@@ -323,7 +392,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">9</property>
+                        <property name="top-attach">12</property>
                       </packing>
                     </child>
                     <child>

--- a/minigalaxy/ui/data/properties.ui
+++ b/minigalaxy/ui/data/properties.ui
@@ -357,10 +357,10 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="button_properties_reset">
-                        <property name="label" translatable="yes">Reset wine executable</property>
+                        <property name="label" translatable="yes">Use System Wine</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
-                        <property name="tooltip-text" translatable="yes">Reset the wine executable for this game</property>
+                        <property name="tooltip-text" translatable="yes">Switch this game back to the system Wine backend</property>
                         <property name="receives-default">True</property>
                         <signal name="clicked" handler="on_button_properties_reset_clicked" swapped="no"/>
                       </object>
@@ -374,8 +374,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Wine executable:</property>
-                        <property name="tooltip-text" translatable="yes">Set Wine executable</property>
+                        <property name="label" translatable="yes">Custom Wine executable:</property>
+                        <property name="tooltip-text" translatable="yes">Select the executable used by the Custom Wine backend</property>
                         <property name="justify">fill</property>
                       </object>
                       <packing>
@@ -388,7 +388,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="title" translatable="yes"/>
-                        <property name="tooltip-text" translatable="yes">Set Wine executable</property>
+                        <property name="tooltip-text" translatable="yes">Select the executable used by the Custom Wine backend</property>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -13,6 +13,12 @@ from minigalaxy.game import InfoKey
 from minigalaxy.installer import create_applications_file
 from minigalaxy.translation import _
 from minigalaxy.launcher import config_game, regedit_game, winetricks_game
+from minigalaxy.umu import (
+    MINIMUM_UMU_VERSION_TEXT,
+    UmuInstallError,
+    get_umu_status,
+    install_managed_umu,
+)
 from minigalaxy.ui.gtk import Gtk, load_ui
 
 
@@ -42,6 +48,9 @@ class Properties(Gtk.Dialog):
     label_properties_compatibility_path_title = Gtk.Template.Child()
     label_properties_compatibility_path = Gtk.Template.Child()
     button_properties_compatibility_refresh = Gtk.Template.Child()
+    label_properties_umu_runtime_title = Gtk.Template.Child()
+    label_properties_umu_runtime = Gtk.Template.Child()
+    button_properties_umu_install = Gtk.Template.Child()
 
     def __init__(self, parent_library, game, config: Config, api):
         Gtk.Dialog.__init__(self, title=_("Properties of {}").format(game.name), parent=parent_library.parent_window,
@@ -60,6 +69,10 @@ class Properties(Gtk.Dialog):
         self.button_properties_compatibility_refresh.connect(
             "clicked",
             self._on_compatibility_refresh,
+        )
+        self.button_properties_umu_install.connect(
+            "clicked",
+            self._on_umu_install,
         )
         self.button_properties_wine.connect(
             "file-set",
@@ -193,6 +206,8 @@ class Properties(Gtk.Dialog):
             and is_custom_wine
         )
 
+        self._update_umu_controls(is_proton)
+
         # Proton is a peer backend, not a wrapper around the host Wine binary.
         # Do not leave Custom Wine controls visible while Proton is selected.
         self.label_wine_custom.set_visible(show_custom_wine)
@@ -251,6 +266,95 @@ class Properties(Gtk.Dialog):
             tooltip_text
         )
 
+    def _update_umu_controls(self, is_proton):
+        """Show UMU runtime status only for Proton compatibility backends."""
+        show_runtime = (
+            self.game.platform == "windows"
+            and is_proton
+        )
+
+        self.label_properties_umu_runtime_title.set_visible(
+            show_runtime
+        )
+        self.label_properties_umu_runtime.set_visible(
+            show_runtime
+        )
+
+        if not show_runtime:
+            self.button_properties_umu_install.hide()
+            return
+
+        status = get_umu_status()
+
+        if status and status.compatible:
+            runtime_text = _(
+                "UMU Launcher {} ✓"
+            ).format(status.version_text)
+            tooltip_text = _(
+                "Using {}\nUMU {} or newer is required for Proton."
+            ).format(
+                status.path,
+                MINIMUM_UMU_VERSION_TEXT,
+            )
+            self.button_properties_umu_install.hide()
+
+        elif status:
+            runtime_text = _(
+                "UMU Launcher {} — update required"
+            ).format(status.version_text)
+            tooltip_text = _(
+                "{}\nMiniGalaxy requires UMU {} or newer for Proton."
+            ).format(
+                status.path,
+                MINIMUM_UMU_VERSION_TEXT,
+            )
+            self.button_properties_umu_install.set_label(
+                _("Update UMU")
+            )
+            self.button_properties_umu_install.show()
+
+        else:
+            runtime_text = _(
+                "UMU Launcher not installed"
+            )
+            tooltip_text = _(
+                "MiniGalaxy requires UMU {} or newer for Proton and can "
+                "install a verified user-level copy automatically."
+            ).format(MINIMUM_UMU_VERSION_TEXT)
+            self.button_properties_umu_install.set_label(
+                _("Install UMU")
+            )
+            self.button_properties_umu_install.show()
+
+        self.label_properties_umu_runtime.set_text(
+            runtime_text
+        )
+        self.label_properties_umu_runtime.set_tooltip_text(
+            tooltip_text
+        )
+
+    def _ensure_umu_available(self):
+        """
+        Ensure Proton has a compatible UMU runtime before saving selection.
+
+        This is intentionally user-level and distro-independent: MiniGalaxy
+        downloads its pinned, checksum-verified upstream standalone zipapp.
+        """
+        status = get_umu_status()
+
+        if status and status.compatible:
+            return True
+
+        try:
+            install_managed_umu()
+        except UmuInstallError as error:
+            self.parent_window.show_error(str(error))
+            self._update_umu_controls(True)
+            return False
+
+        self._update_umu_controls(True)
+        return True
+
     def _save_compatibility_selection(self):
         """
         Persist the selected Windows compatibility tool for this game.
@@ -300,6 +404,9 @@ class Properties(Gtk.Dialog):
             return True
 
         if choice.choice_id.startswith(PROTON_CHOICE_PREFIX):
+            if not self._ensure_umu_available():
+                return False
+
             self.game.set_info(
                 InfoKey.WINDOWS_RUNNER,
                 "proton",
@@ -331,6 +438,9 @@ class Properties(Gtk.Dialog):
         self._populate_compatibility_tools(
             preferred_choice_id=current_choice_id,
         )
+
+    def _on_umu_install(self, button):
+        self._ensure_umu_available()
 
     def _on_custom_wine_file_set(self, button):
         if (
@@ -429,6 +539,9 @@ class Properties(Gtk.Dialog):
             self.label_properties_compatibility_path_title.hide()
             self.label_properties_compatibility_path.hide()
             self.button_properties_compatibility_refresh.hide()
+            self.label_properties_umu_runtime_title.hide()
+            self.label_properties_umu_runtime.hide()
+            self.button_properties_umu_install.hide()
             self.button_properties_regedit.hide()
             self.button_properties_winecfg.hide()
             self.button_properties_winetricks.hide()

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -174,7 +174,8 @@ class Properties(Gtk.Dialog):
 
     def _update_compatibility_controls(self):
         """
-        Update the path display and Wine-specific controls for the selection.
+        Update compatibility status and show only controls relevant to the
+        selected backend.
         """
         choice = self._selected_compatibility_choice()
 
@@ -187,25 +188,30 @@ class Properties(Gtk.Dialog):
         is_proton = choice.choice_id.startswith(
             PROTON_CHOICE_PREFIX
         )
+        show_custom_wine = (
+            self.game.platform == "windows"
+            and is_custom_wine
+        )
 
-        self.button_properties_wine.set_sensitive(
-            self.game.platform == "windows"
-            and is_custom_wine
-        )
-        self.button_properties_reset.set_sensitive(
-            self.game.platform == "windows"
-            and is_custom_wine
-        )
+        # Proton is a peer backend, not a wrapper around the host Wine binary.
+        # Do not leave Custom Wine controls visible while Proton is selected.
+        self.label_wine_custom.set_visible(show_custom_wine)
+        self.button_properties_wine.set_visible(show_custom_wine)
+        self.button_properties_reset.set_visible(show_custom_wine)
+        self.button_properties_wine.set_sensitive(show_custom_wine)
+        self.button_properties_reset.set_sensitive(show_custom_wine)
 
         # The existing Winetricks button invokes the host winetricks binary
-        # directly and is not Proton-aware. Do not allow it to accidentally
-        # modify a Proton-selected game until proper integration is added.
+        # directly and is not Proton-aware.
         if self.game.is_installed():
             self.button_properties_winetricks.set_sensitive(
                 not is_proton
             )
 
         if is_proton:
+            self.label_properties_compatibility_path_title.set_text(
+                _("Proton path:")
+            )
             display_path = choice.path
 
             if not choice.available:
@@ -213,23 +219,36 @@ class Properties(Gtk.Dialog):
                     choice.path
                 )
 
+            tooltip_text = _(
+                "{}\nThis Proton build is used through UMU and the "
+                "Steam Linux Runtime for both installation and launch."
+            ).format(display_path)
+
         elif is_custom_wine:
+            self.label_properties_compatibility_path_title.set_text(
+                _("Wine path:")
+            )
             display_path = (
                 self.button_properties_wine.get_filename()
                 or _("No Wine executable selected")
             )
+            tooltip_text = display_path
 
         else:
+            self.label_properties_compatibility_path_title.set_text(
+                _("Wine path:")
+            )
             display_path = (
                 shutil.which("wine")
                 or _("System Wine executable not found")
             )
+            tooltip_text = display_path
 
         self.label_properties_compatibility_path.set_text(
             display_path
         )
         self.label_properties_compatibility_path.set_tooltip_text(
-            display_path
+            tooltip_text
         )
 
     def _save_compatibility_selection(self):
@@ -357,7 +376,9 @@ class Properties(Gtk.Dialog):
 
     @Gtk.Template.Callback("on_button_properties_regedit_clicked")
     def on_menu_button_regedit(self, widget):
-        regedit_game(self.game)
+        error_message = regedit_game(self.game)
+        if error_message:
+            self.parent_window.show_error(error_message)
 
     @Gtk.Template.Callback("on_button_properties_reset_clicked")
     def on_menu_button_reset(self, widget):
@@ -373,7 +394,9 @@ class Properties(Gtk.Dialog):
 
     @Gtk.Template.Callback("on_button_properties_winecfg_clicked")
     def on_menu_button_winecfg(self, widget):
-        config_game(self.game)
+        error_message = config_game(self.game)
+        if error_message:
+            self.parent_window.show_error(error_message)
 
     @Gtk.Template.Callback("on_button_properties_winetricks_clicked")
     def on_menu_button_winetricks(self, widget):

--- a/minigalaxy/ui/properties.py
+++ b/minigalaxy/ui/properties.py
@@ -2,6 +2,13 @@ import shutil
 import subprocess
 
 from minigalaxy.config import Config
+from minigalaxy.compatibility import (
+    CUSTOM_WINE_CHOICE_ID,
+    PROTON_CHOICE_PREFIX,
+    SYSTEM_WINE_CHOICE_ID,
+    build_compatibility_choices,
+    selected_compatibility_choice_id,
+)
 from minigalaxy.game import InfoKey
 from minigalaxy.installer import create_applications_file
 from minigalaxy.translation import _
@@ -30,6 +37,11 @@ class Properties(Gtk.Dialog):
     button_properties_cancel = Gtk.Template.Child()
     button_properties_ok = Gtk.Template.Child()
     label_wine_custom = Gtk.Template.Child()
+    label_properties_compatibility_tool = Gtk.Template.Child()
+    combo_properties_compatibility = Gtk.Template.Child()
+    label_properties_compatibility_path_title = Gtk.Template.Child()
+    label_properties_compatibility_path = Gtk.Template.Child()
+    button_properties_compatibility_refresh = Gtk.Template.Child()
 
     def __init__(self, parent_library, game, config: Config, api):
         Gtk.Dialog.__init__(self, title=_("Properties of {}").format(game.name), parent=parent_library.parent_window,
@@ -39,6 +51,21 @@ class Properties(Gtk.Dialog):
         self.game = game
         self.config = config
         self.api = api
+        self._compatibility_choices = {}
+
+        self.combo_properties_compatibility.connect(
+            "changed",
+            self._on_compatibility_changed,
+        )
+        self.button_properties_compatibility_refresh.connect(
+            "clicked",
+            self._on_compatibility_refresh,
+        )
+        self.button_properties_wine.connect(
+            "file-set",
+            self._on_custom_wine_file_set,
+        )
+
         self.gamesdb_info = self.api.get_gamesdb_info(self.game)
 
         # Disable/Enable buttons
@@ -52,6 +79,9 @@ class Properties(Gtk.Dialog):
             self.button_properties_wine.set_filename(self.game.get_info(InfoKey.CUSTOM_WINE))
         elif shutil.which("wine"):
             self.button_properties_wine.set_filename(shutil.which("wine"))
+
+        if self.game.platform == "windows":
+            self._populate_compatibility_tools()
 
         # Keep switch FPS disabled/enabled
         self.switch_properties_show_fps.set_active(self.game.get_info(InfoKey.SHOW_FPS))
@@ -72,6 +102,224 @@ class Properties(Gtk.Dialog):
         # Center properties window
         self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
 
+    def _compatibility_choice_label(self, choice):
+        """Return the user-facing label for a compatibility choice."""
+        if choice.choice_id == SYSTEM_WINE_CHOICE_ID:
+            return _("System Wine")
+
+        if choice.choice_id == CUSTOM_WINE_CHOICE_ID:
+            return _("Custom Wine")
+
+        if choice.source == "steam":
+            return _("Steam — {}").format(choice.name)
+
+        if choice.source == "custom":
+            return _("Custom — {}").format(choice.name)
+
+        return _("Missing — {}").format(choice.name)
+
+    def _populate_compatibility_tools(self, preferred_choice_id=None):
+        """
+        Discover installed compatibility tools and populate the selector.
+
+        Discovery happens each time Properties is opened and whenever Refresh
+        is pressed. The currently configured missing Proton path is retained as
+        a visible unavailable choice instead of silently reverting to Wine.
+        """
+        choices = build_compatibility_choices(
+            selected_runner=self.game.get_info(InfoKey.WINDOWS_RUNNER),
+            selected_proton_path=self.game.get_info(InfoKey.PROTON_PATH),
+        )
+
+        self._compatibility_choices = {
+            choice.choice_id: choice
+            for choice in choices
+        }
+
+        self.combo_properties_compatibility.remove_all()
+
+        for choice in choices:
+            self.combo_properties_compatibility.append(
+                choice.choice_id,
+                self._compatibility_choice_label(choice),
+            )
+
+        configured_choice_id = selected_compatibility_choice_id(
+            selected_runner=self.game.get_info(InfoKey.WINDOWS_RUNNER),
+            selected_proton_path=self.game.get_info(InfoKey.PROTON_PATH),
+            custom_wine_path=self.game.get_info(InfoKey.CUSTOM_WINE),
+            system_wine_path=shutil.which("wine") or "",
+        )
+
+        if (
+            preferred_choice_id
+            and preferred_choice_id in self._compatibility_choices
+        ):
+            active_choice_id = preferred_choice_id
+        elif configured_choice_id in self._compatibility_choices:
+            active_choice_id = configured_choice_id
+        else:
+            active_choice_id = SYSTEM_WINE_CHOICE_ID
+
+        self.combo_properties_compatibility.set_active_id(
+            active_choice_id
+        )
+
+        self._update_compatibility_controls()
+
+    def _selected_compatibility_choice(self):
+        choice_id = self.combo_properties_compatibility.get_active_id()
+
+        return self._compatibility_choices.get(choice_id)
+
+    def _update_compatibility_controls(self):
+        """
+        Update the path display and Wine-specific controls for the selection.
+        """
+        choice = self._selected_compatibility_choice()
+
+        if not choice:
+            return
+
+        is_custom_wine = (
+            choice.choice_id == CUSTOM_WINE_CHOICE_ID
+        )
+        is_proton = choice.choice_id.startswith(
+            PROTON_CHOICE_PREFIX
+        )
+
+        self.button_properties_wine.set_sensitive(
+            self.game.platform == "windows"
+            and is_custom_wine
+        )
+        self.button_properties_reset.set_sensitive(
+            self.game.platform == "windows"
+            and is_custom_wine
+        )
+
+        # The existing Winetricks button invokes the host winetricks binary
+        # directly and is not Proton-aware. Do not allow it to accidentally
+        # modify a Proton-selected game until proper integration is added.
+        if self.game.is_installed():
+            self.button_properties_winetricks.set_sensitive(
+                not is_proton
+            )
+
+        if is_proton:
+            display_path = choice.path
+
+            if not choice.available:
+                display_path = _("Missing: {}").format(
+                    choice.path
+                )
+
+        elif is_custom_wine:
+            display_path = (
+                self.button_properties_wine.get_filename()
+                or _("No Wine executable selected")
+            )
+
+        else:
+            display_path = (
+                shutil.which("wine")
+                or _("System Wine executable not found")
+            )
+
+        self.label_properties_compatibility_path.set_text(
+            display_path
+        )
+        self.label_properties_compatibility_path.set_tooltip_text(
+            display_path
+        )
+
+    def _save_compatibility_selection(self):
+        """
+        Persist the selected Windows compatibility tool for this game.
+
+        This runs even for games which are not installed yet because the
+        compatibility choice must be available to the installer.
+        """
+        if self.game.platform != "windows":
+            return True
+
+        choice = self._selected_compatibility_choice()
+
+        if not choice:
+            self.parent_window.show_error(
+                _("No compatibility tool is selected.")
+            )
+            return False
+
+        if choice.choice_id == SYSTEM_WINE_CHOICE_ID:
+            self.game.set_info(InfoKey.WINDOWS_RUNNER, "")
+            self.game.set_info(InfoKey.PROTON_PATH, "")
+            self.game.set_info(InfoKey.CUSTOM_WINE, "")
+
+            return True
+
+        if choice.choice_id == CUSTOM_WINE_CHOICE_ID:
+            custom_wine_path = (
+                self.button_properties_wine.get_filename()
+            )
+
+            if not custom_wine_path:
+                self.parent_window.show_error(
+                    _(
+                        "Select a Wine executable before "
+                        "using Custom Wine."
+                    )
+                )
+                return False
+
+            self.game.set_info(InfoKey.WINDOWS_RUNNER, "")
+            self.game.set_info(InfoKey.PROTON_PATH, "")
+            self.game.set_info(
+                InfoKey.CUSTOM_WINE,
+                str(custom_wine_path),
+            )
+
+            return True
+
+        if choice.choice_id.startswith(PROTON_CHOICE_PREFIX):
+            self.game.set_info(
+                InfoKey.WINDOWS_RUNNER,
+                "proton",
+            )
+            self.game.set_info(
+                InfoKey.PROTON_PATH,
+                choice.path,
+            )
+
+            # Preserve any previously configured Custom Wine path. It is
+            # ignored while Proton is selected but remains available if the
+            # user later switches this game back to Custom Wine.
+            return True
+
+        self.parent_window.show_error(
+            _("The selected compatibility tool is invalid.")
+        )
+
+        return False
+
+    def _on_compatibility_changed(self, widget):
+        self._update_compatibility_controls()
+
+    def _on_compatibility_refresh(self, button):
+        current_choice_id = (
+            self.combo_properties_compatibility.get_active_id()
+        )
+
+        self._populate_compatibility_tools(
+            preferred_choice_id=current_choice_id,
+        )
+
+    def _on_custom_wine_file_set(self, button):
+        if (
+            self.combo_properties_compatibility.get_active_id()
+            == CUSTOM_WINE_CHOICE_ID
+        ):
+            self._update_compatibility_controls()
+
     @Gtk.Template.Callback("on_button_properties_cancel_clicked")
     def cancel_pressed(self, button):
         self.destroy()
@@ -79,6 +327,10 @@ class Properties(Gtk.Dialog):
     @Gtk.Template.Callback("on_button_properties_ok_clicked")
     def ok_pressed(self, button):
         game_installed = self.game.is_installed()
+
+        if not self._save_compatibility_selection():
+            return
+
         if game_installed:
             self.game.set_info(InfoKey.CHECK_UPDATES, self.switch_properties_check_for_updates.get_active())
             self.game.set_info(InfoKey.SHOW_FPS, self.switch_properties_show_fps.get_active())
@@ -96,7 +348,6 @@ class Properties(Gtk.Dialog):
             self.game.set_info(InfoKey.COMMAND, str(self.entry_properties_command.get_text()))
 
         self.game.set_info(InfoKey.HIDE_GAME, self.switch_properties_hide_game.get_active())
-        self.game.set_info(InfoKey.CUSTOM_WINE, str(self.button_properties_wine.get_filename()))
         self.parent_library.filter_library()
 
         if game_installed and self.config.create_applications_file:
@@ -110,7 +361,15 @@ class Properties(Gtk.Dialog):
 
     @Gtk.Template.Callback("on_button_properties_reset_clicked")
     def on_menu_button_reset(self, widget):
-        self.button_properties_wine.select_filename(shutil.which("wine"))
+        system_wine = shutil.which("wine")
+
+        if system_wine:
+            self.button_properties_wine.set_filename(system_wine)
+
+        self.combo_properties_compatibility.set_active_id(
+            SYSTEM_WINE_CHOICE_ID
+        )
+        self._update_compatibility_controls()
 
     @Gtk.Template.Callback("on_button_properties_winecfg_clicked")
     def on_menu_button_winecfg(self, widget):
@@ -142,6 +401,11 @@ class Properties(Gtk.Dialog):
             self.entry_properties_command.set_sensitive(False)
 
         if game.platform == 'linux':
+            self.label_properties_compatibility_tool.hide()
+            self.combo_properties_compatibility.hide()
+            self.label_properties_compatibility_path_title.hide()
+            self.label_properties_compatibility_path.hide()
+            self.button_properties_compatibility_refresh.hide()
             self.button_properties_regedit.hide()
             self.button_properties_winecfg.hide()
             self.button_properties_winetricks.hide()
@@ -149,5 +413,7 @@ class Properties(Gtk.Dialog):
             self.button_properties_reset.hide()
             self.label_wine_custom.hide()
         elif game.platform == 'windows':
+            self.combo_properties_compatibility.set_sensitive(True)
+            self.button_properties_compatibility_refresh.set_sensitive(True)
             self.button_properties_wine.set_sensitive(True)
             self.button_properties_reset.set_sensitive(True)

--- a/minigalaxy/umu.py
+++ b/minigalaxy/umu.py
@@ -1,0 +1,342 @@
+import hashlib
+import io
+import os
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from dataclasses import dataclass
+
+import requests
+
+from minigalaxy.translation import _
+
+
+MINIMUM_UMU_VERSION = (1, 4, 4)
+MINIMUM_UMU_VERSION_TEXT = "1.4.4"
+
+# Accept any compatible UMU already installed by the user/system. When
+# MiniGalaxy needs to provision UMU itself, use this pinned, tested upstream
+# standalone zipapp release and verify it before installation.
+MANAGED_UMU_VERSION = (1, 4, 4)
+MANAGED_UMU_VERSION_TEXT = "1.4.4"
+MANAGED_UMU_URL = (
+    "https://github.com/Open-Wine-Components/umu-launcher/releases/download/"
+    "1.4.4/umu-launcher-1.4.4-zipapp.tar"
+)
+MANAGED_UMU_SHA256 = (
+    "eb590691841f7fad3fc3ad8fd5db4ccb"
+    "87849fe7948e62b28ece7a4ee48cc851"
+)
+MANAGED_UMU_ARCHIVE_MEMBER = "umu/umu-run"
+MAX_MANAGED_UMU_ARCHIVE_BYTES = 8 * 1024 * 1024
+
+
+class UmuInstallError(RuntimeError):
+    """Raised when MiniGalaxy cannot provision its managed UMU launcher."""
+
+
+@dataclass(frozen=True)
+class UmuInstallation:
+    """A discovered UMU launcher and the version reported by that launcher."""
+
+    path: str
+    version: tuple[int, int, int] | None
+    source: str
+
+    @property
+    def compatible(self):
+        return (
+            self.version is not None
+            and self.version >= MINIMUM_UMU_VERSION
+        )
+
+    @property
+    def version_text(self):
+        if self.version is None:
+            return _("unknown")
+
+        return ".".join(str(part) for part in self.version)
+
+
+def get_managed_umu_path():
+    """Return the path reserved for MiniGalaxy's private UMU zipapp."""
+    data_home = os.getenv(
+        "XDG_DATA_HOME",
+        os.path.expanduser("~/.local/share"),
+    )
+
+    return os.path.join(
+        data_home,
+        "minigalaxy",
+        "umu",
+        "umu-run",
+    )
+
+
+def parse_umu_version(output):
+    """Parse the version emitted by ``umu-run --version``."""
+    if not output:
+        return None
+
+    match = re.search(
+        r"umu-launcher\s+version\s+"
+        r"(\d+)\.(\d+)\.(\d+)",
+        output,
+        flags=re.IGNORECASE,
+    )
+
+    if not match:
+        return None
+
+    return tuple(int(part) for part in match.groups())
+
+
+def get_umu_version(path):
+    """Ask an UMU executable for its semantic version."""
+    try:
+        result = subprocess.run(
+            [path, "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    return parse_umu_version(result.stdout)
+
+
+def _candidate_umu_paths():
+    """Yield unique UMU candidates in user-preferred discovery order."""
+    candidates = [
+        ("path", shutil.which("umu-run")),
+        (
+            "user",
+            os.path.expanduser("~/.local/bin/umu-run"),
+        ),
+        ("managed", get_managed_umu_path()),
+    ]
+
+    seen = set()
+
+    for source, path in candidates:
+        if not path:
+            continue
+
+        canonical_path = os.path.realpath(path)
+
+        if canonical_path in seen:
+            continue
+
+        seen.add(canonical_path)
+
+        if (
+            os.path.isfile(path)
+            and os.access(path, os.X_OK)
+        ):
+            yield source, path
+
+
+def find_umu_installations():
+    """Return every executable UMU candidate and its reported version."""
+    return [
+        UmuInstallation(
+            path=path,
+            version=get_umu_version(path),
+            source=source,
+        )
+        for source, path in _candidate_umu_paths()
+    ]
+
+
+def find_compatible_umu():
+    """Return the first UMU installation satisfying MiniGalaxy's minimum."""
+    for installation in find_umu_installations():
+        if installation.compatible:
+            return installation
+
+    return None
+
+
+def get_umu_status():
+    """
+    Return the UMU installation most useful to display in the UI.
+
+    A compatible launcher always wins. If only incompatible/unknown launchers
+    exist, return the first one so the UI can explain why an update is needed.
+    """
+    installations = find_umu_installations()
+
+    for installation in installations:
+        if installation.compatible:
+            return installation
+
+    if installations:
+        return installations[0]
+
+    return None
+
+
+def _download_managed_umu_archive():
+    """Download and checksum the pinned upstream UMU standalone archive."""
+    response = None
+
+    try:
+        response = requests.get(
+            MANAGED_UMU_URL,
+            stream=True,
+            timeout=30,
+        )
+        response.raise_for_status()
+    except requests.RequestException as error:
+        if response is not None:
+            response.close()
+
+        raise UmuInstallError(
+            _(
+                "Could not download UMU Launcher {}: {}"
+            ).format(
+                MANAGED_UMU_VERSION_TEXT,
+                error,
+            )
+        ) from error
+
+    payload = bytearray()
+
+    try:
+        for chunk in response.iter_content(chunk_size=64 * 1024):
+            if not chunk:
+                continue
+
+            payload.extend(chunk)
+
+            if len(payload) > MAX_MANAGED_UMU_ARCHIVE_BYTES:
+                raise UmuInstallError(
+                    _(
+                        "The UMU Launcher download was unexpectedly large "
+                        "and was rejected."
+                    )
+                )
+    finally:
+        response.close()
+
+    digest = hashlib.sha256(payload).hexdigest()
+
+    if digest != MANAGED_UMU_SHA256:
+        raise UmuInstallError(
+            _(
+                "UMU Launcher checksum verification failed. "
+                "The downloaded file was not installed."
+            )
+        )
+
+    return bytes(payload)
+
+
+def _read_umu_zipapp(archive_payload):
+    """Read only the standalone ``umu-run`` member from the verified tar."""
+    try:
+        with tarfile.open(
+            fileobj=io.BytesIO(archive_payload),
+            mode="r:",
+        ) as archive:
+            member = archive.getmember(
+                MANAGED_UMU_ARCHIVE_MEMBER
+            )
+
+            if not member.isfile():
+                raise UmuInstallError(
+                    _("The UMU Launcher archive is invalid.")
+                )
+
+            member_file = archive.extractfile(member)
+
+            if member_file is None:
+                raise UmuInstallError(
+                    _("The UMU Launcher archive is invalid.")
+                )
+
+            return member_file.read()
+
+    except (KeyError, tarfile.TarError) as error:
+        raise UmuInstallError(
+            _("The UMU Launcher archive is invalid.")
+        ) from error
+
+
+def install_managed_umu():
+    """
+    Ensure that a compatible UMU launcher is available.
+
+    Existing compatible system/user installations are respected. Otherwise,
+    MiniGalaxy installs a verified upstream standalone zipapp into its own XDG
+    data directory, requiring no root privileges or distro package manager.
+    """
+    compatible = find_compatible_umu()
+
+    if compatible:
+        return compatible
+
+    archive_payload = _download_managed_umu_archive()
+    executable_payload = _read_umu_zipapp(archive_payload)
+
+    destination = get_managed_umu_path()
+    destination_dir = os.path.dirname(destination)
+    os.makedirs(destination_dir, mode=0o755, exist_ok=True)
+
+    temporary_path = ""
+
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=destination_dir,
+            prefix=".umu-run.",
+            delete=False,
+        ) as temporary_file:
+            temporary_path = temporary_file.name
+            temporary_file.write(executable_payload)
+
+        os.chmod(temporary_path, 0o755)
+        os.replace(temporary_path, destination)
+        temporary_path = ""
+
+    except OSError as error:
+        raise UmuInstallError(
+            _(
+                "Could not install UMU Launcher in {}: {}"
+            ).format(
+                destination_dir,
+                error,
+            )
+        ) from error
+
+    finally:
+        if temporary_path and os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+
+    version = get_umu_version(destination)
+
+    if (
+        version is None
+        or version < MINIMUM_UMU_VERSION
+    ):
+        try:
+            os.unlink(destination)
+        except OSError:
+            pass
+
+        raise UmuInstallError(
+            _(
+                "The installed UMU Launcher could not be verified as "
+                "version {} or newer."
+            ).format(MINIMUM_UMU_VERSION_TEXT)
+        )
+
+    return UmuInstallation(
+        path=destination,
+        version=version,
+        source="managed",
+    )

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,144 @@
+import os
+import tempfile
+
+from pathlib import Path
+from unittest import TestCase
+
+from minigalaxy.compatibility import (
+    find_steam_libraries,
+    find_steam_proton_tools,
+    find_steam_roots,
+    parse_libraryfolders,
+)
+
+
+class TestCompatibility(TestCase):
+    def test_find_steam_roots_deduplicates_symlink_aliases(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            home = Path(temporary_directory)
+
+            steam_root = home / ".local" / "share" / "Steam"
+            steam_root.mkdir(parents=True)
+
+            steam_alias_directory = home / ".steam"
+            steam_alias_directory.mkdir()
+
+            os.symlink(steam_root, steam_alias_directory / "root")
+            os.symlink(steam_root, steam_alias_directory / "steam")
+
+            observed = find_steam_roots(home=home)
+
+            self.assertEqual([steam_root.resolve()], observed)
+
+    def test_parse_libraryfolders_missing_file(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            missing_file = Path(temporary_directory) / "libraryfolders.vdf"
+
+            self.assertEqual([], parse_libraryfolders(missing_file))
+
+    def test_find_steam_libraries_parses_secondary_library(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            steam_root = root / "Steam"
+            secondary_library = root / "Games" / "Steam Library"
+
+            (steam_root / "steamapps").mkdir(parents=True)
+            secondary_library.mkdir(parents=True)
+
+            library_file = steam_root / "steamapps" / "libraryfolders.vdf"
+            library_file.write_text(
+                '"libraryfolders"\n'
+                '{\n'
+                '\t"0"\n'
+                '\t{\n'
+                f'\t\t"path"\t\t"{steam_root}"\n'
+                '\t}\n'
+                '\t"1"\n'
+                '\t{\n'
+                f'\t\t"path"\t\t"{secondary_library}"\n'
+                '\t}\n'
+                '}\n',
+                encoding="utf-8",
+            )
+
+            observed = find_steam_libraries(steam_roots=[steam_root])
+
+            self.assertEqual(
+                [
+                    steam_root.resolve(),
+                    secondary_library.resolve(),
+                ],
+                observed,
+            )
+
+    def test_find_steam_proton_tools_discovers_valve_tools(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            steam_root = Path(temporary_directory) / "Steam"
+            common_directory = steam_root / "steamapps" / "common"
+            common_directory.mkdir(parents=True)
+
+            proton_names = [
+                "Proton 9.0 (Beta)",
+                "Proton - Experimental",
+                "Proton Hotfix",
+            ]
+
+            for proton_name in proton_names:
+                proton_directory = common_directory / proton_name
+                proton_directory.mkdir()
+                (proton_directory / "proton").touch()
+
+            unrelated_directory = common_directory / "Some Game"
+            unrelated_directory.mkdir()
+            (unrelated_directory / "proton").touch()
+
+            observed = find_steam_proton_tools(steam_roots=[steam_root])
+
+            self.assertEqual(
+                sorted(proton_names, key=str.casefold),
+                [tool.name for tool in observed],
+            )
+            self.assertTrue(all(tool.source == "steam" for tool in observed))
+
+    def test_find_steam_proton_tools_discovers_custom_tools(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            steam_root = Path(temporary_directory) / "Steam"
+            steam_root.mkdir()
+
+            compatibility_directory = steam_root / "compatibilitytools.d"
+            compatibility_directory.mkdir()
+
+            ge_proton = compatibility_directory / "GE-Proton10-20"
+            ge_proton.mkdir()
+            (ge_proton / "proton").touch()
+
+            observed = find_steam_proton_tools(steam_roots=[steam_root])
+
+            self.assertEqual(1, len(observed))
+            self.assertEqual("GE-Proton10-20", observed[0].name)
+            self.assertEqual(ge_proton.resolve(), observed[0].path)
+            self.assertEqual("custom", observed[0].source)
+
+    def test_find_steam_proton_tools_deduplicates_steam_aliases(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            home = Path(temporary_directory)
+
+            steam_root = home / ".local" / "share" / "Steam"
+            common_directory = steam_root / "steamapps" / "common"
+            common_directory.mkdir(parents=True)
+
+            proton_directory = common_directory / "Proton - Experimental"
+            proton_directory.mkdir()
+            (proton_directory / "proton").touch()
+
+            steam_alias_directory = home / ".steam"
+            steam_alias_directory.mkdir()
+
+            os.symlink(steam_root, steam_alias_directory / "root")
+            os.symlink(steam_root, steam_alias_directory / "steam")
+
+            observed = find_steam_proton_tools(home=home)
+
+            self.assertEqual(1, len(observed))
+            self.assertEqual("Proton - Experimental", observed[0].name)
+            self.assertEqual(proton_directory.resolve(), observed[0].path)

--- a/tests/test_compatibility_choices.py
+++ b/tests/test_compatibility_choices.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+from unittest import TestCase
+
+from minigalaxy.compatibility import (
+    CUSTOM_WINE_CHOICE_ID,
+    PROTON_CHOICE_PREFIX,
+    SYSTEM_WINE_CHOICE_ID,
+    ProtonTool,
+    build_compatibility_choices,
+    selected_compatibility_choice_id,
+)
+
+
+class TestCompatibilityChoices(TestCase):
+
+    def test_build_choices_includes_wine_and_discovered_proton(self):
+        tools = [
+            ProtonTool(
+                name="Proton - Experimental",
+                path=Path("/steam/Proton - Experimental"),
+                source="steam",
+            ),
+            ProtonTool(
+                name="GE-Proton10-1",
+                path=Path("/steam/compatibilitytools.d/GE-Proton10-1"),
+                source="custom",
+            ),
+        ]
+
+        choices = build_compatibility_choices(
+            proton_tools=tools,
+        )
+
+        self.assertEqual(
+            SYSTEM_WINE_CHOICE_ID,
+            choices[0].choice_id,
+        )
+        self.assertEqual(
+            CUSTOM_WINE_CHOICE_ID,
+            choices[1].choice_id,
+        )
+
+        self.assertEqual("proton", choices[2].kind)
+        self.assertEqual("steam", choices[2].source)
+        self.assertEqual(
+            "/steam/Proton - Experimental",
+            choices[2].path,
+        )
+
+        self.assertEqual("proton", choices[3].kind)
+        self.assertEqual("custom", choices[3].source)
+        self.assertEqual(
+            "/steam/compatibilitytools.d/GE-Proton10-1",
+            choices[3].path,
+        )
+
+    def test_missing_configured_proton_is_retained(self):
+        choices = build_compatibility_choices(
+            proton_tools=[],
+            selected_runner="proton",
+            selected_proton_path="/removed/Proton 9.0",
+        )
+
+        missing = choices[-1]
+
+        self.assertEqual("proton", missing.kind)
+        self.assertEqual("missing", missing.source)
+        self.assertFalse(missing.available)
+        self.assertEqual(
+            "/removed/Proton 9.0",
+            missing.path,
+        )
+
+    def test_system_wine_is_default(self):
+        choice_id = selected_compatibility_choice_id(
+            selected_runner="",
+            selected_proton_path="",
+            custom_wine_path="",
+            system_wine_path="/usr/bin/wine",
+        )
+
+        self.assertEqual(
+            SYSTEM_WINE_CHOICE_ID,
+            choice_id,
+        )
+
+    def test_system_wine_path_is_not_treated_as_custom_wine(self):
+        choice_id = selected_compatibility_choice_id(
+            selected_runner="",
+            selected_proton_path="",
+            custom_wine_path="/usr/bin/wine",
+            system_wine_path="/usr/bin/wine",
+        )
+
+        self.assertEqual(
+            SYSTEM_WINE_CHOICE_ID,
+            choice_id,
+        )
+
+    def test_legacy_custom_wine_is_preserved(self):
+        choice_id = selected_compatibility_choice_id(
+            selected_runner="",
+            selected_proton_path="",
+            custom_wine_path="/opt/wine-custom/bin/wine",
+            system_wine_path="/usr/bin/wine",
+        )
+
+        self.assertEqual(
+            CUSTOM_WINE_CHOICE_ID,
+            choice_id,
+        )
+
+    def test_configured_proton_path_selects_exact_tool(self):
+        choice_id = selected_compatibility_choice_id(
+            selected_runner="proton",
+            selected_proton_path="/steam/Proton - Experimental",
+            custom_wine_path="/opt/wine-custom/bin/wine",
+            system_wine_path="/usr/bin/wine",
+        )
+
+        self.assertEqual(
+            f"{PROTON_CHOICE_PREFIX}"
+            "/steam/Proton - Experimental",
+            choice_id,
+        )

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -409,6 +409,12 @@ class Test(TestCase):
                 key,
                 default_value,
             ),
+        ), mock.patch(
+            "minigalaxy.installer.validate_windows_compatibility",
+            return_value="",
+        ), mock.patch(
+            "os.path.isfile",
+            return_value=True,
         ):
             observed = installer.extract_by_wine(
                 game,
@@ -495,6 +501,9 @@ class Test(TestCase):
                 key,
                 default_value,
             ),
+        ), mock.patch(
+            "minigalaxy.installer.validate_windows_compatibility",
+            return_value="",
         ):
             observed = installer.extract_by_wine(
                 game,
@@ -509,7 +518,7 @@ class Test(TestCase):
             "STORE=gog",
             "GAMEID=0",
             "/usr/bin/umu-run",
-            "",
+            "createprefix",
         ]
 
         expected_regedit_command = [
@@ -553,7 +562,8 @@ class Test(TestCase):
         ])
         self.assertEqual(3, mock_try_command.call_count)
 
-        mock_makedirs.assert_called_once_with(prefix, mode=0o755)
+        # UMU/Proton owns creation of a Proton prefix directory.
+        mock_makedirs.assert_not_called()
         mock_restore_link.assert_called_once_with(game)
 
     @mock.patch('subprocess.Popen')
@@ -837,3 +847,140 @@ class Test(TestCase):
         mock_isempty.side_effect = lambda path: mock_isdir(path) and len(file_structure.get(path)) == 0
         mock_rmdir.side_effect = rmdir_fake
         mock_remove.side_effect = remove_fake
+
+    def test_extract_by_wine_stops_on_proton_validation_error(self):
+        game = Game(
+            "Test Game",
+            install_dir="/home/test/GOG Games/Test Game",
+            platform="windows",
+        )
+        expected = (
+            "UMU Launcher (umu-run) is required to install and run games "
+            "with Proton through the Steam Linux Runtime, but it was not found."
+        )
+
+        with mock.patch(
+            "minigalaxy.installer.validate_windows_compatibility",
+            return_value=expected,
+        ), mock.patch(
+            "minigalaxy.installer.try_wine_command",
+        ) as mock_try_command, mock.patch(
+            "os.makedirs",
+        ) as mock_makedirs:
+            observed = installer.extract_by_wine(
+                game,
+                "/cache/setup.exe",
+                "en-US",
+            )
+
+        self.assertEqual(expected, observed)
+        mock_try_command.assert_not_called()
+        mock_makedirs.assert_not_called()
+
+    def test_extract_by_wine_recovers_empty_existing_proton_prefix(self):
+        game = Game(
+            "Test Game",
+            install_dir="/home/test/GOG Games/Test Game",
+            platform="windows",
+        )
+        prefix = "/home/test/GOG Games/Test Game/prefix"
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(
+                key,
+                default_value,
+            ),
+        ), mock.patch(
+            "minigalaxy.installer.validate_windows_compatibility",
+            return_value="",
+        ), mock.patch(
+            "minigalaxy.launcher.find_umu_run",
+            return_value="/usr/bin/umu-run",
+        ), mock.patch(
+            "os.path.exists",
+            return_value=True,
+        ), mock.patch(
+            "os.path.isfile",
+            return_value=False,
+        ), mock.patch(
+            "os.path.isdir",
+            return_value=True,
+        ), mock.patch(
+            "os.listdir",
+            return_value=[],
+        ), mock.patch(
+            "os.rmdir",
+        ) as mock_rmdir, mock.patch(
+            "minigalaxy.installer.try_wine_command",
+            return_value=False,
+        ) as mock_try_command:
+            observed = installer.extract_by_wine(
+                game,
+                "/cache/setup.exe",
+                "en-US",
+            )
+
+        expected_prefix_command = [
+            "env",
+            f"WINEPREFIX={prefix}",
+            "PROTONPATH=/steam/Proton - Experimental",
+            "STORE=gog",
+            "GAMEID=0",
+            "/usr/bin/umu-run",
+            "createprefix",
+        ]
+
+        self.assertEqual("Proton prefix creation failed.", observed)
+        mock_rmdir.assert_called_once_with(prefix)
+        mock_try_command.assert_called_once_with(expected_prefix_command)
+
+    def test_extract_by_wine_proton_does_not_require_host_wine(self):
+        game = Game(
+            "Test Game",
+            install_dir="/home/test/GOG Games/Test Game",
+            platform="windows",
+        )
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(
+                key,
+                default_value,
+            ),
+        ), mock.patch(
+            "minigalaxy.installer.validate_windows_compatibility",
+            return_value="",
+        ), mock.patch(
+            "minigalaxy.launcher.find_umu_run",
+            return_value="/usr/bin/umu-run",
+        ), mock.patch(
+            "minigalaxy.launcher.get_wine_path",
+        ) as mock_get_wine_path, mock.patch(
+            "os.path.exists",
+            return_value=False,
+        ), mock.patch(
+            "os.path.isfile",
+            return_value=False,
+        ), mock.patch(
+            "minigalaxy.installer.try_wine_command",
+            return_value=False,
+        ):
+            observed = installer.extract_by_wine(
+                game,
+                "/cache/setup.exe",
+                "en-US",
+            )
+
+        self.assertEqual("Proton prefix creation failed.", observed)
+        mock_get_wine_path.assert_not_called()

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -6,7 +6,7 @@ from unittest import TestCase, mock
 from unittest.mock import patch, mock_open, MagicMock, call
 
 from minigalaxy.file_info import FileInfo
-from minigalaxy.game import Game
+from minigalaxy.game import Game, InfoKey
 from minigalaxy import installer
 from minigalaxy.translation import _
 
@@ -322,6 +322,239 @@ class Test(TestCase):
         exp = "Wine extraction failed."
         obs = installer.extract_by_wine(game, installer_path, temp_dir)
         self.assertEqual(exp, obs)
+
+    @mock.patch("minigalaxy.installer.wine_restore_game_link")
+    @mock.patch("minigalaxy.installer.try_wine_command", return_value=True)
+    @mock.patch("os.path.exists", return_value=True)
+    def test_extract_by_wine_preserves_wine_command(
+        self,
+        mock_exists,
+        mock_try_command,
+        mock_restore_link,
+    ):
+        """
+        The default Wine path must produce the same installer command as before
+        Proton support was introduced.
+        """
+        game = Game(
+            "Absolute Drift",
+            install_dir="/home/makson/GOG Games/Absolute Drift",
+            platform="windows",
+        )
+        installer_path = (
+            "/home/makson/.cache/minigalaxy/download/Absolute Drift/"
+            "setup_absolute_drift_1.0f_(64bit)_(47863).exe"
+        )
+
+        observed = installer.extract_by_wine(
+            game,
+            installer_path,
+            "en-US",
+        )
+
+        expected_command = [
+            "env",
+            "WINEPREFIX=/home/makson/GOG Games/Absolute Drift/prefix",
+            "WINEDLLOVERRIDES=winemenubuilder.exe=d",
+            "wine",
+            installer_path,
+            "/DIR=c:\\game",
+            "/LANG=en-US",
+            "/LOG=c:\\install.log",
+            "/SAVEINF=c:\\setup.inf",
+            "/SP-",
+            "/SILENT",
+            "/NORESTART",
+            "/SUPPRESSMSGBOXES",
+        ]
+
+        self.assertEqual("", observed)
+        mock_try_command.assert_called_once_with(expected_command)
+        mock_restore_link.assert_called_once_with(game)
+
+    @mock.patch("minigalaxy.installer.wine_restore_game_link")
+    @mock.patch("minigalaxy.installer.try_wine_command", return_value=True)
+    @mock.patch(
+        "minigalaxy.launcher.shutil.which",
+        return_value="/usr/bin/umu-run",
+    )
+    @mock.patch("os.path.exists", return_value=True)
+    def test_extract_by_wine_uses_umu_for_existing_proton_prefix(
+        self,
+        mock_exists,
+        mock_which,
+        mock_try_command,
+        mock_restore_link,
+    ):
+        """An existing Proton prefix should install directly through UMU."""
+        game = Game(
+            "Absolute Drift",
+            install_dir="/home/makson/GOG Games/Absolute Drift",
+            platform="windows",
+        )
+        installer_path = (
+            "/home/makson/.cache/minigalaxy/download/Absolute Drift/"
+            "setup_absolute_drift_1.0f_(64bit)_(47863).exe"
+        )
+
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(
+                key,
+                default_value,
+            ),
+        ):
+            observed = installer.extract_by_wine(
+                game,
+                installer_path,
+                "en-US",
+            )
+
+        expected_command = [
+            "env",
+            "WINEPREFIX=/home/makson/GOG Games/Absolute Drift/prefix",
+            "PROTONPATH=/steam/Proton - Experimental",
+            "STORE=gog",
+            "GAMEID=0",
+            "WINEDLLOVERRIDES=winemenubuilder.exe=d",
+            "/usr/bin/umu-run",
+            installer_path,
+            "/DIR=c:\\game",
+            "/LANG=en-US",
+            "/LOG=c:\\install.log",
+            "/SAVEINF=c:\\setup.inf",
+            "/SP-",
+            "/SILENT",
+            "/NORESTART",
+            "/SUPPRESSMSGBOXES",
+        ]
+
+        self.assertEqual("", observed)
+        mock_try_command.assert_called_once_with(expected_command)
+        mock_restore_link.assert_called_once_with(game)
+
+    @mock.patch("minigalaxy.installer.as_file")
+    @mock.patch("minigalaxy.installer.get_data_file")
+    @mock.patch("minigalaxy.installer.wine_restore_game_link")
+    @mock.patch("minigalaxy.installer.try_wine_command", return_value=True)
+    @mock.patch(
+        "minigalaxy.launcher.shutil.which",
+        return_value="/usr/bin/umu-run",
+    )
+    @mock.patch("os.makedirs")
+    @mock.patch("os.path.exists", return_value=False)
+    def test_extract_by_wine_initializes_new_proton_prefix(
+        self,
+        mock_exists,
+        mock_makedirs,
+        mock_which,
+        mock_try_command,
+        mock_restore_link,
+        mock_get_data_file,
+        mock_as_file,
+    ):
+        """
+        A new Proton prefix should be initialized by UMU before regedit and
+        the GOG installer are executed.
+        """
+        game = Game(
+            "Absolute Drift",
+            install_dir="/home/makson/GOG Games/Absolute Drift",
+            platform="windows",
+        )
+        installer_path = (
+            "/home/makson/.cache/minigalaxy/download/Absolute Drift/"
+            "setup_absolute_drift_1.0f_(64bit)_(47863).exe"
+        )
+        prefix = "/home/makson/GOG Games/Absolute Drift/prefix"
+
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+
+        fake_resource = MagicMock()
+        fake_reg_file = MagicMock()
+        fake_reg_file.resolve.return_value = (
+            "/test/wine_disable_menubuilder.reg"
+        )
+
+        mock_get_data_file.return_value = fake_resource
+        mock_as_file.return_value.__enter__.return_value = fake_reg_file
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(
+                key,
+                default_value,
+            ),
+        ):
+            observed = installer.extract_by_wine(
+                game,
+                installer_path,
+                "en-US",
+            )
+
+        expected_prefix_command = [
+            "env",
+            f"WINEPREFIX={prefix}",
+            "PROTONPATH=/steam/Proton - Experimental",
+            "STORE=gog",
+            "GAMEID=0",
+            "/usr/bin/umu-run",
+            "",
+        ]
+
+        expected_regedit_command = [
+            "env",
+            f"WINEPREFIX={prefix}",
+            "PROTONPATH=/steam/Proton - Experimental",
+            "STORE=gog",
+            "GAMEID=0",
+            "WINEDLLOVERRIDES=winemenubuilder.exe=d",
+            "PROTON_VERB=runinprefix",
+            "/usr/bin/umu-run",
+            "regedit",
+            "/test/wine_disable_menubuilder.reg",
+        ]
+
+        expected_installer_command = [
+            "env",
+            f"WINEPREFIX={prefix}",
+            "PROTONPATH=/steam/Proton - Experimental",
+            "STORE=gog",
+            "GAMEID=0",
+            "WINEDLLOVERRIDES=winemenubuilder.exe=d",
+            "/usr/bin/umu-run",
+            installer_path,
+            "/DIR=c:\\game",
+            "/LANG=en-US",
+            "/LOG=c:\\install.log",
+            "/SAVEINF=c:\\setup.inf",
+            "/SP-",
+            "/SILENT",
+            "/NORESTART",
+            "/SUPPRESSMSGBOXES",
+        ]
+
+        self.assertEqual("", observed)
+
+        mock_try_command.assert_has_calls([
+            call(expected_prefix_command),
+            call(expected_regedit_command),
+            call(expected_installer_command),
+        ])
+        self.assertEqual(3, mock_try_command.call_count)
+
+        mock_makedirs.assert_called_once_with(prefix, mode=0o755)
+        mock_restore_link.assert_called_once_with(game)
 
     @mock.patch('subprocess.Popen')
     @mock.patch("os.path.isfile")

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -3,7 +3,7 @@ from unittest import TestCase, mock
 from unittest.mock import MagicMock, mock_open
 
 from minigalaxy import launcher
-from minigalaxy.game import Game
+from minigalaxy.game import Game, InfoKey
 from minigalaxy.launch_command import LaunchCommand
 
 
@@ -431,3 +431,152 @@ makson   12866  1378  0 18:09 pts/4    00:00:00 /bin/sh /home/makson/.paradoxlau
         exp = ""
         obs = launcher.check_if_game_start_process_spawned_final_process(err_msg, game)
         self.assertEqual(exp, obs)
+
+    def test_get_windows_environment_defaults_to_wine(self):
+        game = Game("Test Game", install_dir="/test/install/dir")
+
+        with mock.patch.object(game, "get_info", return_value=""):
+            observed = launcher.get_windows_environment(game)
+
+        expected = [
+            "WINEPREFIX=/test/install/dir/prefix",
+        ]
+
+        self.assertEqual(expected, observed)
+
+    def test_get_windows_environment_proton(self):
+        game = Game("Test Game", install_dir="/test/install/dir")
+
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(key, default_value),
+        ):
+            observed = launcher.get_windows_environment(game)
+
+        expected = [
+            "WINEPREFIX=/test/install/dir/prefix",
+            "PROTONPATH=/steam/Proton - Experimental",
+            "STORE=gog",
+            "GAMEID=0",
+        ]
+
+        self.assertEqual(expected, observed)
+
+    def test_get_windows_runner_uses_umu_for_proton(self):
+        game = Game("Test Game", install_dir="/test/install/dir")
+
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(key, default_value),
+        ), mock.patch(
+            "minigalaxy.launcher.shutil.which",
+            return_value="/usr/bin/umu-run",
+        ):
+            observed = launcher.get_windows_runner(game)
+
+        self.assertEqual("/usr/bin/umu-run", observed)
+
+    def test_get_windows_launch_commands_proton(self):
+        files = [
+            "unins000.exe",
+            "start.exe",
+        ]
+
+        game = Game("Test Game", install_dir="/test/install/dir")
+
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(key, default_value),
+        ), mock.patch(
+            "minigalaxy.launcher.shutil.which",
+            return_value="/usr/bin/umu-run",
+        ), mock.patch(
+            "minigalaxy.launcher.wine_restore_game_link"
+        ):
+            observed = launcher.get_windows_launch_commands(game, files)
+
+        expected = [
+            LaunchCommand(
+                name="start.exe",
+                command=[
+                    "env",
+                    "WINEPREFIX=/test/install/dir/prefix",
+                    "PROTONPATH=/steam/Proton - Experimental",
+                    "STORE=gog",
+                    "GAMEID=0",
+                    "/usr/bin/umu-run",
+                    "/test/install/dir/start.exe",
+                ],
+            )
+        ]
+
+        self.assertEqual(expected, observed)
+
+    def test_get_windows_exe_cmd_from_goggame_info_proton(self):
+        game = Game("Test Game", install_dir="/test/install/dir")
+
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+
+        goggame_info = """{
+            "playTasks": [
+                {
+                    "isPrimary": true,
+                    "workingDir": "bin",
+                    "path": "game.exe",
+                    "arguments": "--foo bar"
+                }
+            ]
+        }"""
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(key, default_value),
+        ), mock.patch(
+            "minigalaxy.launcher.shutil.which",
+            return_value="/usr/bin/umu-run",
+        ), mock.patch(
+            "minigalaxy.launcher.os.chdir"
+        ), mock.patch(
+            "builtins.open",
+            mock_open(read_data=goggame_info),
+        ):
+            observed = launcher.get_windows_exe_cmd_from_goggame_info(
+                game,
+                "/test/install/dir/goggame-0.info",
+            )
+
+        expected = [
+            "/usr/bin/umu-run",
+            "start",
+            "/b",
+            "/wait",
+            "/d",
+            "c:\\game\\bin",
+            "c:\\game\\game.exe",
+            "--foo",
+            "bar",
+        ]
+
+        self.assertEqual(expected, observed)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -580,3 +580,227 @@ makson   12866  1378  0 18:09 pts/4    00:00:00 /bin/sh /home/makson/.paradoxlau
         ]
 
         self.assertEqual(expected, observed)
+
+    def test_uses_proton_even_when_proton_path_is_empty(self):
+        game = Game(
+            "Test Game",
+            install_dir="/test/install/dir",
+            platform="windows",
+        )
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(
+                key,
+                default_value,
+            ),
+        ):
+            self.assertTrue(launcher.uses_proton(game))
+
+    def test_get_windows_runner_proton_never_calls_wine(self):
+        game = Game(
+            "Test Game",
+            install_dir="/test/install/dir",
+            platform="windows",
+        )
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(
+                key,
+                default_value,
+            ),
+        ), mock.patch(
+            "minigalaxy.launcher.find_umu_run",
+            return_value="/home/test/.local/bin/umu-run",
+        ), mock.patch(
+            "minigalaxy.launcher.get_wine_path",
+        ) as mock_get_wine_path:
+            observed = launcher.get_windows_runner(game)
+
+        self.assertEqual(
+            "/home/test/.local/bin/umu-run",
+            observed,
+        )
+        mock_get_wine_path.assert_not_called()
+
+    def test_validate_proton_requires_configured_path(self):
+        game = Game(
+            "Test Game",
+            install_dir="/test/install/dir",
+            platform="windows",
+        )
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(
+                key,
+                default_value,
+            ),
+        ):
+            observed = launcher.validate_windows_compatibility(game)
+
+        self.assertEqual(
+            "Proton is selected for this game, but no Proton "
+            "compatibility tool is configured.",
+            observed,
+        )
+
+    def test_validate_proton_requires_selected_tool(self):
+        game = Game(
+            "Test Game",
+            install_dir="/test/install/dir",
+            platform="windows",
+        )
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Missing Proton",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(
+                key,
+                default_value,
+            ),
+        ), mock.patch(
+            "minigalaxy.launcher.os.path.isfile",
+            return_value=False,
+        ):
+            observed = launcher.validate_windows_compatibility(game)
+
+        self.assertEqual(
+            "The selected Proton compatibility tool is unavailable: "
+            "/steam/Missing Proton",
+            observed,
+        )
+
+    def test_validate_proton_requires_umu(self):
+        game = Game(
+            "Test Game",
+            install_dir="/test/install/dir",
+            platform="windows",
+        )
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(
+                key,
+                default_value,
+            ),
+        ), mock.patch(
+            "minigalaxy.launcher.os.path.isfile",
+            return_value=True,
+        ), mock.patch(
+            "minigalaxy.launcher.find_umu_run",
+            return_value="",
+        ):
+            observed = launcher.validate_windows_compatibility(game)
+
+        self.assertEqual(
+            "UMU Launcher (umu-run) is required to install and run games "
+            "with Proton through the Steam Linux Runtime, but it was not found.",
+            observed,
+        )
+
+    def test_find_umu_run_uses_user_local_bin_when_path_omits_it(self):
+        expected = launcher.os.path.expanduser("~/.local/bin/umu-run")
+
+        with mock.patch(
+            "minigalaxy.launcher.shutil.which",
+            return_value=None,
+        ), mock.patch(
+            "minigalaxy.launcher.os.path.isfile",
+            return_value=True,
+        ), mock.patch(
+            "minigalaxy.launcher.os.access",
+            return_value=True,
+        ):
+            observed = launcher.find_umu_run()
+
+        self.assertEqual(expected, observed)
+
+    def test_config_game_proton_uses_runinprefix(self):
+        game = Game(
+            "Test Game",
+            install_dir="/test/install/dir",
+            platform="windows",
+        )
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(
+                key,
+                default_value,
+            ),
+        ), mock.patch(
+            "minigalaxy.launcher.validate_windows_compatibility",
+            return_value="",
+        ), mock.patch(
+            "minigalaxy.launcher.find_umu_run",
+            return_value="/usr/bin/umu-run",
+        ), mock.patch(
+            "minigalaxy.launcher.subprocess.Popen",
+        ) as mock_popen:
+            observed = launcher.config_game(game)
+
+        self.assertEqual("", observed)
+        mock_popen.assert_called_once_with([
+            "env",
+            "WINEPREFIX=/test/install/dir/prefix",
+            "PROTONPATH=/steam/Proton - Experimental",
+            "STORE=gog",
+            "GAMEID=0",
+            "PROTON_VERB=runinprefix",
+            "/usr/bin/umu-run",
+            "winecfg",
+        ])
+
+    def test_start_game_returns_proton_validation_error_before_spawn(self):
+        game = Game(
+            "Test Game",
+            install_dir="/test/install/dir",
+            platform="windows",
+        )
+        command = LaunchCommand(
+            name="game.exe",
+            command=["umu-run", "game.exe"],
+        )
+        expected = "UMU Launcher is required."
+
+        with mock.patch(
+            "minigalaxy.launcher.validate_windows_compatibility",
+            return_value=expected,
+        ), mock.patch(
+            "minigalaxy.launcher.run_game_subprocess",
+        ) as mock_run:
+            observed = launcher.start_game(game, command)
+
+        self.assertEqual(expected, observed)
+        mock_run.assert_not_called()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -715,31 +715,71 @@ makson   12866  1378  0 18:09 pts/4    00:00:00 /bin/sh /home/makson/.paradoxlau
         ), mock.patch(
             "minigalaxy.launcher.find_umu_run",
             return_value="",
+        ), mock.patch(
+            "minigalaxy.launcher.get_umu_status",
+            return_value=None,
         ):
             observed = launcher.validate_windows_compatibility(game)
 
         self.assertEqual(
-            "UMU Launcher (umu-run) is required to install and run games "
-            "with Proton through the Steam Linux Runtime, but it was not found.",
+            "UMU Launcher (umu-run) version 1.4.4 or newer is required to "
+            "install and run games with Proton through the Steam Linux Runtime, "
+            "but it was not found.",
             observed,
         )
 
-    def test_find_umu_run_uses_user_local_bin_when_path_omits_it(self):
-        expected = launcher.os.path.expanduser("~/.local/bin/umu-run")
+    def test_find_umu_run_uses_compatible_discovered_umu(self):
+        installation = MagicMock()
+        installation.path = "/home/test/.local/bin/umu-run"
 
         with mock.patch(
-            "minigalaxy.launcher.shutil.which",
-            return_value=None,
+            "minigalaxy.launcher.find_compatible_umu",
+            return_value=installation,
+        ):
+            observed = launcher.find_umu_run()
+
+        self.assertEqual(
+            "/home/test/.local/bin/umu-run",
+            observed,
+        )
+
+    def test_validate_proton_rejects_old_umu_version(self):
+        game = Game(
+            "Test Game",
+            install_dir="/test/install/dir",
+            platform="windows",
+        )
+        values = {
+            InfoKey.WINDOWS_RUNNER: "proton",
+            InfoKey.PROTON_PATH: "/steam/Proton - Experimental",
+        }
+        status = MagicMock()
+        status.version_text = "1.4.3"
+
+        with mock.patch.object(
+            game,
+            "get_info",
+            side_effect=lambda key, default_value="": values.get(
+                key,
+                default_value,
+            ),
         ), mock.patch(
             "minigalaxy.launcher.os.path.isfile",
             return_value=True,
         ), mock.patch(
-            "minigalaxy.launcher.os.access",
-            return_value=True,
+            "minigalaxy.launcher.find_umu_run",
+            return_value="",
+        ), mock.patch(
+            "minigalaxy.launcher.get_umu_status",
+            return_value=status,
         ):
-            observed = launcher.find_umu_run()
+            observed = launcher.validate_windows_compatibility(game)
 
-        self.assertEqual(expected, observed)
+        self.assertEqual(
+            "UMU Launcher 1.4.3 is installed, but version 1.4.4 or newer "
+            "is required for Proton support.",
+            observed,
+        )
 
     def test_config_game_proton_uses_runinprefix(self):
         game = Game(

--- a/tests/test_umu.py
+++ b/tests/test_umu.py
@@ -1,0 +1,230 @@
+import hashlib
+import io
+import os
+import tarfile
+import tempfile
+from unittest import TestCase, mock
+from unittest.mock import MagicMock
+
+from minigalaxy import umu
+
+
+class TestUmu(TestCase):
+    def test_parse_umu_version(self):
+        output = (
+            "umu-launcher version 1.4.4 "
+            "(3.12.3 (main, Jun 19 2026, 12:46:00))"
+        )
+
+        self.assertEqual(
+            (1, 4, 4),
+            umu.parse_umu_version(output),
+        )
+
+    def test_parse_umu_version_rejects_unknown_output(self):
+        self.assertIsNone(
+            umu.parse_umu_version("Python 3.12.3")
+        )
+
+    def test_installation_compatibility_accepts_newer_umu(self):
+        installation = umu.UmuInstallation(
+            path="/usr/bin/umu-run",
+            version=(1, 5, 0),
+            source="path",
+        )
+
+        self.assertTrue(installation.compatible)
+
+    def test_installation_compatibility_rejects_old_umu(self):
+        installation = umu.UmuInstallation(
+            path="/usr/bin/umu-run",
+            version=(1, 4, 3),
+            source="path",
+        )
+
+        self.assertFalse(installation.compatible)
+
+    @mock.patch(
+        "minigalaxy.umu.get_umu_version",
+        return_value=(1, 4, 4),
+    )
+    @mock.patch(
+        "minigalaxy.umu.os.access",
+        return_value=True,
+    )
+    @mock.patch(
+        "minigalaxy.umu.os.path.isfile",
+        return_value=True,
+    )
+    @mock.patch(
+        "minigalaxy.umu.shutil.which",
+        return_value=None,
+    )
+    def test_user_local_bin_is_discovered_when_path_omits_it(
+        self,
+        mock_which,
+        mock_isfile,
+        mock_access,
+        mock_version,
+    ):
+        expected = os.path.expanduser(
+            "~/.local/bin/umu-run"
+        )
+
+        installations = umu.find_umu_installations()
+
+        self.assertEqual(expected, installations[0].path)
+        self.assertEqual("user", installations[0].source)
+
+    def test_find_compatible_umu_skips_old_candidate(self):
+        old = umu.UmuInstallation(
+            "/usr/bin/umu-run",
+            (1, 4, 3),
+            "path",
+        )
+        managed = umu.UmuInstallation(
+            "/home/test/umu-run",
+            (1, 4, 4),
+            "managed",
+        )
+
+        with mock.patch(
+            "minigalaxy.umu.find_umu_installations",
+            return_value=[old, managed],
+        ):
+            observed = umu.find_compatible_umu()
+
+        self.assertEqual(managed, observed)
+
+    def test_get_umu_status_returns_old_install_when_no_compatible_exists(self):
+        old = umu.UmuInstallation(
+            "/usr/bin/umu-run",
+            (1, 3, 0),
+            "path",
+        )
+
+        with mock.patch(
+            "minigalaxy.umu.find_umu_installations",
+            return_value=[old],
+        ):
+            observed = umu.get_umu_status()
+
+        self.assertEqual(old, observed)
+
+    def test_managed_path_honors_xdg_data_home(self):
+        with mock.patch.dict(
+            os.environ,
+            {"XDG_DATA_HOME": "/test/data"},
+        ):
+            observed = umu.get_managed_umu_path()
+
+        self.assertEqual(
+            "/test/data/minigalaxy/umu/umu-run",
+            observed,
+        )
+
+    def test_install_managed_umu_reuses_compatible_existing_install(self):
+        existing = umu.UmuInstallation(
+            "/usr/bin/umu-run",
+            (1, 5, 0),
+            "path",
+        )
+
+        with mock.patch(
+            "minigalaxy.umu.find_compatible_umu",
+            return_value=existing,
+        ), mock.patch(
+            "minigalaxy.umu._download_managed_umu_archive",
+        ) as mock_download:
+            observed = umu.install_managed_umu()
+
+        self.assertEqual(existing, observed)
+        mock_download.assert_not_called()
+
+    def test_download_rejects_bad_checksum(self):
+        response = MagicMock()
+        response.iter_content.return_value = [b"bad archive"]
+        response.raise_for_status.return_value = None
+
+        with mock.patch(
+            "minigalaxy.umu.requests.get",
+            return_value=response,
+        ), self.assertRaises(umu.UmuInstallError) as error:
+            umu._download_managed_umu_archive()
+
+        self.assertIn(
+            "checksum verification failed",
+            str(error.exception),
+        )
+        response.close.assert_called_once_with()
+
+    def test_install_managed_umu_writes_verified_zipapp(self):
+        zipapp_payload = b"#!/usr/bin/env python3\nprint('umu')\n"
+
+        tar_buffer = io.BytesIO()
+
+        with tarfile.open(
+            fileobj=tar_buffer,
+            mode="w",
+        ) as archive:
+            info = tarfile.TarInfo(
+                umu.MANAGED_UMU_ARCHIVE_MEMBER
+            )
+            info.size = len(zipapp_payload)
+            archive.addfile(
+                info,
+                io.BytesIO(zipapp_payload),
+            )
+
+        archive_payload = tar_buffer.getvalue()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            destination = os.path.join(
+                temp_dir,
+                "minigalaxy",
+                "umu",
+                "umu-run",
+            )
+
+            with mock.patch(
+                "minigalaxy.umu.find_compatible_umu",
+                return_value=None,
+            ), mock.patch(
+                "minigalaxy.umu._download_managed_umu_archive",
+                return_value=archive_payload,
+            ), mock.patch(
+                "minigalaxy.umu.get_managed_umu_path",
+                return_value=destination,
+            ), mock.patch(
+                "minigalaxy.umu.get_umu_version",
+                return_value=(1, 4, 4),
+            ):
+                observed = umu.install_managed_umu()
+
+            self.assertEqual(destination, observed.path)
+            self.assertEqual((1, 4, 4), observed.version)
+            self.assertEqual("managed", observed.source)
+            self.assertTrue(os.access(destination, os.X_OK))
+
+            with open(destination, "rb") as installed_file:
+                self.assertEqual(
+                    zipapp_payload,
+                    installed_file.read(),
+                )
+
+    def test_download_accepts_exact_pinned_checksum(self):
+        payload = b"official-test-payload"
+        response = MagicMock()
+        response.iter_content.return_value = [payload]
+        response.raise_for_status.return_value = None
+
+        with mock.patch(
+            "minigalaxy.umu.MANAGED_UMU_SHA256",
+            hashlib.sha256(payload).hexdigest(),
+        ), mock.patch(
+            "minigalaxy.umu.requests.get",
+            return_value=response,
+        ):
+            observed = umu._download_managed_umu_archive()
+
+        self.assertEqual(payload, observed)


### PR DESCRIPTION
## Description

Adds per-game Steam Proton support for Windows GOG games through UMU while preserving the existing Wine behavior as the default.

### What this adds

- Discovers Valve Proton installations from Steam libraries, including additional `libraryfolders.vdf` locations.
- Discovers custom/GE Proton compatibility tools.
- Adds a per-game compatibility selector for System Wine, Custom Wine, and discovered Proton tools.
- Uses the selected Proton build through UMU for both the GOG installer and later game launches.
- Creates Proton prefixes through UMU from the first installer process instead of installing with Wine first or converting/moving prefixes afterward.
- Keeps MiniGalaxy in control of the existing GOG game-library location.
- Explicitly prevents a configured Proton backend from silently falling back to host Wine when Proton or UMU is unavailable.
- Requires UMU Launcher 1.4.4+ for Proton mode and accepts newer compatible installations.
- Detects system/user UMU installations and can provision a checksum-verified upstream UMU 1.4.4 standalone zipapp into MiniGalaxy's XDG data directory without root privileges or distro-specific package-manager logic.
- Shows UMU runtime/version status in game Properties when Proton is selected.
- Leaves System Wine and Custom Wine behavior independent of UMU.

### Validation

- Full regression suite: **221 tests passed**.
- `flake8`: **0 findings**.
- `git diff --check`: clean.
- Python compile check: passed.
- Properties XML parsing: passed.
- GTK template import: passed.
- Live UMU dependency detection tested with `/usr/bin/umu-run` 1.4.4.
- Real isolated managed-UMU provisioning test passed.
- End-to-end Windows game test: **Croc Legend of the Gobbos Classic** installed successfully using Steam Proton Experimental through UMU/Steam Linux Runtime.

### Compatibility model

- System Wine → system Wine, no UMU requirement.
- Custom Wine → selected Wine executable, no UMU requirement.
- Proton → selected Proton + UMU + Steam Linux Runtime, no host-Wine dependency and no silent Wine fallback.

This does not add games to Steam as non-Steam shortcuts. Steam is used only as a source of installed Proton compatibility tools.

### Related upstream work

- Addresses #639.
- Implements the Proton portion of #288.
- Related to draft PR #622; this PR takes a narrower per-game approach while preserving the existing Wine path.

## Checklist

- [x] CHANGELOG.md was updated.
