### PR TITLE
Bugfix: Concurreny issue leading to games from API being skipped in library rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **1.4.3**
+- Fix not-installed Linux games missing from the library (thanks to slowsage)
 - Releases will now include a basic AppImage (experimental) (thanks to GB609)
 - Releases now target Ubuntu 26.04
 - Mangohud dlsym enabled by default (thanks to RoGreat)

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import threading
+import time
 
 from minigalaxy.api import Api
 from minigalaxy.config import Config
@@ -51,7 +52,6 @@ class Library(Gtk.Viewport):
         self.owned_products_ids = []
         self._queue = []
         self.category_filters = []
-        self._library_generation = 0
         self.configure_library_sort()
 
     def _debounce(self, thunk):
@@ -72,45 +72,37 @@ class Library(Gtk.Viewport):
         self.update_library()
 
     def update_library(self) -> None:
-        self._library_generation += 1
-        generation = self._library_generation
-        library_update_thread = threading.Thread(target=self.__update_library, args=(generation,))
+        library_update_thread = threading.Thread(target=self.__update_library)
         library_update_thread.daemon = True
         library_update_thread.start()
 
-    def __update_library(self, generation):
+    def __update_library(self):
         GLib.idle_add(self.__load_tile_states)
         self.owned_products_ids = self.api.get_owned_products_ids()
-        installed = self.__get_installed_games()
-        # Show installed before the API round-trip. Worker does not touch self.games.
-        GLib.idle_add(self.__apply_installed_games, installed, generation)
-        retrieved_games, err_msg = self.__fetch_library_from_api()
-        GLib.idle_add(self.__apply_api_games, retrieved_games, err_msg, generation)
+        # Get already installed games first
+        self.games = self.__get_installed_games()
+        self.__create_gametiles_iteratively(5)
 
-    def __apply_installed_games(self, installed, generation):
-        if generation != self._library_generation:
-            return False
-        self.games = sorted(installed)
-        self.filter_library()
-        self.__create_gametiles(self.games)
-        return False
+        # Get games from the API
+        self.__add_games_from_api()
+        self.__create_gametiles_iteratively(5)
+        GLib.idle_add(self.filter_library)
 
-    def __apply_api_games(self, retrieved_games, err_msg, generation):
-        if generation != self._library_generation:
-            return False
-        self.__merge_api_games(retrieved_games, err_msg)
-        self.games = [game for game in self.games if self.__should_show_game(game)]
-        self.games.sort()
-        self.filter_library()
-        self.__create_gametiles(self.games)
-        return False
+    def __create_gametiles_iteratively(self, step_width=5):
+        if len(self.games) < step_width*2:
+            GLib.idle_add(self.__create_gametiles, [*self.games])
+            # wait until the update is done to make sure there's a consistent state before going on
+            time.sleep(0.1)
+            return
 
-    def __should_show_game(self, game) -> bool:
-        return (
-            game.is_installed()
-            or game.id in self.config.current_downloads
-            or game.platform in self.config.platform_mode
-        )
+        # make a copy of self.games to guard against concurrent removals sabotaging chunks
+        games_to_add = [*self.games]
+        index = 0
+        while index < len(games_to_add):
+            games_chunk = games_to_add[index:index+step_width]
+            GLib.idle_add(self.__create_gametiles, games_chunk)
+            index += step_width
+            time.sleep(0.1)
 
     def __load_tile_states(self):
         for child in self.flowbox.get_children():
@@ -175,8 +167,17 @@ class Library(Gtk.Viewport):
                 # request to load the thumbnail, if there is a url for it and it hasnt been loaded before
                 game.library_tile.load_thumbnail()
                 continue
-            if self.__should_show_game(game):
+            if game.is_installed():
                 self.__add_gametile(game)
+            elif game.id in self.config.current_downloads:
+                self.__add_gametile(game)
+            elif game.platform in self.config.platform_mode:
+                self.__add_gametile(game)
+            elif game in self.games:
+                # housekeeping: API.get_library returns all owned games
+                # (useful when api-caching is introduced as the same request can be used independent of platform_mode)
+                # removing not shown games is only a small memory optimization
+                self.games.remove(game)
 
     def __add_gametile(self, game):
         view = self.config.view
@@ -235,15 +236,9 @@ class Library(Gtk.Viewport):
 
         return games
 
-    def __fetch_library_from_api(self):
-        logging.info("Start retrieving owned games from the api...")
-        return self.api.get_library()
-
     def __add_games_from_api(self):
-        retrieved_games, err_msg = self.__fetch_library_from_api()
-        self.__merge_api_games(retrieved_games, err_msg)
-
-    def __merge_api_games(self, retrieved_games, err_msg):
+        logging.info("Start retrieving owned games from the api...")
+        retrieved_games, err_msg = self.api.get_library()
         if not err_msg:
             self.offline = False
         else:

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import threading
-import time
 
 from minigalaxy.api import Api
 from minigalaxy.config import Config
@@ -52,6 +51,7 @@ class Library(Gtk.Viewport):
         self.owned_products_ids = []
         self._queue = []
         self.category_filters = []
+        self._library_generation = 0
         self.configure_library_sort()
 
     def _debounce(self, thunk):
@@ -72,33 +72,45 @@ class Library(Gtk.Viewport):
         self.update_library()
 
     def update_library(self) -> None:
-        library_update_thread = threading.Thread(target=self.__update_library)
+        self._library_generation += 1
+        generation = self._library_generation
+        library_update_thread = threading.Thread(target=self.__update_library, args=(generation,))
         library_update_thread.daemon = True
         library_update_thread.start()
 
-    def __update_library(self):
+    def __update_library(self, generation):
         GLib.idle_add(self.__load_tile_states)
         self.owned_products_ids = self.api.get_owned_products_ids()
-        # Get already installed games first
-        self.games = self.__get_installed_games()
-        self.__create_gametiles_iteratively(5)
+        installed = self.__get_installed_games()
+        # Show installed before the API round-trip. Worker does not touch self.games.
+        GLib.idle_add(self.__apply_installed_games, installed, generation)
+        retrieved_games, err_msg = self.__fetch_library_from_api()
+        GLib.idle_add(self.__apply_api_games, retrieved_games, err_msg, generation)
 
-        # Get games from the API
-        self.__add_games_from_api()
-        self.__create_gametiles_iteratively(5)
-        GLib.idle_add(self.filter_library)
+    def __apply_installed_games(self, installed, generation):
+        if generation != self._library_generation:
+            return False
+        self.games = sorted(installed)
+        self.filter_library()
+        self.__create_gametiles(self.games)
+        return False
 
-    def __create_gametiles_iteratively(self, step_width=5):
-        if len(self.games) < step_width*2:
-            GLib.idle_add(self.__create_gametiles)
-            return
+    def __apply_api_games(self, retrieved_games, err_msg, generation):
+        if generation != self._library_generation:
+            return False
+        self.__merge_api_games(retrieved_games, err_msg)
+        self.games = [game for game in self.games if self.__should_show_game(game)]
+        self.games.sort()
+        self.filter_library()
+        self.__create_gametiles(self.games)
+        return False
 
-        index = 0
-        while index < len(self.games):
-            games_chunk = self.games[index:index+step_width]
-            GLib.idle_add(self.__create_gametiles, games_chunk)
-            index += step_width
-            time.sleep(0.1)
+    def __should_show_game(self, game) -> bool:
+        return (
+            game.is_installed()
+            or game.id in self.config.current_downloads
+            or game.platform in self.config.platform_mode
+        )
 
     def __load_tile_states(self):
         for child in self.flowbox.get_children():
@@ -163,17 +175,8 @@ class Library(Gtk.Viewport):
                 # request to load the thumbnail, if there is a url for it and it hasnt been loaded before
                 game.library_tile.load_thumbnail()
                 continue
-            if game.is_installed():
+            if self.__should_show_game(game):
                 self.__add_gametile(game)
-            elif game.id in self.config.current_downloads:
-                self.__add_gametile(game)
-            elif game.platform in self.config.platform_mode:
-                self.__add_gametile(game)
-            elif game in self.games:
-                # housekeeping: API.get_library returns all owned games
-                # (useful when api-caching is introduced as the same request can be used independent of platform_mode)
-                # removing not shown games is only a small memory optimization
-                self.games.remove(game)
 
     def __add_gametile(self, game):
         view = self.config.view
@@ -232,9 +235,15 @@ class Library(Gtk.Viewport):
 
         return games
 
-    def __add_games_from_api(self):
+    def __fetch_library_from_api(self):
         logging.info("Start retrieving owned games from the api...")
-        retrieved_games, err_msg = self.api.get_library()
+        return self.api.get_library()
+
+    def __add_games_from_api(self):
+        retrieved_games, err_msg = self.__fetch_library_from_api()
+        self.__merge_api_games(retrieved_games, err_msg)
+
+    def __merge_api_games(self, retrieved_games, err_msg):
         if not err_msg:
             self.offline = False
         else:

--- a/tests/ui/__init__.py
+++ b/tests/ui/__init__.py
@@ -21,6 +21,12 @@ class MockGiRepository:
         class Dialog:
             pass
 
+        class Switch:
+            pass
+
+        class SearchEntry:
+            pass
+
         class Template:
             def __init__(self, string=None):
                 pass
@@ -52,6 +58,9 @@ class MockGiRepository:
         pass
 
     class GLib:
-        pass
+        @staticmethod
+        def idle_add(callback, *args):
+            callback(*args)
+            return 0
 
     Notify = MagicMock()

--- a/tests/ui/__init__.py
+++ b/tests/ui/__init__.py
@@ -4,9 +4,10 @@ from unittest.mock import MagicMock
 class MockGiRepository:
 
     class Gtk:
-        Widget = MagicMock()
-        Settings = MagicMock()
+        AboutDialog = MagicMock()
         ResponseType = MagicMock()
+        Settings = MagicMock()
+        Widget = MagicMock()
 
         class ApplicationWindow:
             def __init__(self, title):

--- a/tests/ui/test_ui_library.py
+++ b/tests/ui/test_ui_library.py
@@ -258,10 +258,12 @@ class TestLibrary(TestCase):
         config.show_hidden_games = True
         api = MagicMock()
         api.get_owned_products_ids.return_value = []
-        api.get_library.return_value = api_games, err_msg
+        api.get_library.return_value = [*api_games], err_msg
         library = Library(MagicMock(), config, api, MagicMock())
         library.flowbox.get_children.return_value = []
-        library._Library__get_installed_games = MagicMock(return_value=installed)
+        # the list returned by this mock must be a copy, or its not possible to assert with it
+        # because Library will take it as self.games and manipulate it
+        library._Library__get_installed_games = MagicMock(return_value=[*installed])
         GameTile.reset_mock()
         library.flowbox.reset_mock()
         library.flowbox.get_children.return_value = []
@@ -312,8 +314,7 @@ class TestLibrary(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             installed, api_games, expected_linux, _windows = self._mixed_library_games(tmpdir)
             library = self._tile_library(installed, api_games)
-            library._library_generation = 1
-            library._Library__update_library(1)
+            library._Library__update_library()
 
             added_ids = {game.id for game in self._added_tile_games()}
             self.assertIn(installed[0].id, added_ids)
@@ -324,8 +325,7 @@ class TestLibrary(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             installed, api_games, expected_linux, windows = self._mixed_library_games(tmpdir)
             library = self._tile_library(installed, api_games)
-            library._library_generation = 1
-            library._Library__update_library(1)
+            library._Library__update_library()
 
             remaining_ids = {game.id for game in library.games}
             added_ids = {game.id for game in self._added_tile_games()}
@@ -343,8 +343,7 @@ class TestLibrary(TestCase):
             api_windows = Game(name="Installed Windows", game_id=42, platform="windows")
             downloadable_windows = Game(name="Uninstalled Windows", game_id=43, platform="windows")
             library = self._tile_library([installed_windows], [api_windows, downloadable_windows])
-            library._library_generation = 1
-            library._Library__update_library(1)
+            library._Library__update_library()
 
             remaining_ids = {game.id for game in library.games}
             added_ids = {game.id for game in self._added_tile_games()}
@@ -366,16 +365,16 @@ class TestLibrary(TestCase):
             installed, api_games, expected_linux, windows = self._mixed_library_games(tmpdir)
             library = self._tile_library(installed, api_games)
             library.api.get_library.side_effect = lambda: (events.append("api"), (api_games, ""))[1]
-            library._library_generation = 1
-            apply_installed = library._Library__apply_installed_games
+            apply_installed = library._Library__create_gametiles
             with patch.object(library_module.GLib, "idle_add", side_effect=queue_idle):
-                library._Library__update_library(1)
+                library._Library__update_library()
+                self._flush_idle(idle_queue, 1)  # __load_tile_states
 
                 self.assertIn("api", events)
                 self.assertLess(events.index(apply_installed), events.index("api"))
 
                 self._flush_idle(idle_queue, 1)
-                self.assertEqual([], self._added_tile_games())
+                self.assertEqual(installed, self._added_tile_games())
 
                 self._flush_idle(idle_queue, 1)
                 added_after_installed = self._added_tile_games()
@@ -393,31 +392,6 @@ class TestLibrary(TestCase):
                 for game in windows:
                     self.assertNotIn(game.id, added_ids)
                 self.assertEqual([], idle_queue)
-
-    def test_update_library_sets_filter_before_adding_tiles(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            installed, api_games, _linux, _windows = self._mixed_library_games(tmpdir)
-            library = self._tile_library(installed, api_games)
-            library._library_generation = 1
-            library._Library__update_library(1)
-
-            method_names = [name for name, _args, _kwargs in library.flowbox.mock_calls]
-            self.assertIn("set_filter_func", method_names)
-            self.assertIn("add", method_names)
-            self.assertLess(method_names.index("set_filter_func"), method_names.index("add"))
-
-    def test_stale_generation_apply_is_ignored(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            installed, api_games, expected_linux, _windows = self._mixed_library_games(tmpdir)
-            library = self._tile_library(installed, api_games)
-            library._library_generation = 2
-            library._Library__apply_installed_games(installed, 1)
-            library._Library__apply_api_games(api_games, "", 1)
-
-            self.assertEqual([], library.games)
-            self.assertEqual([], self._added_tile_games())
-            for game in expected_linux:
-                self.assertIsNone(game.library_tile)
 
 
 del sys.modules['gi']

--- a/tests/ui/test_ui_library.py
+++ b/tests/ui/test_ui_library.py
@@ -23,6 +23,8 @@ sys.modules['minigalaxy.ui.gametile'] = m_gametile
 sys.modules['minigalaxy.ui.gametilelist'] = m_gametilelist
 sys.modules['minigalaxy.ui.categoryfilters'] = m_categoryfilters
 from minigalaxy.game import Game           # noqa: E402
+from minigalaxy.ui.gametile import GameTile  # noqa: E402
+from minigalaxy.ui import library as library_module  # noqa: E402
 from minigalaxy.ui.library import Library, get_installed_windows_games, read_game_categories_file, \
     update_game_categories_file  # noqa: E402
 
@@ -245,6 +247,177 @@ class TestLibrary(TestCase):
             tmpfile.seek(os.SEEK_SET)
             actual = json.load(tmpfile)
             self.assertDictEqual(actual, expected)
+
+    def _tile_library(self, installed, api_games, err_msg=""):
+        config = MagicMock()
+        config.locale = "en"
+        config.installed_filter = False
+        config.platform_mode = ["linux"]
+        config.view = "grid"
+        config.current_downloads = []
+        config.show_hidden_games = True
+        api = MagicMock()
+        api.get_owned_products_ids.return_value = []
+        api.get_library.return_value = api_games, err_msg
+        library = Library(MagicMock(), config, api, MagicMock())
+        library.flowbox.get_children.return_value = []
+        library._Library__get_installed_games = MagicMock(return_value=installed)
+        GameTile.reset_mock()
+        library.flowbox.reset_mock()
+        library.flowbox.get_children.return_value = []
+        return library
+
+    def _flush_idle(self, queue, count=1):
+        for _ in range(count):
+            func, args = queue.pop(0)
+            func(*args)
+
+    def _flush_all_idle(self, queue):
+        while queue:
+            self._flush_idle(queue, 1)
+
+    def _added_tile_games(self):
+        return [call.args[1] for call in GameTile.call_args_list]
+
+    def _mixed_library_games(self, tmpdir):
+        """Installed linux + windows-only rows mixed with not-installed linux titles.
+
+        Interleaving hidden-platform rows with shown ones is the shape that
+        skipped later linux titles when tiles were created in index chunks
+        while Windows rows were removed from the live list.
+        """
+        installed = Game(name="Installed Linux", game_id=1, install_dir=tmpdir, platform="linux")
+        linux_games = [
+            Game(name=f"Linux Game {i}", game_id=100 + i, platform="linux")
+            for i in range(4)
+        ]
+        windows = [
+            Game(name=f"Windows Only {i}", game_id=9000 + i, platform="windows")
+            for i in range(8)
+        ]
+        api_games = [
+            Game(name="Installed Linux", game_id=1, platform="linux"),
+            windows[0], windows[1], windows[2], windows[3],
+            linux_games[0],
+            windows[4],
+            linux_games[1],
+            windows[5],
+            linux_games[2],
+            windows[6], windows[7],
+            linux_games[3],
+        ]
+        return [installed], api_games, linux_games, windows
+
+    def test_update_library_does_not_skip_not_installed_linux_games(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            installed, api_games, expected_linux, _windows = self._mixed_library_games(tmpdir)
+            library = self._tile_library(installed, api_games)
+            library._library_generation = 1
+            library._Library__update_library(1)
+
+            added_ids = {game.id for game in self._added_tile_games()}
+            self.assertIn(installed[0].id, added_ids)
+            for game in expected_linux:
+                self.assertIn(game.id, added_ids, f"{game.name} should have a tile")
+
+    def test_update_library_removes_windows_only_games(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            installed, api_games, expected_linux, windows = self._mixed_library_games(tmpdir)
+            library = self._tile_library(installed, api_games)
+            library._library_generation = 1
+            library._Library__update_library(1)
+
+            remaining_ids = {game.id for game in library.games}
+            added_ids = {game.id for game in self._added_tile_games()}
+            for game in windows:
+                self.assertNotIn(game.id, remaining_ids)
+                self.assertNotIn(game.id, added_ids)
+            for game in expected_linux:
+                self.assertIn(game.id, remaining_ids)
+
+    def test_update_library_keeps_installed_windows_games(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            installed_windows = Game(
+                name="Installed Windows", game_id=42, install_dir=tmpdir, platform="windows"
+            )
+            api_windows = Game(name="Installed Windows", game_id=42, platform="windows")
+            downloadable_windows = Game(name="Uninstalled Windows", game_id=43, platform="windows")
+            library = self._tile_library([installed_windows], [api_windows, downloadable_windows])
+            library._library_generation = 1
+            library._Library__update_library(1)
+
+            remaining_ids = {game.id for game in library.games}
+            added_ids = {game.id for game in self._added_tile_games()}
+            self.assertIn(42, remaining_ids)
+            self.assertIn(42, added_ids)
+            self.assertNotIn(43, remaining_ids)
+            self.assertNotIn(43, added_ids)
+
+    def test_update_library_applies_installed_before_api(self):
+        idle_queue = []
+        events = []
+
+        def queue_idle(func, *args):
+            events.append(func)
+            idle_queue.append((func, args))
+            return 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            installed, api_games, expected_linux, windows = self._mixed_library_games(tmpdir)
+            library = self._tile_library(installed, api_games)
+            library.api.get_library.side_effect = lambda: (events.append("api"), (api_games, ""))[1]
+            library._library_generation = 1
+            apply_installed = library._Library__apply_installed_games
+            with patch.object(library_module.GLib, "idle_add", side_effect=queue_idle):
+                library._Library__update_library(1)
+
+                self.assertIn("api", events)
+                self.assertLess(events.index(apply_installed), events.index("api"))
+
+                self._flush_idle(idle_queue, 1)
+                self.assertEqual([], self._added_tile_games())
+
+                self._flush_idle(idle_queue, 1)
+                added_after_installed = self._added_tile_games()
+                self.assertEqual([installed[0].id], [game.id for game in added_after_installed])
+                for game in expected_linux:
+                    self.assertNotIn(game.id, {g.id for g in added_after_installed})
+
+                self._flush_idle(idle_queue, 1)
+                self._flush_all_idle(idle_queue)
+                added_after_api = self._added_tile_games()
+                added_ids = {game.id for game in added_after_api}
+                self.assertEqual(1 + len(expected_linux), len(added_after_api))
+                for game in expected_linux:
+                    self.assertIn(game.id, added_ids)
+                for game in windows:
+                    self.assertNotIn(game.id, added_ids)
+                self.assertEqual([], idle_queue)
+
+    def test_update_library_sets_filter_before_adding_tiles(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            installed, api_games, _linux, _windows = self._mixed_library_games(tmpdir)
+            library = self._tile_library(installed, api_games)
+            library._library_generation = 1
+            library._Library__update_library(1)
+
+            method_names = [name for name, _args, _kwargs in library.flowbox.mock_calls]
+            self.assertIn("set_filter_func", method_names)
+            self.assertIn("add", method_names)
+            self.assertLess(method_names.index("set_filter_func"), method_names.index("add"))
+
+    def test_stale_generation_apply_is_ignored(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            installed, api_games, expected_linux, _windows = self._mixed_library_games(tmpdir)
+            library = self._tile_library(installed, api_games)
+            library._library_generation = 2
+            library._Library__apply_installed_games(installed, 1)
+            library._Library__apply_api_games(api_games, "", 1)
+
+            self.assertEqual([], library.games)
+            self.assertEqual([], self._added_tile_games())
+            for game in expected_linux:
+                self.assertIsNone(game.library_tile)
 
 
 del sys.modules['gi']


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

See the original explanation and PR at #770 

Thanks again to @slowsage for finding that issue.

I've cherry-picked the original commit and adjusted the fix according to my original suggestion before the PR was cancelled, while keeping as much as possible from the original test work.

@slowsage Is the way i've done it ok with you? I've made sure to keep your commit and credits intact as i don't want to steal your code. 

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
