### PR TITLE
Feature: Better build reporting

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -18,12 +18,31 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-testing.txt
     - name: Lint with flake8
+      shell: bash
       run: |
-        flake8 . --append-config=.flake8.soft --count --show-source --statistics
+        echo -e '# Flake results\n```' >> "${GITHUB_STEP_SUMMARY}"
+        if flake8 . --append-config=.flake8.soft --count --show-source --statistics 2>&1 | tee -a "${GITHUB_STEP_SUMMARY}"; then
+          success=0
+        else
+          success=1
+        fi
+        echo -e '\n```\n' >> "${GITHUB_STEP_SUMMARY}"
+        exit "${success}"
     - name: Lint with flake8 (strict, but non-fatal)
       run: |
         flake8 . --count --show-source --statistics --exit-zero
     - name: Run unit tests
+      shell: bash
       run: |
-        python3 -m coverage run --source minigalaxy -m unittest discover -v tests && python3 -m coverage report -m
-
+        echo -e '\n# Test Results:\n```\n' >>"${GITHUB_STEP_SUMMARY}"
+        if python3 -m coverage run --source minigalaxy -m unittest discover -v tests 2>&1 | tee test-results.tmp.log; then
+          success="0"
+        else
+          success="${PIPESTATUS[0]}"
+        fi
+        tail -n 5 test-results.tmp.log >>"${GITHUB_STEP_SUMMARY}"
+        rm test-results.tmp.log
+        echo -e '\n```\n' >>"${GITHUB_STEP_SUMMARY}"
+        echo -e '\n # Coverage Results\n' >>"${GITHUB_STEP_SUMMARY}"
+        python3 -m coverage report -m --format=markdown >>"${GITHUB_STEP_SUMMARY}"
+        exit "${success}"


### PR DESCRIPTION
## Description

I recently discovered in the github logs that minigalaxy also records and prints coverage. As funny as it may read, i actually didn't know (or forgot) that we do this.
But it's hidden away in build step logs, which is a shame. We should leverage the reporting we have and make it a bit easier to see and access the most important points.

This is what i'm intending to do here. The following steps will now output log info to the job summary page:
- `flake8` for regular sources
- python tests print the final summary. Detail logs still need to be locked at by navigating into the logs of the step itself. The full details are just too large to show and i haven't found a good way to filter it down to failures only.
- coverage: Regardless of whether the tests fail, the recorded coverage table is added to the job summary. When the tests failed, the build will still fail afterwards the same way it did before

I know, it's not really a feature directed at end users. But i think it's useful for the dev CI/CD setup.

You can see the effects in the job history at my fork:
- PR branch = good case: https://github.com/GB609/minigalaxy/actions/runs/32380168099
- Test branch with flake error: https://github.com/GB609/minigalaxy/actions/runs/32379558357
- Test branch with failing test: https://github.com/GB609/minigalaxy/actions/runs/32379387572

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
