### PR TITLE
Feature: Remove unused code

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -396,27 +396,6 @@ def create_applications_file(game, override=False):
     return error_message
 
 
-def compare_directories(dir1, dir2):
-    files_1 = []
-    files_2 = []
-
-    if os.path.isdir(dir1):
-        files_1 = os.listdir(dir1)
-    if os.path.isdir(dir2):
-        files_2 = os.listdir(dir2)
-
-    if not set(files_1).issubset(set(files_2)):
-        return False
-
-    result = True
-    for f in files_1:
-        if os.path.getsize(os.path.join(dir1, f)) != \
-           os.path.getsize(os.path.join(dir2, f)):
-            result = False
-
-    return result
-
-
 def remove_installer(game: Game, installer: str, keep_installers_dir: str, keep_installers: bool, inventory=None):
     installer_dir = os.path.dirname(installer)
     if not os.path.isdir(installer_dir):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -442,39 +442,6 @@ class Test(TestCase):
         result2 = installer.get_exec_line(game2)
         self.assertEqual('"/home/test/GOG Games/Blocks That Matter/start.sh"', result2)
 
-    @mock.patch('os.path.getsize')
-    @mock.patch('os.listdir')
-    @mock.patch('os.path.isdir')
-    def test_compare_directory_true(self, mock_path_isdir, mock_list_dir, mock_os_path_getsize):
-        mock_path_isdir.return_value = True
-        mock_list_dir.return_value = ["beneath_a_steel_sky_en_gog_2_20150.sh", "beneath_a_steel_sky_en_gog_2_20150.part1"]
-        mock_os_path_getsize.return_value = 100
-
-        obs = installer.compare_directories("/home/test/.cache/minigalaxy/installer/test", "/home/test/GOG Games/installer/test")
-        self.assertEqual(obs, True)
-
-    @mock.patch('os.path.getsize')
-    @mock.patch('os.listdir')
-    @mock.patch('os.path.isdir')
-    def test_compare_directory_false(self, mock_path_isdir, mock_list_dir, mock_os_path_getsize):
-        mock_path_isdir.return_value = True
-        mock_list_dir.side_effect = [
-            ["beneath_a_steel_sky_en_gog_2_20150.sh", "beneath_a_steel_sky_en_gog_2_20150.part1"],
-            ["beneath_a_steel_sky_en_gog_2_20150.sh"],
-        ]
-
-        obs = installer.compare_directories("/home/test/.cache/minigalaxy/installer/test", "/home/test/GOG Games/installer/test")
-        self.assertEqual(obs, False)
-
-        mock_list_dir.side_effect = [
-            ["beneath_a_steel_sky_en_gog_2_20150.sh", "beneath_a_steel_sky_en_gog_2_20150.part1"],
-            ["beneath_a_steel_sky_en_gog_2_20150.sh", "beneath_a_steel_sky_en_gog_2_20150.part1"],
-        ]
-        mock_os_path_getsize.side_effect = [100, 200, 300, 400]
-
-        obs = installer.compare_directories("/home/test/.cache/minigalaxy/installer/test", "/home/test/GOG Games/installer/test")
-        self.assertEqual(obs, False)
-
     def test_remove_installer_no_installer(self):
         """
         No installer present


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This is another one of my 'while i'm at it....' refactoring/cleanup PRs i tend to do while trying to implement other, larger features.

This time i do a revision of the code that manages if, how and where installers are downloaded, placed and named. I need more clarity here to implement support for the game platform selection.

I'm planning to introduce a central management for installers,  `installer.py:InstallerRepository` and move code littered across several other locations here.
This mostly concerns global functions defined in `installer.py` and various places with path calculations in and/or searches for installers in `library_entry.py`.

While going over the code i discovered the function `compare_directories` which isn't in use anymore. I figured we can drop it entirely in that case.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
