### PR TITLE
Feature: No fallback retry when manually canceling a wine install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **1.4.3**
+- Canceling an automatic windows game installation will not retry with the fallback any longer (thanks to GB609)
 - Fix not-installed Linux games missing from the library (thanks to slowsage)
 - Releases will now include a basic AppImage (experimental) (thanks to GB609)
 - Releases now target Ubuntu 26.04

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -236,7 +236,8 @@ def extract_by_wine(game, installer, game_lang, config=Config()):
     prefix_dir = os.path.join(game.install_dir, "prefix")
     wine_env = [
         f"WINEPREFIX={prefix_dir}",
-        "WINEDLLOVERRIDES=winemenubuilder.exe=d"
+        "WINEDLLOVERRIDES=winemenubuilder.exe=d",
+        "WINEDEBUG=fixme-all"  # disable a few misleading wine log statements
     ]
     wine_bin = get_wine_path(game)
 
@@ -251,7 +252,8 @@ def extract_by_wine(game, installer, game_lang, config=Config()):
         reg_file_resource = get_data_file("wine_disable_menubuilder.reg")
         with as_file(reg_file_resource) as reg_file:
             command = ["env", *wine_env, wine_bin, "regedit", str(reg_file.resolve())]
-            if not try_wine_command(command):
+            success, code = try_wine_command(command)
+            if not success:
                 return _("Wineprefix creation failed.")
 
     # calculate relative link prefix/c/game to game.install_dir
@@ -275,13 +277,17 @@ def extract_by_wine(game, installer, game_lang, config=Config()):
     ]
 
     # first, try full unattended install.
-    success = try_wine_command(installer_cmd_basic + installer_args_full)
+    success, code = try_wine_command(installer_cmd_basic + installer_args_full)
     if not success:
+        # look at the exit codes and runtime behaviour to determine if the second try is needed
+        # see https://jrsoftware.org/ishelp/index.php?topic=setupexitcodes
+        if code in [2, 5]:  # user decided to cancel
+            return _("Installation canceled by user.")
         # some games will reject the /SILENT flag
         # because they require the user to accept EULA at the beginning
         # Open normal installer as fallback and hope for the best
         logging.error('Unattended install failed. Try install with wizard dialog.')
-        success = try_wine_command(installer_cmd_basic)
+        success, code = try_wine_command(installer_cmd_basic)
 
     if not success:
         return _("Wine extraction failed.")
@@ -293,10 +299,11 @@ def try_wine_command(command_arr):
     logging.debug('trying to run wine command:[%s]', shlex.join(command_arr))
     stdout, stderr, exitcode = _exe_cmd(command_arr, True)
     if exitcode not in [0]:
+        logging.error("Wine install failed with exit code: %d", exitcode)
         logging.error(stderr)
-        return False
+        return False, exitcode
 
-    return True
+    return True, 0
 
 
 def move_and_overwrite(game, temp_dir, installed_to_tmp):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -309,9 +309,7 @@ class Test(TestCase):
 
     @mock.patch('subprocess.Popen')
     @mock.patch("os.path.exists")
-    @mock.patch("os.unlink")
-    @mock.patch("os.symlink")
-    def test2_extract_by_wine(self, mock_symlink, mock_unlink, mock_path_exists, mock_subprocess):
+    def test2_extract_by_wine(self, mock_path_exists, mock_subprocess):
         """[scenario: install failed]"""
         mock_path_exists.return_value = True
         mock_subprocess().poll.return_value = 1
@@ -321,6 +319,20 @@ class Test(TestCase):
         installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
         temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
         exp = "Wine extraction failed."
+        obs = installer.extract_by_wine(game, installer_path, temp_dir)
+        self.assertEqual(exp, obs)
+
+    @mock.patch('subprocess.Popen')
+    @mock.patch("os.path.exists")
+    def test_extract_by_wine_user_cancelled(self, mock_path_exists, mock_subprocess):
+        mock_path_exists.return_value = True
+        mock_subprocess().poll.return_value = 2
+        mock_subprocess().stdout.readline.return_value = ""
+        mock_subprocess().stderr.readline.return_value = ""
+        game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform=Platform.WINDOWS)
+        installer_path = "/home/makson/.cache/minigalaxy/download/Absolute Drift/setup_absolute_drift_1.0f_(64bit)_(47863).exe"
+        temp_dir = "/home/makson/.cache/minigalaxy/extract/1136126792"
+        exp = "Installation canceled by user."
         obs = installer.extract_by_wine(game, installer_path, temp_dir)
         self.assertEqual(exp, obs)
 


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

The wine install process uses a two-step approach. But up to now, this process did not take exit codes or other feedback from the installer into account.

It does now. When a user decides to cancel the first, unattended install (by force-closing), minigalaxy should not treat this the same as any other generic installation error and thus not fall back to the second attempt.

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
