### PR TITLE
Fix system message locale selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **1.4.3**
+- Use the system message locale for the interface and preserve formatting locales when changing language (thanks to be-student).
 - Fix not-installed Linux games missing from the library (thanks to slowsage)
 - Releases will now include a basic AppImage (experimental) (thanks to GB609)
 - Releases now target Ubuntu 26.04

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ install directory 'c:\game' given in the wizard as this an elementary part of th
 
 ## Supported languages
 
+By default, the interface follows the system message locale (`LC_MESSAGES`),
+independently of keyboard and formatting locales. The program language setting
+overrides the interface language; selecting the system default restores the
+startup message locale. Language selection is initialized centrally in
+`minigalaxy/translation.py`, and does not change numeric, date, or character
+locale categories. `LANG` remains available to launched games.
+
 Currently, Minigalaxy can be displayed in the following languages:
 
 - Brazilian Portuguese

--- a/minigalaxy/translation.py
+++ b/minigalaxy/translation.py
@@ -9,7 +9,34 @@ TRANSLATION_DOMAIN = "minigalaxy"
 try:
     locale.setlocale(locale.LC_ALL, '')
 except locale.Error:
-    logging.error("Unsupported locale detected, continuing without translation support", exc_info=1)
+    logging.error("Unsupported locale detected, continuing with available locale categories", exc_info=1)
+
+# A formatting category (for example LC_TIME) may be unavailable even when
+# LC_MESSAGES is valid. Initialize the message category independently.
+try:
+    locale.setlocale(locale.LC_MESSAGES, '')
+except locale.Error:
+    logging.error("Unsupported message locale, continuing with the current message locale", exc_info=1)
+
+system_message_locale = locale.setlocale(locale.LC_MESSAGES)
+
+
+def set_message_locale(language):
+    """Apply a program language without changing formatting or character categories.
+
+    The empty configuration value always restores the startup system language.
+    """
+    target = (language, 'UTF-8') if language else system_message_locale
+    locale.setlocale(locale.LC_MESSAGES, target)
+
+
+current_locale = Config().locale
+try:
+    set_message_locale(current_locale)
+except locale.Error:
+    logging.error("Configured program language is unavailable, using the system language", exc_info=1)
+    set_message_locale('')
+    current_locale = ''
 
 try:
     locale.bindtextdomain(TRANSLATION_DOMAIN, LOCALE_DIR)
@@ -24,14 +51,11 @@ except AttributeError:
 gettext.bindtextdomain(TRANSLATION_DOMAIN, LOCALE_DIR)
 gettext.textdomain(TRANSLATION_DOMAIN)
 
-# Make sure LANGUAGE and LANG are not set, or translations will not be loaded
+# LANGUAGE can override the explicit program language in native gettext.
+# Keep LANG intact so games inherit the original system locale.
 os.unsetenv("LANGUAGE")
-os.unsetenv("LANG")
 
-current_locale = Config().locale
-# getlocale() returns the locale set by setlocale(LC_ALL, '') earlier in this
-# module, which read the environment before LANG/LANGUAGE were unset above.
-default_locale = locale.getlocale()[0]
+default_locale = locale.getlocale(locale.LC_MESSAGES)[0]
 logging.debug("Init locales: default=%s, current=%s", default_locale, current_locale)
 logging.debug("Loading locale files from %s", LOCALE_DIR)
 if current_locale == '':

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -1,5 +1,4 @@
 import json
-import locale
 import logging
 import os
 import re
@@ -33,16 +32,6 @@ class Library(Gtk.Viewport):
 
         self.parent_window = parent_window
         self.config = config
-
-        current_locale = self.config.locale
-        default_locale = locale.getlocale()[0]
-        if current_locale == '':
-            locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
-        else:
-            try:
-                locale.setlocale(locale.LC_ALL, (current_locale, 'UTF-8'))
-            except NameError:
-                locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
 
         self.api = api
         self.download_manager = download_manager

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -7,7 +7,7 @@ from minigalaxy import Platform
 from minigalaxy.config import Config
 from minigalaxy.constants import PLATFORM_MODE, SUPPORTED_DOWNLOAD_LANGUAGES, SUPPORTED_LOCALES, VIEWS
 from minigalaxy.download_manager import DownloadManager
-from minigalaxy.translation import _
+from minigalaxy.translation import _, set_message_locale
 from minigalaxy.ui.gtk import Gtk, load_ui
 from minigalaxy.ui.widget_utils import get_combo_value, populate_combobox
 
@@ -56,9 +56,6 @@ class Preferences(Gtk.Dialog):
     def __set_locale_list(self) -> None:
         # Set the active option
         current_locale = self.config.locale
-        default_locale = locale.getlocale()
-        if current_locale is None:
-            locale.setlocale(locale.LC_ALL, default_locale)
 
         populate_combobox(self.combobox_program_language, SUPPORTED_LOCALES, current_locale)
 
@@ -70,11 +67,10 @@ class Preferences(Gtk.Dialog):
 
     def __apply_locale_choice(self) -> None:
         locale_choice = get_combo_value(self.combobox_program_language)
-        if locale_choice == '' or not locale_choice:
-            locale_choice = locale.getlocale()[0]
+        locale_choice = locale_choice or ''
 
         try:
-            locale.setlocale(locale.LC_ALL, (locale_choice, 'UTF-8'))
+            set_message_locale(locale_choice)
             self.config.locale = locale_choice
         except locale.Error:
             self.parent.show_error(_("Failed to change program language. Make sure locale is generated on your system."))

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import locale
 
 from minigalaxy.download_manager import DownloadManager
 from minigalaxy.ui.categoryfilters import CategoryFilters
@@ -32,15 +31,6 @@ class Window(Gtk.ApplicationWindow):
     download_list = Gtk.Template.Child()
 
     def __init__(self, config: Config, api: 'Api', download_manager: DownloadManager, name="Minigalaxy"):
-        current_locale = config.locale
-        default_locale = locale.getlocale()[0]
-        if current_locale == '':
-            locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
-        else:
-            try:
-                locale.setlocale(locale.LC_ALL, (current_locale, 'UTF-8'))
-            except NameError:
-                locale.setlocale(locale.LC_ALL, (default_locale, 'UTF-8'))
         Gtk.ApplicationWindow.__init__(self, title=name)
 
         self.api = api

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,0 +1,70 @@
+import gettext
+import locale
+import runpy
+from contextlib import contextmanager
+from unittest import TestCase
+from unittest.mock import call, patch
+
+
+class TestTranslation(TestCase):
+    @contextmanager
+    def load_translation(self, language='', message_language='en_US', setlocale_effect=None):
+        # Execute an isolated module namespace: never replace the live translator
+        # imported by the rest of the suite or mutate the runner's locale/env.
+        with patch('locale.setlocale', return_value='en_US.UTF-8', side_effect=setlocale_effect) as setlocale, \
+                patch('locale.getlocale', return_value=(message_language, 'UTF-8')) as getlocale, \
+                patch('locale.bindtextdomain', create=True), patch('locale.textdomain', create=True), \
+                patch('gettext.bindtextdomain'), patch('gettext.textdomain'), \
+                patch('minigalaxy.config.Config') as config, \
+                patch('gettext.translation', return_value=gettext.NullTranslations()) as translation, \
+                patch('os.unsetenv') as unsetenv, patch('logging.error'):
+            config.return_value.locale = language
+            getlocale.side_effect = lambda category=locale.LC_CTYPE: (
+                message_language if category == locale.LC_MESSAGES else 'de_DE', 'UTF-8')
+            module = runpy.run_path('minigalaxy/translation.py')
+            yield module, setlocale, translation, unsetenv
+
+    def test_message_language_is_independent_of_character_locale(self):
+        for message_language in ('en_US', 'fr_FR', None):
+            with self.subTest(message_language=message_language):
+                with self.load_translation(message_language=message_language) as (_, _, translation, _):
+                    self.assertEqual(translation.call_args.kwargs['languages'], [message_language or 'en'])
+
+    def test_unavailable_formatting_locale_does_not_block_messages(self):
+        def setlocale(category, value=None):
+            if category == locale.LC_ALL:
+                raise locale.Error('unavailable LC_TIME')
+            return 'en_US.UTF-8'
+
+        with self.load_translation(setlocale_effect=setlocale) as (_, setter, translation, _):
+            self.assertIn(call(locale.LC_MESSAGES, ''), setter.call_args_list)
+            self.assertEqual(translation.call_args.kwargs['languages'], ['en_US'])
+
+    def test_configured_language_applies_to_native_and_python_gettext(self):
+        with self.load_translation(language='fr_FR') as (_, setter, translation, _):
+            self.assertIn(call(locale.LC_MESSAGES, ('fr_FR', 'UTF-8')), setter.call_args_list)
+            self.assertEqual(translation.call_args.kwargs['languages'], ['fr_FR'])
+
+    def test_unavailable_configured_language_falls_back_to_system(self):
+        def setlocale(category, value=None):
+            if value == ('missing', 'UTF-8'):
+                raise locale.Error('unavailable program language')
+            return 'en_US.UTF-8'
+
+        with self.load_translation(language='missing', setlocale_effect=setlocale) as (_, setter, translation, _):
+            self.assertEqual(setter.call_args, call(locale.LC_MESSAGES, 'en_US.UTF-8'))
+            self.assertEqual(translation.call_args.kwargs['languages'], ['en_US'])
+
+    def test_restoring_system_language_preserves_other_categories(self):
+        with self.load_translation() as (module, setter, _, _):
+            setter.reset_mock()
+            module['set_message_locale']('fr_FR')
+            module['set_message_locale']('')
+            self.assertEqual(setter.call_args_list, [
+                call(locale.LC_MESSAGES, ('fr_FR', 'UTF-8')),
+                call(locale.LC_MESSAGES, 'en_US.UTF-8'),
+            ])
+
+    def test_lang_is_retained_for_launched_games(self):
+        with self.load_translation() as (_, _, _, unsetenv):
+            self.assertNotIn(call('LANG'), unsetenv.call_args_list)


### PR DESCRIPTION
## Description

Fixes #710.

When `LC_MESSAGES` is English and `LC_CTYPE` is German, the interface currently selects German. An unavailable formatting locale can also make the initial `LC_ALL` setup fail before the message language is initialized.

Initialize the message locale centrally in `translation.py`, independently of formatting-category failures. Apply configured program languages to `LC_MESSAGES`, remove repeated locale resets from window/library construction, and retain the empty system-default preference when restoring the startup language. Keep `LANG` available to launched games. The existing handling of `LANGUAGE` remains unchanged.

Validation:
- Python 3.11: 185 unittest tests passed, including six translation regression tests through normal discovery.
- Flake8 with the CI configuration, changelog format check, and `git diff --check` passed.
- Real macOS subprocesses with English `LC_MESSAGES`, German `LC_CTYPE`, and both valid and unavailable `LC_TIME` retained the English message locale and German character locale.
- Native GTK rendering was not exercised on this macOS host; native locale/gettext setup is covered with controlled mocks. Linux CI remains the platform check.

AI assistance was used for implementation and validation.

## Checklist

- [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
