### PR TITLE
Bugfixes: fixed some small bugs and errors during install

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -152,14 +152,14 @@ def fail_on_error(message_to_test, fail_type=None, data=None):
 
 
 def verify_installer_integrity(game, installer_inventory, progress_callback=None):
-    error_message = []
+    error_messages = []
     invalid_files = {}
 
     progress_callback(InstallResultType.VERIFY_START, game.name, installer_inventory)
-    for installer in installer_inventory.as_keep_files_list():
+    for installer in installer_inventory.contained_files():
         installer_file_name = os.path.basename(installer)
         if not os.path.exists(installer):
-            error_message = _("{} failed to download.").format(installer_file_name)
+            error_messages.append(_("{} failed to download.").format(installer_file_name))
 
         if not installer_inventory.has_checksum(installer_file_name):
             logging.warning("Warning. No info about correct %s MD5 checksum", installer_file_name)
@@ -175,11 +175,11 @@ def verify_installer_integrity(game, installer_inventory, progress_callback=None
             logging.info("%s integrity is preserved. MD5 is: %s", installer_file_name, calculated_checksum)
             progress_callback(InstallResultType.VERIFY_PROGRESS, installer_file_name, calculated_checksum)
         else:
-            error_message.append(_("{} was corrupted. Please download it again.").format(installer_file_name))
+            error_messages.append(_("{} was corrupted. Please download it again.").format(installer_file_name))
             invalid_files[installer] = calculated_checksum
 
-    if error_message:
-        raise InstallException('\n'.join(error_message), InstallResultType.CHECKSUM_ERROR, invalid_files)
+    if error_messages:
+        raise InstallException('\n'.join(error_messages), InstallResultType.CHECKSUM_ERROR, invalid_files)
 
 
 def verify_disk_space(game, installer):
@@ -280,17 +280,17 @@ def extract_by_wine(game, installer, game_lang, config=Config()):
 
     # first, try full unattended install.
     success, code = try_wine_command(installer_cmd_basic + installer_args_full)
-    if not success:
-        # look at the exit codes and runtime behaviour to determine if the second try is needed
-        # see https://jrsoftware.org/ishelp/index.php?topic=setupexitcodes
-        if code in [2, 5]:  # user decided to cancel
-            return _("Installation canceled by user.")
+    # look at the exit codes and runtime behaviour to determine if the second try is needed
+    # see https://jrsoftware.org/ishelp/index.php?topic=setupexitcodes
+    if not success and code not in [2, 5]:
         # some games will reject the /SILENT flag
         # because they require the user to accept EULA at the beginning
         # Open normal installer as fallback and hope for the best
         logging.error('Unattended install failed. Try install with wizard dialog.')
         success, code = try_wine_command(installer_cmd_basic)
 
+    if code in [2, 5]:  # user decided to cancel
+        return _("Installation canceled by user.")
     if not success:
         return _("Wine extraction failed.")
 
@@ -636,7 +636,7 @@ class InstallerInventory:
             os.makedirs(self.directory, mode=0o755)
 
         with open(self.inventory_file, 'w') as inventory_file:
-            json.dump(self.data, inventory_file)
+            json.dump(self.data, inventory_file, indent=2)
 
     def add_file(self, name, file_info):
         self.data[os.path.basename(name)] = file_info.as_dict()

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -13,6 +13,15 @@ from minigalaxy import installer
 from minigalaxy.translation import _
 
 
+def prepare_inventory(installer_name, md5, size):
+    """Helper tool to construct instances of InstallerInventory for tests.
+    Takes data for a single file.
+    """
+    inventory = installer.InstallerInventory(installer_name)
+    inventory.add_file(installer_name, FileInfo(md5, size))
+    return inventory
+
+
 class TestInstaller(TestCase):
 
     def setUp(self):
@@ -45,7 +54,7 @@ class TestInstaller(TestCase):
         mock_checksum.side_effect = installer.InstallException("Checksum Error", installer.InstallResultType.CHECKSUM_ERROR, failed_file_list)
         game = Game("Absolute Drift", install_dir="/home/makson/GOG Games/Absolute Drift", platform=Platform.WINDOWS)
 
-        inventory = self.prepare_inventory("/cache/adrift_setup.exe", "", 0)
+        inventory = prepare_inventory("/cache/adrift_setup.exe", "", 0)
         inventory.add_file("/cache/adrift_setup-1.bin", FileInfo("", 0))
         with self.assertRaises(installer.InstallException) as result:
             installer.install_game(game, installer="", config=self.config,
@@ -64,7 +73,7 @@ class TestInstaller(TestCase):
 
         progress_callback = MagicMock()
 
-        inventory = self.prepare_inventory("/cache/adrift_setup.exe", "", 0)
+        inventory = prepare_inventory("/cache/adrift_setup.exe", "", 0)
         inventory.add_file("/cache/adrift_setup-1.bin", FileInfo("", 0))
         with self.assertRaises(installer.InstallException) as result:
             installer.install_game(game, installer="", config=self.config,
@@ -169,7 +178,7 @@ class TestInstaller(TestCase):
         game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
         installer_path = "/home/user/.cache/minigalaxy/download/" \
                          "Beneath a Steel Sky/{}".format(installer_name)
-        inventory = self.prepare_inventory(installer_path, md5_sum, 0)
+        inventory = prepare_inventory(installer_path, md5_sum, 0)
 
         progress_callback = MagicMock()
 
@@ -194,7 +203,7 @@ class TestInstaller(TestCase):
                     md5sum={installer_name: md5_sum})
         installer_path = "/home/user/.cache/minigalaxy/download/" \
                          "Beneath a Steel Sky/{}".format(installer_name)
-        inventory = self.prepare_inventory(installer_path, md5_sum, 0)
+        inventory = prepare_inventory(installer_path, md5_sum, 0)
         exp = _("{} was corrupted. Please download it again.").format(installer_name)
 
         progress_callback = MagicMock()
@@ -560,15 +569,6 @@ class TestInstaller(TestCase):
         assert not mock_remove.called
         self.assertEqual(obs, "")
 
-    def prepare_inventory(self, installer_name, md5, size):
-        '''
-        Helper tool to construct instances of InstallerInventory for tests.
-        Takes data for a single file.
-        '''
-        inventory = installer.InstallerInventory(installer_name)
-        inventory.add_file(installer_name, FileInfo(md5, size))
-        return inventory
-
     def setup_os_mocks(self, file_structure, mock_listdir, mock_rmdir, mock_isfile, mock_remove, mock_isempty, mock_isdir):
 
         def rmdir_fake(path):
@@ -595,3 +595,20 @@ class TestInstaller(TestCase):
         mock_isempty.side_effect = lambda path: mock_isdir(path) and len(file_structure.get(path)) == 0
         mock_rmdir.side_effect = rmdir_fake
         mock_remove.side_effect = remove_fake
+
+
+class TestInventory(TestCase):
+
+    def setUp(self):
+        md5_sum = "5cc68247b61ba31e37e842fd04409d98"
+        installer_name = "beneath_a_steel_sky_en_gog_2_20150.sh"
+        self.game = Game("Beneath A Steel Sky", install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
+        self.installer_path = f"/home/user/.cache/minigalaxy/download/Beneath a Steel Sky/{installer_name}"
+        self.inventory = prepare_inventory(self.installer_path, md5_sum, 0)
+
+    def test_as_keep_files_list_include_json(self):
+        inventory_files = self.inventory.as_keep_files_list()
+        json_file_name = self.installer_path.replace('.sh', '.json')
+
+        self.assertEqual(2, len(inventory_files))
+        self.assertIn(json_file_name, inventory_files)


### PR DESCRIPTION
## Description

1. Wine install is a bit more clever about the failure reason of an install: Manual user cancels change the error message and won't trigger a fallback retry in case the unattended installer was stopped midway by force-closing the window

2. Excluded the installer inventory json from the list of files for the checksum check. This is purely cosmetic and removes a warning from the log

3. Actual bug: `verify_installer_integrity` builds an array of error messages, except in one situation where a string is assigned. This lead to problems with the generic `\n`.join at the end of the function, which resulted in the entire message getting a linebreak after every character.

4. Developer convenience: Pretty-print installer inventory files

## Checklist
 
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
