### PR TITLE
Preserve library tiles during refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 **1.4.3**
-- Preserve active download progress when refreshing the library after preference changes (thanks to be-student)
+- Preserve active downloads across library refreshes; stop and resume them when changing the tile view (thanks to be-student)
 - Canceling an automatic windows game installation will not retry with the fallback any longer (thanks to GB609)
 - Fix not-installed Linux games missing from the library (thanks to slowsage)
 - Releases will now include a basic AppImage (experimental) (thanks to GB609)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **1.4.3**
+- Preserve active download progress when refreshing the library after preference changes (thanks to be-student)
 - Canceling an automatic windows game installation will not retry with the fallback any longer (thanks to GB609)
 - Fix not-installed Linux games missing from the library (thanks to slowsage)
 - Releases will now include a basic AppImage (experimental) (thanks to GB609)

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -82,28 +82,17 @@ class Library(Gtk.Viewport):
         GLib.idle_add(self.__load_tile_states)
         self.owned_products_ids = self.api.get_owned_products_ids()
         # Get already installed games first
-        previous_games = self.games
         self.games = self.__get_installed_games()
-        for game in previous_games:
-            if game.id in self.config.current_downloads and game not in self.games:
-                self.games.append(game)
         self.__create_gametiles_iteratively(5)
 
         # Get games from the API
         self.__add_games_from_api()
-        self.__create_gametiles_iteratively(5)
-        GLib.idle_add(self.__remove_stale_gametiles)
+        self.__create_gametiles_iteratively(5, prune_stale=True)
         GLib.idle_add(self.filter_library)
 
-    def __remove_stale_gametiles(self):
-        for child in self.flowbox.get_children():
-            tile = child.get_children()[0]
-            if tile.game not in self.games:
-                self.flowbox.remove(child)
-
-    def __create_gametiles_iteratively(self, step_width=5):
+    def __create_gametiles_iteratively(self, step_width=5, prune_stale=False):
         if len(self.games) < step_width*2:
-            GLib.idle_add(self.__create_gametiles, [*self.games])
+            GLib.idle_add(self.__create_gametiles, [*self.games], prune_stale)
             # wait until the update is done to make sure there's a consistent state before going on
             time.sleep(0.1)
             return
@@ -113,7 +102,7 @@ class Library(Gtk.Viewport):
         index = 0
         while index < len(games_to_add):
             games_chunk = games_to_add[index:index+step_width]
-            GLib.idle_add(self.__create_gametiles, games_chunk)
+            GLib.idle_add(self.__create_gametiles, games_chunk, prune_stale)
             index += step_width
             time.sleep(0.1)
 
@@ -158,7 +147,7 @@ class Library(Gtk.Viewport):
         tile2 = child2.get_children()[0].game
         return tile2 < tile1
 
-    def __create_gametiles(self, games_to_add=None) -> None:
+    def __create_gametiles(self, games_to_add=None, prune_stale=False) -> None:
         """Gets called twice: Once for installed, once for not installed games."""
 
         if not games_to_add:
@@ -168,6 +157,12 @@ class Library(Gtk.Viewport):
 
         for child in self.flowbox.get_children():
             tile = child.get_children()[0]
+            if prune_stale and tile.game.id in self.config.current_downloads and tile.game not in self.games:
+                self.games.append(tile.game)
+            if prune_stale and tile.game not in self.games:
+                self.flowbox.remove(child)
+                tile.game.library_tile = None
+                continue
             if tile.game in games_to_add:
                 logging.debug("Update existing tile for [%s] with new game instance", tile.game.name)
                 new_game = games_to_add[games_to_add.index(tile.game)]
@@ -175,24 +170,25 @@ class Library(Gtk.Viewport):
                 tile.game = new_game
 
         for game in games_to_add:
-            if game.library_tile:
-                # the game already has a visible entry in the library
-                # request to load the thumbnail, if there is a url for it and it hasnt been loaded before
-                game.library_tile.load_thumbnail()
-                continue
-            if game.is_installed():
-                self.__add_gametile(game)
-            elif game.id in self.config.current_downloads:
-                self.__add_gametile(game)
-            elif game.platform in self.config.platform_mode:
+            if self.__should_show_game(game):
                 self.__add_gametile(game)
             elif game in self.games:
                 # housekeeping: API.get_library returns all owned games
                 # (useful when api-caching is introduced as the same request can be used independent of platform_mode)
                 # removing not shown games is only a small memory optimization
+                if game.library_tile:
+                    self.flowbox.remove(game.library_tile.get_parent())
+                    game.library_tile = None
                 self.games.remove(game)
 
+    def __should_show_game(self, game):
+        return (game.is_installed() or game.id in self.config.current_downloads
+                or game.platform in self.config.platform_mode)
+
     def __add_gametile(self, game):
+        if game.library_tile:
+            game.library_tile.load_thumbnail()
+            return
         view = self.config.view
         if view == "grid":
             game_tile = GameTile(self, game)

--- a/minigalaxy/ui/library.py
+++ b/minigalaxy/ui/library.py
@@ -65,11 +65,12 @@ class Library(Gtk.Viewport):
         for thunk in queue:
             GLib.idle_add(thunk)
 
-    def reset(self):
-        self.games = []
-        for child in self.flowbox.get_children():
-            self.flowbox.remove(child)
-        self.flowbox.show_all()
+    def reset(self, rebuild=False):
+        """Refresh the library, preserving tiles unless their view must change."""
+        if rebuild:
+            self.games = []
+            for child in self.flowbox.get_children():
+                self.flowbox.remove(child)
         self.update_library()
 
     def update_library(self) -> None:
@@ -81,13 +82,24 @@ class Library(Gtk.Viewport):
         GLib.idle_add(self.__load_tile_states)
         self.owned_products_ids = self.api.get_owned_products_ids()
         # Get already installed games first
+        previous_games = self.games
         self.games = self.__get_installed_games()
+        for game in previous_games:
+            if game.id in self.config.current_downloads and game not in self.games:
+                self.games.append(game)
         self.__create_gametiles_iteratively(5)
 
         # Get games from the API
         self.__add_games_from_api()
         self.__create_gametiles_iteratively(5)
+        GLib.idle_add(self.__remove_stale_gametiles)
         GLib.idle_add(self.filter_library)
+
+    def __remove_stale_gametiles(self):
+        for child in self.flowbox.get_children():
+            tile = child.get_children()[0]
+            if tile.game not in self.games:
+                self.flowbox.remove(child)
 
     def __create_gametiles_iteratively(self, step_width=5):
         if len(self.games) < step_width*2:

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -6,7 +6,7 @@ import shutil
 from minigalaxy import Platform
 from minigalaxy.config import Config
 from minigalaxy.constants import PLATFORM_MODE, SUPPORTED_DOWNLOAD_LANGUAGES, SUPPORTED_LOCALES, VIEWS
-from minigalaxy.download_manager import DownloadManager
+from minigalaxy.download_manager import DownloadManager, DownloadState
 from minigalaxy.translation import _
 from minigalaxy.ui.gtk import Gtk, load_ui
 from minigalaxy.ui.widget_utils import get_combo_value, populate_combobox
@@ -83,6 +83,7 @@ class Preferences(Gtk.Dialog):
         view = get_combo_value(self.combobox_view)
         if view != self.config.view:
             self.config.view = view
+            self.download_manager.cancel_all_downloads(cancel_state=DownloadState.STOPPED)
             self.parent.reset_library(rebuild=True)
 
     def __apply_theme_choice(self) -> None:

--- a/minigalaxy/ui/preferences.py
+++ b/minigalaxy/ui/preferences.py
@@ -82,8 +82,8 @@ class Preferences(Gtk.Dialog):
     def __apply_view_choice(self) -> None:
         view = get_combo_value(self.combobox_view)
         if view != self.config.view:
-            self.parent.reset_library()
-        self.config.view = view
+            self.config.view = view
+            self.parent.reset_library(rebuild=True)
 
     def __apply_theme_choice(self) -> None:
         settings = Gtk.Settings.get_default()

--- a/minigalaxy/ui/window.py
+++ b/minigalaxy/ui/window.py
@@ -162,8 +162,8 @@ class Window(Gtk.ApplicationWindow):
         if not os.path.exists(ICON_DIR):
             os.makedirs(ICON_DIR, mode=0o755)
 
-    def reset_library(self):
-        self.library.reset()
+    def reset_library(self, rebuild=False):
+        self.library.reset(rebuild=rebuild)
 
     def update_library(self):
         self.library.update_library()

--- a/tests/ui/test_ui_library.py
+++ b/tests/ui/test_ui_library.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import os
 import sys
@@ -89,9 +90,27 @@ class TestLibrary(TestCase):
         test_library.flowbox.reset_mock()
         test_library.flowbox.get_children.return_value = [retained_child, stale_child]
 
-        test_library._Library__remove_stale_gametiles()
+        test_library.config.current_downloads = [retained_game.id]
+        test_library._Library__create_gametiles(prune_stale=True)
 
         test_library.flowbox.remove.assert_called_once_with(stale_child)
+
+    def test_existing_tile_is_dropped_when_platform_becomes_hidden(self):
+        game = Game(name="Windows only", game_id=55, platform=Platform.WINDOWS)
+        library = self._tile_library([], [game])
+        library.games = [game]
+        tile = MagicMock(game=game)
+        child = MagicMock()
+        child.get_children.return_value = [tile]
+        tile.get_parent.return_value = child
+        game.library_tile = tile
+        library.flowbox.get_children.return_value = [child]
+
+        library._Library__create_gametiles([game])
+
+        library.flowbox.remove.assert_called_once_with(child)
+        self.assertIsNone(game.library_tile)
+        self.assertNotIn(game, library.games)
 
     def test_refresh_keeps_active_download_when_api_is_offline(self):
         active_download = Game(name="Active download", game_id=1)
@@ -99,6 +118,9 @@ class TestLibrary(TestCase):
         test_library = self._tile_library([], [], err_msg="offline")
         test_library.games = [active_download]
         test_library.config.current_downloads = [active_download.id]
+        child = MagicMock()
+        child.get_children.return_value = [MagicMock(game=active_download)]
+        test_library.flowbox.get_children.return_value = [child]
 
         test_library._Library__update_library()
 
@@ -461,3 +483,27 @@ del sys.modules['minigalaxy.ui.preferences']
 del sys.modules['minigalaxy.ui.gametile']
 del sys.modules['minigalaxy.ui.gametilelist']
 del sys.modules['minigalaxy.ui.categoryfilters']
+
+
+def test_view_change_stops_downloads_before_rebuilding_tiles():
+    from types import SimpleNamespace
+    from minigalaxy.download_manager import DownloadState
+    from pathlib import Path
+
+    source = Path(__file__).parents[2] / "minigalaxy/ui/preferences.py"
+    tree = ast.parse(source.read_text())
+    preferences = next(node for node in tree.body if isinstance(node, ast.ClassDef))
+    method = next(node for node in preferences.body if isinstance(node, ast.FunctionDef)
+                  and node.name == "__apply_view_choice")
+    namespace = {"get_combo_value": lambda _: "list", "DownloadState": DownloadState}
+    exec(compile(ast.Module(body=[method], type_ignores=[]), str(source), "exec"), namespace)
+    events = []
+    state = SimpleNamespace(
+        combobox_view=None, config=SimpleNamespace(view="grid"),
+        download_manager=SimpleNamespace(cancel_all_downloads=lambda **kw: events.append(("stop", kw))),
+        parent=SimpleNamespace(reset_library=lambda **kw: events.append(("reset", kw))),
+    )
+    namespace["__apply_view_choice"](state)
+    assert events == [("stop", {"cancel_state": DownloadState.STOPPED}), ("reset", {"rebuild": True})]
+    namespace["__apply_view_choice"](state)
+    assert len(events) == 2

--- a/tests/ui/test_ui_library.py
+++ b/tests/ui/test_ui_library.py
@@ -46,6 +46,65 @@ class TestLibrary(TestCase):
     mock_config = MagicMock()
     mock_config.locale = "en"
 
+    def test_reset_preserves_existing_tiles(self):
+        test_library = Library(MagicMock(), self.mock_config, MagicMock(), MagicMock())
+        game = Game(name="Active download", game_id=1)
+        child = MagicMock()
+        child.get_children.return_value = [MagicMock(game=game)]
+        test_library.games = [game]
+        test_library.flowbox.reset_mock()
+        test_library.flowbox.get_children.return_value = [child]
+        test_library.update_library = MagicMock()
+
+        test_library.reset()
+
+        self.assertEqual([game], test_library.games)
+        test_library.flowbox.remove.assert_not_called()
+        test_library.update_library.assert_called_once()
+
+    def test_reset_rebuilds_tiles_when_requested(self):
+        test_library = Library(MagicMock(), self.mock_config, MagicMock(), MagicMock())
+        game = Game(name="Existing game", game_id=1)
+        child = MagicMock()
+        test_library.games = [game]
+        test_library.flowbox.reset_mock()
+        test_library.flowbox.get_children.return_value = [child]
+        test_library.update_library = MagicMock()
+
+        test_library.reset(rebuild=True)
+
+        self.assertEqual([], test_library.games)
+        test_library.flowbox.remove.assert_called_once_with(child)
+        test_library.update_library.assert_called_once()
+
+    def test_stale_tiles_are_removed_after_refresh(self):
+        test_library = Library(MagicMock(), self.mock_config, MagicMock(), MagicMock())
+        retained_game = Game(name="Retained game", game_id=1)
+        stale_game = Game(name="Stale game", game_id=2)
+        retained_child = MagicMock()
+        retained_child.get_children.return_value = [MagicMock(game=retained_game)]
+        stale_child = MagicMock()
+        stale_child.get_children.return_value = [MagicMock(game=stale_game)]
+        test_library.games = [retained_game]
+        test_library.flowbox.reset_mock()
+        test_library.flowbox.get_children.return_value = [retained_child, stale_child]
+
+        test_library._Library__remove_stale_gametiles()
+
+        test_library.flowbox.remove.assert_called_once_with(stale_child)
+
+    def test_refresh_keeps_active_download_when_api_is_offline(self):
+        active_download = Game(name="Active download", game_id=1)
+        active_download.library_tile = MagicMock()
+        test_library = self._tile_library([], [], err_msg="offline")
+        test_library.games = [active_download]
+        test_library.config.current_downloads = [active_download.id]
+
+        test_library._Library__update_library()
+
+        self.assertIn(active_download, test_library.games)
+        self.assertEqual([], GameTile.call_args_list)
+
     def test1_add_games_from_api(self):
         self_games = []
         for game in SELF_GAMES:


### PR DESCRIPTION
## Description

Preserve existing game tiles during ordinary library refreshes so active download listeners keep receiving progress updates. Stale tiles are removed after reconciliation, while changing grid/list view still performs an explicit rebuild.

Fixes #740

## Checklist

- [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
