### PR TITLE
[Installer rework]: Step 2 - More and better install data classes

### DIFF
--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -875,7 +875,7 @@ class InstallException(Exception):
 
 class InstallTask:
     def __init__(self, install_id=None, result_callback=None, *args, **kwargs):
-        self.game = InstallTask.__locate_game_in_args(*args, **kwargs)
+        self.game = InstallTask._locate_type_in_args(Game, *args, **kwargs)
         if not install_id:
             install_id = self.game.id
         if not result_callback or not callable(result_callback):
@@ -911,11 +911,11 @@ class InstallTask:
         return f"InstallTask(id={self.installer_id}, args={self.arg_array}, kwargs={str(self.named_args)})"
 
     @staticmethod
-    def __locate_game_in_args(*args, **kwargs):
+    def _locate_type_in_args(class_type, *args, **kwargs):
         for a in [*args, *kwargs.values()]:
-            if isinstance(a, Game):
+            if isinstance(a, class_type):
                 return a
-        raise ValueError("No instance of Game in InstallTask constructor arguments")
+        raise ValueError(f"No instance of {class_type.__name__} in InstallTask constructor arguments")
 
     @staticmethod
     def get_title_for_id(game: Game, item_id):

--- a/minigalaxy/installer.py
+++ b/minigalaxy/installer.py
@@ -10,7 +10,7 @@ import textwrap
 import time
 
 from collections import deque
-from enum import Enum, auto
+from enum import Enum, StrEnum, auto
 from queue import Empty
 from threading import Thread, RLock
 from importlib.resources import as_file
@@ -576,34 +576,46 @@ def match_game_lang_to_installer(installer: str, language: str, outputLogFile=No
 class InstallerInventory:
     '''Helper class to keep track of completeness of installer downloads'''
 
+    class MetaKey(StrEnum):
+        """Lists and contains all meta data keys used by InstallerInventory"""
+
+        ID = "gogid"
+        PLATFORM = "platform"
+
     def __init__(self, installer_path=None):
         self.inventory_file = None
+        self.data = {}
+        self.meta = {}
         if installer_path:
             self.set_path_once(installer_path)
 
     @staticmethod
-    def from_file_system(installer_path):
+    def from_file_system(installer_executable_path, files_to_check=[]):
         """
         Helper utility to build an instance of InstallerInventory from files in the same directory
-        that belong to the given installer_path.
+        as the file given with 'installer_executable_path'.
         Expects the following naming convention:
         - game_installer_version.[exe|sh]
         - game_installer_version-1.bin
         - game_installer_version-2.bin ...
 
-        The inventory will contain all files whose names are matching
-        the base name of the installer (without extension) in the SAME directory.
-        No recursion.
+        The inventory will contain all files names matching the base name of the installer (without extension).
+        Only files in the SAME directory are checked. No recursion.
+        It works with different game version, but result and behaviour are unspecified for mixed platform directories.
 
         This is a fallback for games that have been downloaded before InstallerInventory was introduced.
         Files added like this won't have checksums and the is_complete check makes little sense.
+
+        @param files_to_check: optional. Used as a performance optimization in situations where a directory is
+               iterated by the calling code as well.
         """
-        inventory = InstallerInventory(installer_path)
+        inventory = InstallerInventory(installer_executable_path)
         if os.path.isfile(inventory.inventory_file):
             return inventory
 
         # if the file doesn't exist, populate from disk to get names at the very least
-        for f in os.listdir(inventory.directory):
+        directory_content = files_to_check if files_to_check else os.listdir(inventory.directory)
+        for f in directory_content:
             fullpath = os.path.join(inventory.directory, f)
             if os.path.isfile(fullpath) and f.startswith(inventory.name_prefix):
                 inventory.add_file(f, FileInfo(size=InstallerInventory.size_of(fullpath)))
@@ -614,20 +626,77 @@ class InstallerInventory:
     def size_of(file):
         return os.stat(file).st_size
 
+    @property
+    def item_id(self):
+        return self.meta.get(InstallerInventory.MetaKey.ID, 0)
+
+    @item_id.setter
+    def item_id(self, new_value) -> None:
+        self.meta[InstallerInventory.MetaKey.ID] = new_value
+
+    @property
+    def target_platform(self):
+        if not self.meta.get(InstallerInventory.MetaKey.PLATFORM, None):
+            platform = self.__detect_platform_type()
+            self.meta[InstallerInventory.MetaKey.PLATFORM] = platform
+        return self.meta[InstallerInventory.MetaKey.PLATFORM]
+
+    @target_platform.setter
+    def target_platform(self, new_value: str) -> None:
+        self.meta[InstallerInventory.MetaKey.PLATFORM] = new_value
+
     def set_path_once(self, installer_path=None):
+        """Encapsulates a batch of one-time initialisations like setting directory and inventory file names.
+        The initialisation also tries to directly load the contents of the inventory file via `load` (if existing).
+        This only happens when the name of the inventory file wasn't created yet AND a none-empty path was given.
+        Without a path, the function only tries to deduce a few (new) meta data items from the inventory's file list.
+        """
         if not self.inventory_file and installer_path:
             self.directory = os.path.dirname(installer_path)
             self.name_prefix = os.path.basename(os.path.splitext(installer_path)[0])
             self.inventory_file = os.path.join(self.directory, f"{self.name_prefix}.json")
             self.load()
 
+        # some code to handle old installer inventories and pre-inventory downloaded files
+        # These are only relevant when path doesn't point to a json, but is a sh or exe.
+        # When it's a json, it should contain a none-empty file list which the regular getters can handle
+        # because saving an empty inventory doesn't make sense at all
+        if self.contained_files():
+            return
+        if not self.target_platform:
+            # try to init target_platform from the installer path alone if the inventory doesn't have a file list
+            self.target_platform = self.__detect_platform_type([installer_path])
+
     def load(self):
+        """Try to read the inventory from file. This function applies a rudimentary merge between meta data from file
+        and any key which might already exist on the instance.
+        Values set on the instance will take priority over data from the file.
+
+        This is mostly required for situations where an instance of `InstallerInventory` is (re-)created before the full
+        path to the executable is known (e.g. when creating a new inventory in download preparation before looping files).
+        In that case, `load_path_once` must be called later and there is the danger of adding metadata BEFORE `load`
+        is called. This metadata would be lost once the initialisation is done, leading to very hard to find bugs with
+        data consistency.
+
+        The underlying assumption is that inventory files age, and code will include migration logic when rewriting them.
+        """
         if not os.path.isfile(self.inventory_file):
-            self.data = {}
             return self.data
 
         with open(self.inventory_file, 'r') as inventory:
             self.data = json.load(inventory)
+
+        new_meta = self.data.get('%META%', {})
+        if new_meta:
+            enum_members = [*InstallerInventory.MetaKey]
+            for key in new_meta:
+                # drop obsolete keys by not picking them up from the file
+                if key not in enum_members:
+                    continue
+                self.meta.setdefault(key, new_meta[key])
+
+        if "%META%" in self.data:
+            del self.data['%META%']
 
         return self.data
 
@@ -636,7 +705,9 @@ class InstallerInventory:
             os.makedirs(self.directory, mode=0o755)
 
         with open(self.inventory_file, 'w') as inventory_file:
-            json.dump(self.data, inventory_file, indent=2)
+            payload = self.data.copy()
+            payload['%META%'] = self.meta.copy()
+            json.dump(payload, inventory_file, indent=2)
 
     def add_file(self, name, file_info):
         self.data[os.path.basename(name)] = file_info.as_dict()
@@ -715,6 +786,31 @@ class InstallerInventory:
                 delete_list.append(os.path.join(self.directory, file))
 
         safe_delete(delete_list)
+
+    def __detect_platform_type(self, files=[]):
+        """Go over the list of files in the installer and determine OS based on file name endings.
+        @param files: optional. Uses the files contained in the installer by default.
+               Can be used in situations where the installer itself doesn't contain any files (yet)
+        """
+        if not files:
+            files = self.contained_files()
+        if list(filter(lambda n: n.endswith(".sh"), files)):
+            return Platform.LINUX
+        if list(filter(lambda n: n.endswith(".exe") or n.endswith(".bin"), files)):
+            return Platform.WINDOWS
+
+        return None
+
+    def __str__(self):
+        return f"InstallerInventory(id={self.item_id}, plf={self.target_platform})"
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, other):
+        if not isinstance(other, InstallerInventory):
+            return False
+        return self.data == other.data and self.meta == other.meta
 
 
 class InstallResultType(Enum):

--- a/minigalaxy/ui/library_entry.py
+++ b/minigalaxy/ui/library_entry.py
@@ -118,7 +118,11 @@ class LibraryEntry:
         elif self.current_state in [State.INSTALLED, State.UPDATABLE]:
             err_msg = self.launch_game()
         elif self.current_state == State.INSTALLABLE:
-            install_thread = threading.Thread(target=self.__install_game, args=(self.get_keep_executable_path(),))
+            exe_path = self.get_keep_executable_path()
+            inventory = InstallerInventory.from_file_system(exe_path)
+            install_thread = threading.Thread(target=self.__install_game,
+                                              args=(self.get_keep_executable_path(),),
+                                              kwargs={"inventory": inventory})
             install_thread.start()
         elif self.current_state == State.DOWNLOADABLE:
             download_thread = threading.Thread(target=self.__download_game)
@@ -286,6 +290,9 @@ class LibraryEntry:
         download_files = []
 
         download_inventory = InstallerInventory()
+        # make sure to init the new meta data
+        download_inventory.item_id = gog_item.id
+        download_inventory.target_platform = download_info.get('os', self.game.platform)
         callback_factory = CallbackFuncWrapper(gog_item,
                                                finish_func,
                                                self.__cancel,
@@ -449,15 +456,19 @@ class LibraryEntry:
 
     def _install(self, gog_item_id, save_location, update=False, dlc_title="",
                  inventory=None, on_success=None, on_failure=None):
+
+        error_message = self._update_inventory_item_id(self.api, inventory, self.game, dlc_title)
+        if error_message:
+            GLib.idle_add(self.parent_window.show_error,
+                          _("Failed to install {}").format(dlc_title),
+                          error_message)
+            return
+
         if not self.predownload_state:
             # when started from predownloaded local files
             self.predownload_state = self.current_state
 
-        if update:
-            processing_state = State.UPDATING
-        else:
-            processing_state = State.INSTALLING
-
+        processing_state = State.UPDATING if update else State.INSTALLING
         self.update_to_state_if_idle(processing_state)
 
         def install_finished(result):
@@ -471,6 +482,32 @@ class LibraryEntry:
             self.config,
             installer_inventory=inventory
         )
+
+    @staticmethod
+    def _update_inventory_item_id(api, inventory: InstallerInventory, game: Game, dlc_title=""):
+        """This function  is a temporary measure until the generalization of Game and Dlc info as 'GogItem' is done:
+        Old inventory might be available locally which were saved before the meta 'item_id' was introduced.
+        These aren't re-downloaded but still need to correctly supply the id.
+        """
+        if not inventory.item_id:
+            if dlc_title:
+                found_dlc = LibraryEntry._get_dlc_by_title(api, game, dlc_title)
+                # this could happen when MG has gone offline since its start and any game info caches have timed out
+                if not found_dlc:
+                    return _("You need to be online to install this DLC")
+                real_id = found_dlc.get('id')
+            else:
+                real_id = game.id
+            inventory.item_id = real_id
+            inventory.save()
+        return None
+
+    @staticmethod
+    def _get_dlc_by_title(api, game, dlc_title):
+        product_info = api.get_info(game)
+        found_dlc = list(filter(lambda dlc: dlc.get("title", "") == dlc_title,
+                                product_info.get("expanded_dlcs", [])))
+        return found_dlc[0] if len(found_dlc) == 1 else None
 
     def __uninstall_game(self):
         self.update_to_state(State.UNINSTALLING)

--- a/tests/installer/test_installer_inventory.py
+++ b/tests/installer/test_installer_inventory.py
@@ -1,0 +1,66 @@
+import json
+import os
+import shutil
+
+from unittest import TestCase
+
+from minigalaxy import Platform
+from minigalaxy.file_info import FileInfo
+from minigalaxy.game import Game
+from minigalaxy.installer import InstallerInventory
+
+
+def prepare_inventory(installer_name, md5, size) -> InstallerInventory:
+    """Helper tool to construct instances of InstallerInventory for tests.
+    Takes data for a single file.
+    """
+    inventory = InstallerInventory(installer_name)
+    inventory.add_file(installer_name, FileInfo(md5, size))
+    return inventory
+
+
+class TestInventory(TestCase):
+
+    def setUp(self):
+        md5_sum = "5cc68247b61ba31e37e842fd04409d98"
+        installer_name = "beneath_a_steel_sky_en_gog_2_20150.sh"
+        self.test_dir = f"/tmp/minigalaxy-test/{id(self)}"
+        self.game = Game("Beneath A Steel Sky", game_id=20150, install_dir="/home/makson/GOG Games/Beneath a Steel Sky")
+        self.installer_path = f"{self.test_dir}/download/Beneath a Steel Sky/{installer_name}"
+        self.inventory = prepare_inventory(self.installer_path, md5_sum, 0)
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir, ignore_errors=True)
+        super().tearDown()
+
+    def test_as_keep_files_list_include_json(self):
+        inventory_files = self.inventory.as_keep_files_list()
+        json_file_name = self.installer_path.replace('.sh', '.json')
+
+        self.assertEqual(2, len(inventory_files))
+        self.assertIn(json_file_name, inventory_files)
+
+    def test_load_save(self):
+        self.inventory.item_id = self.game.id
+        self.inventory.target_platform = Platform.LINUX
+        self.inventory.save()
+
+        expected_json = {
+            "beneath_a_steel_sky_en_gog_2_20150.sh": {
+                "size": 0,
+                "md5": "5cc68247b61ba31e37e842fd04409d98"
+            },
+            "%META%": {
+                "gogid": 20150,
+                "platform": Platform.LINUX.value
+            }
+        }
+
+        with open(self.inventory.inventory_file, 'r') as raw_json_file:
+            raw_json = json.load(raw_json_file)
+
+        self.assertEqual(expected_json, raw_json)
+
+        loaded_inventory = InstallerInventory.from_file_system(self.inventory.inventory_file)
+        self.assertEqual(self.inventory, loaded_inventory)

--- a/tests/test_installer_queue.py
+++ b/tests/test_installer_queue.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock
 from threading import RLock, Thread
 
 from minigalaxy import installer, Platform
+from minigalaxy.config import Config
+from minigalaxy.file_info import FileInfo
 from minigalaxy.game import Game
+from minigalaxy.installer import InstallTask
 
 
 class Test(TestCase):
@@ -138,3 +141,25 @@ class Test(TestCase):
 
         # counter-test: pass game as part of kwargs, it should not raise an exception
         installer.InstallTask(815, callback, game=game)
+
+    def test_locate_argument_byType(self):
+        test_args = [self, Config()]
+        test_kwargs = {
+            "callable": MagicMock(),
+            "file_info": FileInfo("", 0)
+        }
+
+        self.assertIs(test_args[1], InstallTask._locate_type_in_args(Config, *test_args, **test_kwargs))
+        self.assertIs(test_kwargs["callable"], InstallTask._locate_type_in_args(MagicMock, *test_args, **test_kwargs))
+
+    def test_locate_argument_byType_fails(self):
+        test_args = [self, Config()]
+        test_kwargs = {
+            "callable": MagicMock(),
+            "file_info": FileInfo("", 0)
+        }
+
+        with self.assertRaises(ValueError) as error:
+            InstallTask._locate_type_in_args(Game, *test_args, **test_kwargs)
+
+        self.assertEqual("No instance of Game in InstallTask constructor arguments", str(error.exception))

--- a/tests/ui/test_ui_library.py
+++ b/tests/ui/test_ui_library.py
@@ -2,11 +2,14 @@ import json
 import os
 import sys
 import uuid
+import tempfile
+
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, patch, mock_open
-import tempfile
 from tests.ui import MockGiRepository
 from minigalaxy import Platform
+from minigalaxy.installer import InstallerInventory
+from minigalaxy.translation import _
 
 m_gtk = MagicMock()
 m_gi = MagicMock()
@@ -15,19 +18,24 @@ m_preferences = MagicMock()
 m_gametile = MagicMock()
 m_gametilelist = MagicMock()
 m_categoryfilters = MagicMock()
+m_launchoption = MagicMock()
+m_iconbar = MagicMock()
 
 sys.modules['gi.repository'] = MockGiRepository()
 sys.modules['gi'] = m_gi
 sys.modules['minigalaxy.ui.window'] = m_window
 sys.modules['minigalaxy.ui.preferences'] = m_preferences
+sys.modules['minigalaxy.ui.game_icon_bar'] = m_iconbar
 sys.modules['minigalaxy.ui.gametile'] = m_gametile
 sys.modules['minigalaxy.ui.gametilelist'] = m_gametilelist
 sys.modules['minigalaxy.ui.categoryfilters'] = m_categoryfilters
+sys.modules['minigalaxy.ui.chooselauchoption'] = m_launchoption
 from minigalaxy.game import Game           # noqa: E402
 from minigalaxy.ui.gametile import GameTile  # noqa: E402
 from minigalaxy.ui import library as library_module  # noqa: E402
 from minigalaxy.ui.library import Library, get_installed_windows_games, read_game_categories_file, \
     update_game_categories_file  # noqa: E402
+from minigalaxy.ui.library_entry import LibraryEntry  # noqa: E402
 
 SELF_GAMES = {"Neverwinter Nights: Enhanced Edition": "1097893768", "Beneath A Steel Sky": "1207658695",
               "Stellaris (English)": "1508702879"}
@@ -271,7 +279,7 @@ class TestLibrary(TestCase):
         return library
 
     def _flush_idle(self, queue, count=1):
-        for _ in range(count):
+        for r in range(count):
             func, args = queue.pop(0)
             func(*args)
 
@@ -395,10 +403,61 @@ class TestLibrary(TestCase):
                 self.assertEqual([], idle_queue)
 
 
+class TestLibraryEntry(TestCase):
+
+    def test_update_inventory_id_unchanged(self):
+        inventory = InstallerInventory()
+        inventory.item_id = 12
+        game = MagicMock()
+        game.id = 808
+
+        self.assertIsNone(LibraryEntry._update_inventory_item_id(MagicMock(), inventory, game),
+                          "Should not return any failure message")
+        self.assertEqual(12, inventory.item_id, "Update must not change existing item_ids")
+
+    def test_update_inventory_id_game(self):
+        inventory = InstallerInventory()
+        inventory.save = MagicMock()  # patch out save to prevent writes
+        game = MagicMock()
+        game.id = 808
+
+        self.assertIsNone(LibraryEntry._update_inventory_item_id(MagicMock(), inventory, game),
+                          "Should not return any failure message")
+        self.assertEqual(808, inventory.item_id, "Update should take ID from Game")
+        inventory.save.assert_called_once()
+
+    def test_update_inventory_id_dlc_ok(self):
+        inventory = InstallerInventory()
+        inventory.save = MagicMock()  # patch out save to prevent writes
+        game = MagicMock()
+        api = MagicMock()
+        api.get_info.return_value = {
+            "expanded_dlcs": [
+                {"id": 42, "title": "This is a funky DLC"},
+                {"id": 9, "title": "another-dlc"}
+            ]
+        }
+        self.assertIsNone(LibraryEntry._update_inventory_item_id(api, inventory, game, "another-dlc"),
+                          "Should not return any failure message")
+        self.assertEqual(9, inventory.item_id, "Update should take ID from DLC with title 'another-dlc")
+        inventory.save.assert_called_once()
+
+    def test_update_inventory_id_dlc_offline_error(self):
+        inventory = InstallerInventory()
+        inventory.save = MagicMock()  # patch out save to prevent writes
+        game = MagicMock()
+        api = MagicMock()
+        self.assertEqual(_("You need to be online to install this DLC"),
+                         LibraryEntry._update_inventory_item_id(api, inventory, game, "another-dlc"))
+        inventory.save.assert_not_called()
+
+
 del sys.modules['gi']
 del sys.modules['gi.repository']
 del sys.modules['minigalaxy.ui.window']
 del sys.modules['minigalaxy.ui.preferences']
+del sys.modules['minigalaxy.ui.game_icon_bar']
 del sys.modules['minigalaxy.ui.gametile']
 del sys.modules['minigalaxy.ui.gametilelist']
 del sys.modules['minigalaxy.ui.categoryfilters']
+del sys.modules['minigalaxy.ui.chooselauchoption']


### PR DESCRIPTION
<!-- Note: Only PRs where the automated tests pass will be reviewed, so make sure they pass -->
## Description

This is part 2 of a series of changes to come to improve handling of game installations and make them more maintainable.

The key point is that, to support dynamic target platform selection, the way how installers are saved and downloaded must be harmonized. Moreover, Minigalaxy needs to save more info about the installers themselves to ensure that changing configuration will not corrupt or confuse them.

It might be possible with how the code looks right now, but would likely be much more complicated. My initial approach without the rework above involved a lot of file checking and directory renaming, which doesn't scale all too well and is needlessly complicated.

With a bit of inspiriration from `gogdownloader` i plan to rework the directory structure used to save offline installers to be more like 
- `installer/<game-slug>/<platform>/<installer-files>`
- `installer/<game-slug>/<platform>/<dlc-slug>/<dlc-installer-files>`

Slugs are given by gog in the api and provide reproducible, file-system compatible names while also being human-understandable (contrary to just using the game ids). I think they are better than doing our own string manipulations.

Potential future applications of this rework:
- a dedicated offline installers management feature
- integration with batch downloader tools like `goginstaller` just by following the directory scheme above

## Roadmap

- [x] 1. Changed `install_game` to use `Config` instead of several atomatic parameters
- [ ] **`CURRENT STEP`**: 2. Introduce and enhance data classes for installation.  
         `InstallerInventory` gets a new batch of meta information about the installers.  
         Inventories created with this commit can't be opened with previous versions (incompatible through new key `%META%`).
- [ ] 3. change `install_game` and `LibraryEntry` to use `InstallerInventory` and drop string parameter for installer executable
- [ ] 4. Code re-organization: Split up `installer.py` into a real directory sub-module. Simplifies testing and allow for extended use of type hints which aren't possible right now because of the code structure
- [ ] 5. Generalize `LibraryEntry` and `install_game` by using a new data type `InstallableItem` instead of `Game` and dlc titles/ids
- [ ] 6. Introduce `InstallerRepository` and offload logic from `LibraryEntry` related to locating and retrieving installers to that class
- (not _directly_ part of this series, but depending on step 6.) Finishing feature for platform selection
- (optional) For tests, i've converted a few methods in `LibraryEntry` not strictly related to GTK and UI into static methods to make them testable. The next logical action here would be to extract them into an (unsorted) utility function file.

## Checklist
 (marking this for now, but the current step is not yet worth an entry to changelog)
 - [x] _CHANGELOG.md_ was updated (**format**: - Change made (thanks to github_username))
